### PR TITLE
Update reportable notifications view

### DIFF
--- a/deploy/shipping/views.sql
+++ b/deploy/shipping/views.sql
@@ -27,8 +27,7 @@ create or replace view shipping.reportable_condition_v1 as
         sample.identifier as sample,
         barcode,
         site.identifier as site,
-        presence_absence.details->>'reporting_status' as reporting_status,
-        presence_absence.details->>'timestamp' as reporting_timestamp
+        presence_absence.details->>'reporting_log' as reporting_log
 
     from warehouse.presence_absence
     join warehouse.target using (target_id)


### PR DESCRIPTION
Update `shipping.reportable_notification_v1` to read the reporting log
from the new 'reporting_log' key in `presence_absence.details`.

Per https://github.com/seattleflu/id3c/pull/47 

Does this need a new sqitch tag? 