### PR TITLE
Link more targets to organisms

### DIFF
--- a/deploy/warehouse/target/data.sql
+++ b/deploy/warehouse/target/data.sql
@@ -5,7 +5,26 @@ begin;
 
 insert into warehouse.organism (lineage, identifiers, details)
     values
+        ('Adenovirus',              'NCBITAXON => 10508',       null),
         ('Bordetella_pertussis',    'NCBITAXON => 520',         '{"report_to_public_health": true}'),
+        ('Chlamydophila_pneumoniae','NCBITAXON => 83558',       null),
+        ('Enterovirus',             'NCBITAXON => 12059',       null),
+        ('Enterovirus.D',           'NCBITAXON => 138951',      null),
+        ('Enterovirus.D.68',        'NCBITAXON => 42789',       null),
+        ('Rhinovirus',              null,                       null),
+        ('Human_bocavirus',         'NCBITAXON => 329641',      null),
+        ('Human_coronavirus',       null,                       null),
+        ('Human_coronavirus.HKU1',  'NCBITAXON => 290028',      null),
+        ('Human_coronavirus.NL63',  'NCBITAXON => 277944',      null),
+        ('Human_coronavirus.229E',  'NCBITAXON => 11137',       null),
+        ('Human_coronavirus.OC43',  'NCBITAXON => 31631',       null),
+        ('Human_metapneumovirus',   'NCBITAXON => 162145',      null),
+        ('Human_parainfluenza',     null,                       null),
+        ('Human_parainfluenza.1',   'NCBITAXON => 12730',       null),
+        ('Human_parainfluenza.2',   'NCBITAXON => 1979160',     null),
+        ('Human_parainfluenza.3',   'NCBITAXON => 11216',       null),
+        ('Human_parainfluenza.4',   'NCBITAXON => 1979161',     null),
+        ('Human_parechovirus',      'NCBITAXON => 1803956',     null),
         ('Influenza',               null,                       null),
         ('Influenza.A',             'NCBITAXON => 11320',       null),
         ('Influenza.A.H1N1',        'NCBITAXON => 114727',      null),
@@ -16,9 +35,12 @@ insert into warehouse.organism (lineage, identifiers, details)
         ('Influenza.C',             'NCBITAXON => 11552',       null),
         ('Measles',                 'NCBITAXON => 11234',       '{"report_to_public_health": true}'),
         ('Mumps',                   'NCBITAXON => 1979165',     '{"report_to_public_health": true}'),
+        ('Mycoplasma_pneumoniae',   'NCBITAXON => 2104',        null),
         ('RSV',                     'NCBITAXON => 11250',       null),
         ('RSV.A',                   'NCBITAXON => 208893',      null),
-        ('RSV.B',                   'NCBITAXON => 208895',      null)
+        ('RSV.B',                   'NCBITAXON => 208895',      null),
+        ('Streptococcus_pneumoniae','NCBITAXON => 1313',        null)
+
 
     on conflict (lineage) do update
         set identifiers = coalesce(organism.identifiers, '') || EXCLUDED.identifiers,
@@ -27,16 +49,65 @@ insert into warehouse.organism (lineage, identifiers, details)
 
 with target_lineage (identifier, lineage) as (
     values
-        ('B.pertussis', 'Bordetella_pertussis'::ltree),
-        ('Flu_A_H1',    'Influenza.A.H1N1'),
-        ('Flu_A_H3',    'Influenza.A.H3N2'),
-        ('Flu_A_pan',   'Influenza.A'),
-        ('Flu_B_pan',   'Influenza.B'),
-        ('AP324NU',     'Influenza.C'),
-        ('Measles',     'Measles'),
-        ('Mumps',       'Mumps'),
-        ('RSVA',        'RSV.A'),
-        ('RSVB',        'RSV.B')
+        ('Adenovirus_pan_1',            'Adenovirus'::ltree),
+        ('Adenovirus_pan_2',            'Adenovirus'),
+        ('AdV_1of2',                    'Adenovirus'),
+        ('AdV_2of2',                    'Adenovirus'),
+        ('AI20U8U',                     'Bordetella_pertussis'),
+        ('B.pertussis',                 'Bordetella_pertussis'),
+        ('B.Pertussis',                 'Bordetella_pertussis'),
+        ('AI1RW2H',                     'Chlamydophila_pneumoniae'),
+        ('C_pneumoniae',                'Chlamydophila_pneumoniae'),
+        ('C. pneumoniae',               'Chlamydophila_pneumoniae'),
+        ('C. pneumoniae_AI1RW2H',       'Chlamydophila_pneumoniae'),
+        ('C.pneumoniae',                'Chlamydophila_pneumoniae'),
+        ('AP7DPVF',                     'Enterovirus'),
+        ('Enterovirus_pan',             'Enterovirus'),
+        ('Ev_pan',                      'Enterovirus'),
+        ('EV_pan',                      'Enterovirus'),
+        ('APFVK4U',                     'Enterovirus.D.68'),
+        ('enterovirus-D_APFVK4U',       'Enterovirus.D.68'),
+        ('Enterovirus-D_APFVK4U',       'Enterovirus.D.68'),
+        ('EV_D68',                      'Enterovirus.D.68'),
+        ('Bocavirus',                   'Human_bocavirus'),
+        ('HBoV',                        'Human_bocavirus'),
+        ('CoV_HKU1',                    'Human_coronavirus.HKU1'),
+        ('CoV_NL63',                    'Human_coronavirus.NL63'),
+        ('CoV_229E',                    'Human_coronavirus.229E'),
+        ('CoV_OC43',                    'Human_coronavirus.OC43'),
+        ('hMPV',                        'Human_metapneumovirus'),
+        ('hPIV1',                       'Human_parainfluenza.1'),
+        ('hPIV2',                       'Human_parainfluenza.2'),
+        ('hPIV3',                       'Human_parainfluenza.3'),
+        ('hPIV4',                       'Human_parainfluenza.4'),
+        ('HPeV',                        'Human_parechovirus'),
+        ('flu_A_pan',                   'Influenza.A'),
+        ('Flu_A_pan',                   'Influenza.A'),
+        ('Flu_A_H1',                    'Influenza.A.H1N1'),
+        ('Flu_A_H3',                    'Influenza.A.H3N2'),
+        ('Flu_b_pan',                   'Influenza.B'),
+        ('Flu_B_pan',                   'Influenza.B'),
+        ('Influenza_B',                 'Influenza.B'),
+        ('AP324NU',                     'Influenza.C'),
+        ('Measles',                     'Measles'),
+        ('APKA3DE',                     'Mumps'),
+        ('Mumps',                       'Mumps'),
+        ('AI5IRK5',                     'Mycoplasma_pneumoniae'),
+        ('M_pneumoniae',                'Mycoplasma_pneumoniae'),
+        ('M. pneumoniae',               'Mycoplasma_pneumoniae'),
+        ('M. pneumoniae_AI5IRK5',       'Mycoplasma_pneumoniae'),
+        ('M.pneumoniae',                'Mycoplasma_pneumoniae'),
+        ('11 Rhinovirus_pan_1',         'Rhinovirus'),
+        ('12 Rhinovirus_pan_2',         'Rhinovirus'),
+        ('RV_1of2',                     'Rhinovirus'),
+        ('RV_2of2',                     'Rhinovirus'),
+        ('RSVA',                        'RSV.A'),
+        ('RSVB',                        'RSV.B'),
+        ('APZTD4A',                     'Streptococcus_pneumoniae'),
+        ('S_pneumoniae',                'Streptococcus_pneumoniae'),
+        ('S. pneumoniae',               'Streptococcus_pneumoniae'),
+        ('S. pneumoniae_APZTD4A',       'Streptococcus_pneumoniae'),
+        ('S.pneumoniae',                'Streptococcus_pneumoniae')
 )
 insert into warehouse.target (identifier, organism_id, control)
 
@@ -46,6 +117,16 @@ insert into warehouse.target (identifier, organism_id, control)
 
     on conflict (identifier) do update
         set organism_id = EXCLUDED.organism_id
+;
+
+
+insert into warehouse.target (identifier, control)
+    values
+        ('Hs04930436_g1',   't'),
+        ('Ac00010014_a1',   't')
+
+    on conflict (identifier) do update
+        set control = EXCLUDED.control
 ;
 
 commit;

--- a/deploy/warehouse/target/data@2019-09-27b.sql
+++ b/deploy/warehouse/target/data@2019-09-27b.sql
@@ -1,0 +1,51 @@
+-- Deploy seattleflu/id3c-data:warehouse/target/data to pg
+-- requires: seattleflu/schema:warehouse/target/organism
+
+begin;
+
+insert into warehouse.organism (lineage, identifiers, details)
+    values
+        ('Bordetella_pertussis',    'NCBITAXON => 520',         '{"report_to_public_health": true}'),
+        ('Influenza',               null,                       null),
+        ('Influenza.A',             'NCBITAXON => 11320',       null),
+        ('Influenza.A.H1N1',        'NCBITAXON => 114727',      null),
+        ('Influenza.A.H3N2',        'NCBITAXON => 119210',      null),
+        ('Influenza.B',             'NCBITAXON => 11520',       null),
+        ('Influenza.B.Vic',         null,                       null),
+        ('Influenza.B.Yam',         null,                       null),
+        ('Influenza.C',             'NCBITAXON => 11552',       null),
+        ('Measles',                 'NCBITAXON => 11234',       '{"report_to_public_health": true}'),
+        ('Mumps',                   'NCBITAXON => 1979165',     '{"report_to_public_health": true}'),
+        ('RSV',                     'NCBITAXON => 11250',       null),
+        ('RSV.A',                   'NCBITAXON => 208893',      null),
+        ('RSV.B',                   'NCBITAXON => 208895',      null)
+
+    on conflict (lineage) do update
+        set identifiers = coalesce(organism.identifiers, '') || EXCLUDED.identifiers,
+            details     = coalesce(organism.details, '{}')   || EXCLUDED.details
+;
+
+with target_lineage (identifier, lineage) as (
+    values
+        ('B.pertussis', 'Bordetella_pertussis'::ltree),
+        ('Flu_A_H1',    'Influenza.A.H1N1'),
+        ('Flu_A_H3',    'Influenza.A.H3N2'),
+        ('Flu_A_pan',   'Influenza.A'),
+        ('Flu_B_pan',   'Influenza.B'),
+        ('AP324NU',     'Influenza.C'),
+        ('Measles',     'Measles'),
+        ('Mumps',       'Mumps'),
+        ('RSVA',        'RSV.A'),
+        ('RSVB',        'RSV.B')
+)
+insert into warehouse.target (identifier, organism_id, control)
+
+    select identifier, organism_id, false
+      from target_lineage
+      join warehouse.organism using (lineage)
+
+    on conflict (identifier) do update
+        set organism_id = EXCLUDED.organism_id
+;
+
+commit;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -20,3 +20,5 @@ shipping/views [shipping/views@2019-09-12] 2019-09-26T18:22:13Z Kairsten Fay <kf
 @2019-09-27 2019-09-27T17:06:31Z Thomas Sibley <tsibley@fredhutch.org> # Changes for 27 September 2019
 shipping/views [shipping/views@2019-09-27] 2019-09-27T17:11:20Z Thomas Sibley <tsibley@fredhutch.org> # Add flu assembly jobs view
 @2019-09-27b 2019-09-27T17:14:15Z Thomas Sibley <tsibley@fredhutch.org> # second batch of changes for 27 Sept 2019
+warehouse/target/data [warehouse/target/data@2019-09-27b] 2019-09-30T22:08:52Z Kairsten Fay <kfay@fredhutch.org> # Link more targets to organisms
+@2019-09-30 2019-09-30T23:59:55Z Kairsten Fay <kfay@fredhutch.org> # Link more targets to organisms


### PR DESCRIPTION
Update the target and organism tables according to the new Thermo Assay
names.

I have a few questions here:
~* How do I know if one of these new pathogens is reportable? ~
~* Should I add anything to the `identifiers` column of `warehouse.organism`? Having seen only the new Thermo Assay names data dictionary, I don't currently understand how that column is populated. I see the comment in the `organism.sql` file of ID3C that says :~
~    >    'Key-value pairs of external identifiers (i.e. dbxrefs) for this organism; keys should use well-known database or ontology prefix (e.g. NCBITaxon)';~

   ~But don't really know what a dbxref is or where to find it, even after Googling.~

~* Should I track controls (e.g. RnaseP Control)? I can add an extra column to the `with target_lineage (identifier, lineage) as (...` clause. Then should I update all targets to have a boolean `control` value?~
~* Why does only Bordetella (in `target_lineage`) use `::ltree`?~
~* Am I only adding the new Thermo Assay definition? I see that there are still quite a few targets in `warehouse.target` without linked a `organism_id` that exist as old Thermo Assay definitions.~

