### PR TITLE
WIP: Create new routine, etl redcap-det swab-n-send

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -68,10 +68,17 @@
         },
         "deepdiff": {
             "hashes": [
-                "sha256:1123762580af0904621136d117c8397392a244d3ff0fa0a50de57a7939582476",
-                "sha256:6ab13e0cbb627dadc312deaca9bef38de88a737a9bbdbfbe6e3857748219c127"
+                "sha256:51a1228346c91c8dbb586caefb9df6dddfed3a0abff834e72f547a5e405e0fc6",
+                "sha256:62ca21020e9c01383b5c45b9d89f418bdb78b4bb53f1d2374cd09db549e6959a"
             ],
-            "version": "==4.0.7"
+            "version": "==4.0.8"
+        },
+        "fhir.resources": {
+            "hashes": [
+                "sha256:4eabb6d8497e7b8f57ffff0fe68f38eebf85cad0fc9f534d6a9dc69af86ace56",
+                "sha256:93bf0c5748f7b14edbca15edfafe8a6a24e0b3de19bdaff2f0a65ea2f319d15c"
+            ],
+            "version": "==5.0.1"
         },
         "fiona": {
             "hashes": [
@@ -104,6 +111,13 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -167,24 +181,29 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:05dbfe72684cc14b92568de1bc1f41e5f62b00f714afc9adee42f6311738091f",
-                "sha256:0d82cb7271a577529d07bbb05cb58675f2deb09772175fab96dc8de025d8ac05",
-                "sha256:10132aa1fef99adc85a905d82e8497a580f83739837d7cbd234649f2e9b9dc58",
-                "sha256:12322df2e21f033a60c80319c25011194cd2a21294cc66fee0908aeae2c27832",
-                "sha256:16f19b3aa775dddc9814e02a46b8e6ae6a54ed8cf143962b4e53f0471dbd7b16",
-                "sha256:3d0b0989dd2d066db006158de7220802899a1e5c8cf622abe2d0bd158fd01c2c",
-                "sha256:438a3f0e7b681642898fd7993d38e2bf140a2d1eafaf3e89bb626db7f50db355",
-                "sha256:5fd214f482ab53f2cea57414c5fb3e58895b17df6e6f5bca5be6a0bb6aea23bb",
-                "sha256:73615d3edc84dd7c4aeb212fa3748fb83217e00d201875a47327f55363cef2df",
-                "sha256:7bd355ad7496f4ce1d235e9814ec81ee3d28308d591c067ce92e49f745ba2c2f",
-                "sha256:7d077f2976b8f3de08a0dcf5d72083f4af5411e8fddacd662aae27baa2601196",
-                "sha256:a4092682778dc48093e8bda8d26ee8360153e2047826f95a3f5eae09f0ae3abf",
-                "sha256:b458de8624c9f6034af492372eb2fee41a8e605f03f4732f43fc099e227858b2",
-                "sha256:e70fc8ff03a961f13363c2c95ef8285e0cf6a720f8271836f852cc0fa64e97c8",
-                "sha256:ee8e9d7cad5fe6dde50ede0d2e978d81eafeaa6233fb0b8719f60214cf226578",
-                "sha256:f4a4f6aba148858a5a5d546a99280f71f5ee6ec8182a7d195af1a914195b21a2"
+                "sha256:0b0dd8f47fb177d00fa6ef2d58783c4f41ad3126b139c91dd2f7c4b3fdf5e9a5",
+                "sha256:25ffe71f96878e1da7e014467e19e7db90ae7d4e12affbc73101bcf61785214e",
+                "sha256:26efd7f7d755e6ca966a5c0ac5a930a87dbbaab1c51716ac26a38f42ecc9bc4b",
+                "sha256:28b1180c758abf34a5c3fea76fcee66a87def1656724c42bb14a6f9717a5bdf7",
+                "sha256:2e418f0a59473dac424f888dd57e85f77502a593b207809211c76e5396ae4f5c",
+                "sha256:30c84e3a62cfcb9e3066f25226e131451312a044f1fe2040e69ce792cb7de418",
+                "sha256:4650d94bb9c947151737ee022b934b7d9a845a7c76e476f3e460f09a0c8c6f39",
+                "sha256:4dd830a11e8724c9c9379feed1d1be43113f8bcce55f47ea7186d3946769ce26",
+                "sha256:4f2a2b279efde194877aff1f76cf61c68e840db242a5c7169f1ff0fd59a2b1e2",
+                "sha256:62d22566b3e3428dfc9ec972014c38ed9a4db4f8969c78f5414012ccd80a149e",
+                "sha256:669795516d62f38845c7033679c648903200980d68935baaa17ac5c7ae03ae0c",
+                "sha256:75fcd60d682db3e1f8fbe2b8b0c6761937ad56d01c1dc73edf4ef2748d5b6bc4",
+                "sha256:9395b0a41e8b7e9a284e3be7060db9d14ad80273841c952c83a5afc241d2bd98",
+                "sha256:9e37c35fc4e9410093b04a77d11a34c64bf658565e30df7cbe882056088a91c1",
+                "sha256:a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e",
+                "sha256:b46554ad4dafb2927f88de5a1d207398c5385edbb5c84d30b3ef187c4a3894d8",
+                "sha256:c867eeccd934920a800f65c6068acdd6b87e80d45cd8c8beefff783b23cdc462",
+                "sha256:dd0667f5be56fb1b570154c2c0516a528e02d50da121bbbb2cbb0b6f87f59bc2",
+                "sha256:de2b1c20494bdf47f0160bd88ed05f5e48ae5dc336b8de7cfade71abcc95c0b9",
+                "sha256:f1df7b2b7740dd777571c732f98adb5aad5450aee32772f1b39249c8a50386f6",
+                "sha256:ffca69e29079f7880c5392bf675eb8b4146479d976ae1924d01cd92b04cccbcc"
             ],
-            "version": "==1.17.2"
+            "version": "==1.17.3"
         },
         "ordered-set": {
             "hashes": [

--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -1,5 +1,5 @@
 """
-Custom ID3C CLI commands.
+Custom ID3C ETL commands.
 
 This module is listed in the entry points configuration of setup.py, which
 causes the core id3c.cli module to load this file at CLI runtime.
@@ -8,6 +8,5 @@ By in turn loading our own individual commands here, we allow each command
 module to register itself via Click's decorators.
 """
 from . import (
-    reportable_conditions,
-    etl
+    redcap_det_swab_n_send
 )

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -515,10 +515,10 @@ def create_resource_questionnaire_response(record: dict, patient: dict,
         "item": items,
     }
 
-    if not items:
-        del questionnaire_response['item'] # TODO I get a typing error if I add items after declaring questionnaire_response
+    if items:
+        return questionnaire_response
 
-    return questionnaire_response
+    return None
 
 
 def questionnaire_item(record: dict, question_id: str, response_type: str) -> Optional[dict]:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -1,0 +1,668 @@
+"""
+Process REDCap DET documents into the relational warehouse.
+
+Contains some hard-coded logic for which project ID correlates to which project
+(e.g. 17421 is the PID for Shelters)
+"""
+import os
+import re
+import click
+import json
+import hashlib
+import logging
+import requests
+from uuid import uuid4
+from typing import Any, Collection, Dict, List, Match, Optional, Union
+from datetime import datetime, timezone
+from id3c.db.session import DatabaseSession
+from id3c.db.datatypes import Json
+from id3c.cli.command import with_database_session
+from id3c.cli.command.etl import etl, race
+
+from id3c.cli.command.etl.redcap_det import (
+    is_complete,
+    redcap_det,
+    insert_fhir_bundle,
+    mark_skipped,
+    mark_processed,
+    get_redcap_record
+)
+
+
+LOG = logging.getLogger(__name__)
+
+
+REVISION = 1
+ETL_NAME = 'redcap-det swab-n-send'
+etl_id = { 'revision': REVISION, "etl_name": ETL_NAME }
+
+REDCAP_URL = 'redcap.iths.org'
+INTERNAL_SYSTEM = "https://seattleflu.org"
+UW_CENSUS_TRACT = '53033005302'
+
+@redcap_det.command("swab-n-send", help = __doc__)
+
+@click.option("--log-output/--no-output",
+    help        = "Write the output FHIR documents to stdout. You will likely want to redirect this to a file",
+    default     = False)
+
+@with_database_session
+def redcap_det_swab_n_send(*, log_output: bool, db: DatabaseSession):
+    LOG.debug(f"Starting the REDCap DET ETL routine for Single Swab n Send, revision {REVISION}")
+
+    PROJECT_ID = '17561'  # TODO use '17421' in production
+    TOKEN_NAME = 'REDCAP_SINGLE_SWAB_AND_SEND_TOKEN'  # TODO use 'REDCAP_SWAB_N_SEND_TOKEN' in production
+    INSTRUMENTS_REQUIRED_TO_BE_COMPLETE = [
+        # 'consent',   # TODO use in production
+        'enrollment_questionnaire',
+        'back_end_mail_scans',
+        # 'illness_questionnaire_nasal_swab_collection',  # TODO use in production
+        'post_collection_data_entry_qc'
+    ]
+
+    # Fetch and iterate over REDCap DET records that aren't processed
+    #
+    # Rows we fetch are locked for update so that two instances of this
+    # command don't try to process the same longitudinal records.
+    LOG.debug("Fetching unprocessed REDCap DET Single Swab n Send records")
+
+    redcap_det = db.cursor("REDCap DET")
+    redcap_det.execute("""
+        select redcap_det_id as id, document
+          from receiving.redcap_det
+         where not processing_log @> %s
+          and document->>'project_id' = %s
+         order by id
+           for update
+        """, (Json([{ "etl": ETL_NAME, "revision": REVISION }]), PROJECT_ID))
+
+    for det in redcap_det:
+        with db.savepoint(f"redcap_det {det.id}"):
+            LOG.info(f"Processing REDCap DET {det.id}")
+
+            redcap_record = get_redcap_record(det.document['record'])
+
+            # TODO turn on for production
+            # if not redcap_instruments_are_complete(redcap_record, INSTRUMENTS_REQUIRED_TO_BE_COMPLETE):
+            #     LOG.info(f"Skipping incomplete or unverified REDCap DET {det.id}")
+            #     mark_skipped(db, det.id, etl_id)
+            #     continue
+
+            location_resources = locations(redcap_record)
+
+            patient         = create_resource_patient(redcap_record)
+            encounter       = create_resource_encounter(redcap_record, PROJECT_ID, patient, location_resources)
+            questionnaire   = create_resource_questionnaire_response(redcap_record, patient, encounter)
+            specimen        = create_resource_specimen(redcap_record, patient)
+            immunization    = create_resource_immunization(redcap_record, patient)
+
+            bundle = {
+                "resourceType": "Bundle",
+                "id": str(uuid4()),
+                "type": "collection",
+                "timestamp": datetime.now().astimezone().isoformat(),
+                "entry": [
+                    resource(patient),
+                    resource(encounter),
+                    resource(questionnaire),
+                    resource(specimen),
+                    resource(immunization)
+                ]
+            }
+
+            for location in location_resources:
+                bundle['entry'].append(location)
+
+        if log_output:
+            print(json.dumps(bundle, indent=2))
+
+        insert_fhir_bundle(db, bundle)
+        mark_processed(db, det.id)
+
+
+def resource(resource: dict) -> dict:
+    return { "resource": resource, "fullUrl": f"urn:uuid:{uuid4()}" }
+
+
+def redcap_instruments_are_complete(redcap_record: dict, required_instruments: list) -> bool:
+    """
+    Returns True if all the required REDCap instruments in this project are
+    complete, else False.
+    """
+    return all([ is_complete(instrument, redcap_record) for instrument in required_instruments ])
+
+
+def locations(redcap_record: dict) -> list:
+    """ Creates a list of Location resources from a REDCap record. """
+    def uw_affiliation(redcap_record: dict) -> List[Dict[Any, Any]]:
+        uw_affiliation = redcap_record['uw_affiliation']
+
+        uw_locations = []
+        if uw_affiliation in ['1', '2']:
+            uw_locations.append(
+                create_resource_location(f"{INTERNAL_SYSTEM}/location", UW_CENSUS_TRACT, "school"))
+
+        if uw_affiliation in ['2', '3', '4']:
+            uw_locations.append(
+                create_resource_location(f"{INTERNAL_SYSTEM}/location", UW_CENSUS_TRACT, "work"))
+
+        return uw_locations
+
+    def housing(redcap_record: dict) -> dict:
+        lodging_options = [
+            'Shelter',
+            'Assisted living facility',
+            'Skilled nursing center',
+            'No consistent primary residence'
+        ]
+
+        if redcap_record['housing_type'] in lodging_options:
+            housing_type = 'lodging'
+        else:
+            housing_type = 'residence'
+
+        # TODO census tract
+        if redcap_record['home_country'] == 'US':
+            address = {
+                'street1': redcap_record['home_street'],
+                'city': redcap_record['homecity_other'],
+                'state': redcap_record['home_state_55ec63'],
+                'country': redcap_record['home_country'],
+                'zipcode': redcap_record['home_zipcode_2'],
+            }
+
+        return create_resource_location(
+            f"{INTERNAL_SYSTEM}/location", '#TODO CENSUS TRACT', housing_type)
+
+    locations = [
+        resource(create_resource_location(f"{INTERNAL_SYSTEM}/site", 'self-test', "site"))
+    ]
+
+    housing_location = housing(redcap_record)
+    if housing_location:
+        locations.append(resource(housing_location))
+
+    uw_location = uw_affiliation(redcap_record)
+    for location in uw_location:
+        if location:
+            locations.append(resource(location))
+
+    return locations
+
+
+def create_resource_location(system: str, value: str, type: str, parent: str=None) -> dict:
+    """ Returns a FHIR Location resource. """
+    location_type_map = {
+        "residence": "PTRES",
+        "school": "SCHOOL",
+        "work": "WORK",
+        "site": "HUSCS",
+        "lodging": "PTLDG",
+    }
+
+    location = {
+        "resourceType": "Location",
+        "mode": "instance",
+        "identifier": [{
+            "system": system,
+            "value": value
+        }],
+        "type": [{
+            "coding": [{
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": location_type_map[type]
+            }]
+        }]
+    }
+
+    if parent:
+        location["partOf"] = { "reference": parent }  # TODO we're not really using this key right now
+
+    return location
+
+
+def create_resource_patient(redcap_record: dict) -> dict:
+    """ Returns a FHIR Patient resource. """
+    return {
+        "resourceType": "Patient",
+        "identifier": [{
+            "system": f"{INTERNAL_SYSTEM}/individual",
+            "value": generate_patient_hash(redcap_record),
+        }],
+        "gender": sex(redcap_record)
+    }
+
+
+def generate_patient_hash(redcap_record: dict) -> dict:
+    """ Returns a hash generated from patient information. """
+    personal_information = {
+        "name": canonicalize_name(f"{redcap_record['first_name_1']}{redcap_record['last_name_1']}"),
+        "gender": sex(redcap_record),  # TODO redundant?
+        "birthday": convert_to_iso(redcap_record['birthday'], '%Y-%m-%d'),
+        "zipcode": redcap_record['home_zipcode_2']  # TODO redundant?
+    }
+
+    return generate_hash(str(sorted(personal_information.items())))
+
+
+def create_resource_immunization(redcap_record: dict, patient: dict) -> dict:
+    """ Returns a FHIR Immunization resource. """
+    immunization = {
+        "resourceType": "Immunization",
+        "status": vaccine(redcap_record),
+        "vaccineCode": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "46233009",
+                    "display": "Influenza virus vaccine"
+                }
+            ]
+        },
+        "patient": {
+            "type": "Patient",
+            "identifier": patient['identifier'][0],
+        }
+    }
+
+    date = vaccine_date(redcap_record)
+
+    if date:
+        immunization["occurrenceDateTime"] = date
+    else:
+        immunization["occurrenceString"] = "No Vaccine"
+    # TODO it seems we have to have occurrenceDate or occurrenceString which seems weird considering
+    # 'not-done' is an acceptable status
+
+    return immunization
+
+
+
+def create_resource_encounter(redcap_record: dict, project_id: str, patient: dict, locations: list) -> dict:
+    """ Returns a FHIR Encounter resource. """
+
+    def grab_symptom_keys(key: str) -> Optional[Match[str]]:
+        if redcap_record[key] != '':
+            return re.match('symptoms(_child)?___[0-9]{1,3}$', key)
+        else:
+            return None
+
+    def build_conditions_list(symptom_key: str) -> dict:
+        return create_resource_condition(redcap_record, redcap_record[symptom_key], patient)
+
+    def build_diagnosis_list(symptom_key: str) -> dict:
+        return { "condition": { "reference": f"#{symptom(redcap_record[symptom_key])}" } }
+
+    def build_locations_list(location: dict) -> dict:
+        return {
+            "location": {
+                "type": "Location",
+                "reference": location['fullUrl']
+            }
+        }
+
+    symptom_keys = list(filter(grab_symptom_keys, redcap_record))
+
+    encounter = {
+        "resourceType": "Encounter",
+        "identifier": [{
+            "system": f"{INTERNAL_SYSTEM}/encounter",
+            "value": f"{REDCAP_URL}/{project_id}/{redcap_record['record_id']}",
+        }],
+        "class": {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "code": "HH"
+        },
+        "status": "finished",
+        "period": {
+            "start": convert_to_iso(redcap_record['enrollment_date_time'], "%Y-%m-%d %H:%M")
+        },
+        "subject": {
+            "type": "Patient",
+            "identifier": patient['identifier'][0],
+        },
+        "location": list(map(build_locations_list, locations)),
+    }
+
+    contained = list(map(build_conditions_list, symptom_keys))
+    if contained:
+        encounter['contained'] = contained
+
+    diagnosis = list(map(build_diagnosis_list, symptom_keys))
+    if diagnosis:
+        encounter['diagnosis'] = diagnosis
+
+    return encounter
+
+
+def convert_to_iso(time: str, current_format: str) -> str:
+    """
+    Converts a *time* to ISO format from the *current_format* specified in C-standard format codes.
+    """
+    return datetime.strptime(time, current_format).astimezone().isoformat()  # TODO uses locale time zone
+
+
+def create_resource_condition(redcap_record: dict, symptom_name: str, patient: dict) -> dict:
+    """ Returns a FHIR Condition resource. """
+    def symptom_duration(redcap_record: dict) -> str:
+        return convert_to_iso(redcap_record['symptom_duration'], "%Y-%m-%d")
+
+    def severity(symptom_name: Optional[str]) -> Optional[str]:
+        if symptom_name:
+            category = re.search('fever|cough|ache|fatigue|sorethroat', symptom_name.lower())
+            if category:
+                return f"{category[0]}_severity"
+
+        return None
+
+    mapped_symptom_name = symptom(symptom_name)
+
+    condition = {
+        "resourceType": "Condition",
+        "id": mapped_symptom_name,
+        "code": {
+            "coding": [
+                {
+                    "system": f"{INTERNAL_SYSTEM}/symptom",
+                    "code": mapped_symptom_name
+                }
+            ]
+        },
+        "onsetDateTime": symptom_duration(redcap_record),
+        "subject": {
+            "type": "Patient",
+            "identifier": patient['identifier'][0],
+        }
+    }
+
+    symptom_severity = severity(mapped_symptom_name)
+    if symptom_severity:
+        condition['severity'] = { "text": redcap_record[symptom_severity] }  # TODO lowercase?
+
+    return condition
+
+
+def create_resource_specimen(redcap_record: dict, patient: dict) -> dict:
+    """ """
+    # TODO: turn on barcode logic in production and replace the following line:
+    barcode = redcap_record['utm_tube_barcode']
+
+    # barcode = redcap_record['utm_tube_barcode_2']
+    # reentered_barcode = redcap_record['reenter_barcode']
+
+    # if redcap_record['barcode_confirm'] == "No":
+    #     barcode = redcap_record['corrected_barcode']
+    # elif barcode != reentered_barcode:
+    #     raise Error # TODO
+    # elif barcode != redcap_record['return_utm_barcode']:
+    #     raise Error # TODO
+
+    # TODO in production, throw error if no barcode (or skip)
+
+    specimen = {
+        "resourceType": "Specimen",
+        "identifier": [{
+            "system": f"{INTERNAL_SYSTEM}/sample",
+            "value": barcode,
+        }],
+        "subject": {
+            "type": "Patient",
+            "identifier": patient['identifier'][0],
+        }
+    }
+
+    # TODO I believe in production all samples should have a sample process date
+    received_time = redcap_record['samp_process_date']
+    if received_time:
+        specimen["receivedTime"] = convert_to_iso(received_time, "%Y-%m-%d %H:%M")
+
+    # TODO same as above comment
+    collected_time = redcap_record['collection_date']
+    if collected_time:
+        specimen["collection"] = {
+            "collectedDateTime": convert_to_iso(collected_time, "%Y-%m-%d %H:%M")
+        }
+
+    return specimen
+
+def create_resource_questionnaire_response(redcap_record: dict, patient: dict,
+    encounter: dict) -> dict:
+    """ Returns a FHIR Specimen resource. """
+
+    def create_custom_race_key(redcap_record: dict) -> List:
+        """
+        Handles the 'race' edge case by combining "select all that apply"-type
+        responses into one list.
+        """
+        race_keys = list(filter(grab_race_keys, redcap_record))
+        race_names = list(map(lambda x: redcap_record[x], race_keys))
+        return race(race_names)
+
+    def grab_race_keys(key: str) -> Optional[Match[str]]:
+        if redcap_record[key] != '':
+            return re.match('race___[0-9]{1,3}$', key)
+        else:
+            return None
+
+    def build_questionnaire_items(question: str) -> Optional[dict]:
+        return questionnaire_item(redcap_record, question, category)
+
+    coding_questions = [
+        'race',
+    ]
+
+    boolean_questions = [
+        'ethnicity',
+        'barcode_confirm',
+        'travel_states',
+        'travel_countries',
+    ]
+
+    integer_questions = [
+        'age',
+        'age_months',
+    ]
+
+    string_questions = [
+        'education',
+        'insurance',
+        'doctor_3e8fae',
+        'how_hear_sfs',
+        'samp_process_date',
+        'house_members_d5f2d9',
+        'shelter_members',
+        'where_sick',
+        # 'antiviral_0',    TODO turn on for production
+        'acute_symptom_onset',
+        'doctor_1week',
+        # 'antiviral_1',    TODO turn on for production
+        # 'poc_behaviors',  TODO turn on for production
+    ]
+
+    question_categories = {
+        'valueCoding': coding_questions,
+        'valueBoolean': boolean_questions,
+        'valueInteger': integer_questions,
+        'valueString': string_questions,
+    }
+
+    redcap_record['race'] = create_custom_race_key(redcap_record)
+
+    items: List[dict] = []
+    for category in question_categories:
+        category_items = list(map(build_questionnaire_items, question_categories[category]))
+        for item in category_items:
+            if item:
+                items.append(item)
+
+    questionnaire_response = {
+        "resourceType": "QuestionnaireResponse",
+        "status": "completed",
+        "subject": {
+            "type": "Patient",
+            "identifier": patient['identifier'][0],
+        },
+        "encounter": {
+            "type": "Encounter",
+            "identifier": encounter['identifier'][0],
+        },
+        "item": items,
+    }
+
+    if not items:
+        del questionnaire_response['item'] # TODO I get a typing error if I add items after declaring questionnaire_response
+
+    return questionnaire_response
+
+
+def questionnaire_item(redcap_record: dict, question_id: str, response_type: str) -> Optional[dict]:
+    """ Creates a QuestionnaireResponse internal item from a REDCap record. """
+    response = redcap_record[question_id]
+
+    def cast_to_coding(string: str):
+        """ Currently the only QuestionnaireItem we code is race. """
+        return {
+            "system": f"{INTERNAL_SYSTEM}/race",
+            "code": string,
+        }
+
+    def cast_to_string(string: str) -> Optional[str]:
+        if string != '':
+            return string
+        return None
+
+    def cast_to_integer(string: str) -> int:
+        try:
+            return int(string)
+        except ValueError:
+            return None
+
+    def cast_to_boolean(string: str) -> Optional[bool]:
+        if string == 'Yes':
+            return True
+        elif re.match(r'^No(?=$|,[\w\s]*)$', string):  # Starts with "No", has optional comma and text
+            return False
+        return None
+
+    def build_response_answers(response: Union[str, List]) -> Optional[List]:
+        answers = []
+        if not isinstance(response, list):
+            response = [response]
+
+        for item in response:
+            type_casted_item = casting_functions[response_type](item)
+
+            if type_casted_item:
+                answers.append({ response_type: type_casted_item })
+
+        return answers
+
+    casting_functions = {
+        'valueCoding': cast_to_coding,
+        'valueInteger': cast_to_integer,
+        'valueBoolean': cast_to_boolean,
+        'valueString': cast_to_string,
+    }
+
+    answers = build_response_answers(response)
+    if answers:
+        return {
+            "linkId": question_id,
+            "answer": answers,
+        }
+
+    return None
+
+def symptom(symptom_name: str) -> Optional[str]:
+    """
+    Returns a symptom name mapped from the REDCap data dictionary to the Audere
+    (ID3C) equivalent name.
+    """
+    symptom_map = {
+        'Feeling feverish':                     'feelingFeverish',
+        'Headache':                             'headaches',
+        'Cough':                                'cough',
+        'Chills or shivering':                  'chillsOrShivering',
+        'Sweats':                               'sweats',
+        'Sore throat or itchy/scratchy throat': 'soreThroat',
+        'Nausea or vomiting':                   'nauseaOrVomiting',
+        'Runny or stuffy nose':                 'runnyOrStuffyNose',
+        'Feeling more tired than usual':        'fatigue',
+        'Muscle or body aches':                 'muscleOrBodyAches',
+        'Diarrhea':                             'diarrhea',
+        'Ear pain/discharge':                   'earPainOrDischarge',
+        'Rash':                                 'rash',
+        'Increased trouble with breathing':     'increasedTroubleBreathing',
+        'None of the above':                    None,
+    }
+
+    if symptom_name not in symptom_map:
+        raise KeyError(f"Unknown symptom name \"{symptom_name}\"")
+
+    return symptom_map[symptom_name]
+
+def sex(redcap_record: dict) -> str:
+    """
+    Returns a *redcap_record* sex value mapped to a FHIR gender value.
+    This function uses a map instead of converting to lowercase to guard against
+    potential new or unexpected values for 'sex' in REDCap.
+    """
+    sex_map = {
+        'Male': 'male',
+        'Female': 'female',
+        'Indeterminate/other': 'other',
+        '': 'unknown'
+    }
+
+    try:
+        return sex_map[redcap_record['sex']]
+
+    except:
+        raise KeyError(f"Unknown sex \"{redcap_record['sex']}\"")
+
+
+def vaccine(redcap_record: dict) -> Optional[str]:
+    """ Maps a vaccine response to a standardized FHIR value. """
+    vaccine_map = {
+        'Yes': 'completed',
+        'No': 'not-done',
+        'Do not know': None,
+        '': None,
+    }
+
+    try:
+        return vaccine_map[redcap_record['vaccine']]
+    except:
+        raise KeyError(f"Unknown vaccine response \"{redcap_record['vaccine']}\"")
+
+
+def vaccine_date(redcap_record: dict) -> Optional[str]:
+    """ Converts a vaccination date to ISO format. """
+    year = redcap_record['vaccine_year_fc54b4']
+    month = redcap_record['vaccine_month_dfe1c1']
+
+    try:
+        return convert_to_iso(f'{month} {year}', '%B %Y')
+    except ValueError:
+        return None
+
+
+def residence_census_tract():
+    # TODO
+    pass
+
+
+def canonicalize_name(name: str) -> str:  # TODO should live in shared module
+  return re.sub(r'[\s\d\W]', '', name).upper()
+
+def generate_hash(identifier: str):  # TODO import? currently lives in `clinical`
+    """
+    Generate hash for *identifier* that is linked to identifiable records.
+    Must provide a "PARTICIPANT_DEIDENTIFIER_SECRET" as an OS environment
+    variable.
+    """
+    secret = os.environ["PARTICIPANT_DEIDENTIFIER_SECRET"]
+    new_hash = hashlib.sha256()
+    new_hash.update(identifier.encode("utf-8"))
+    new_hash.update(secret.encode("utf-8"))
+    return new_hash.hexdigest()

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -596,7 +596,7 @@ def symptom(symptom_name: str) -> Optional[str]:
         'Feeling more tired than usual':        'fatigue',
         'Muscle or body aches':                 'muscleOrBodyAches',
         'Diarrhea':                             'diarrhea',
-        'Ear pain/discharge':                   'earPainOrDischarge',
+        'Ear pain or discharge':                'earPainOrDischarge',
         'Rash':                                 'rash',
         'Increased trouble with breathing':     'increasedTroubleBreathing',
         'None of the above':                    None,


### PR DESCRIPTION
Here is the "bare bones" ETL for REDCap Swab n Send records. 

The outstanding TODOs are related to:
* moving all the REDCap ETLs to a shared file with subcommands (see the stub)
* geocoding
* deidentification (personal and household) 
* leftovers from the draft-mode "Single Swab and Send" that need to be updated with the new "Swab and Send" survey (that currently has no data points) 


I wanted to get some eyes on this to see if we have a reasonable approach in parsing REDCap records to FHIR format. 

See seattleflu/id3c/pull/73 for minor helper function changes that accompany this PR. 