### PR TITLE
Update reportable conditions

### DIFF
--- a/lib/seattleflu/id3c/cli/command/reportable_conditions.py
+++ b/lib/seattleflu/id3c/cli/command/reportable_conditions.py
@@ -98,7 +98,11 @@ def notify(*, action: str):
                         "Inferring site from manifest data.")
 
                 url = SLACK_WEBHOOK_REPORTING_GENERAL \
-                    if record.site not in childrens_sites and record.sheet != 'SCH' \
+                    if (record.site not in childrens_sites and
+                        record.sheet != 'SCH' and
+                        record.sample_origin != 'sch_retro' and
+                        record.swab_site != 'sch_ed' and
+                        record.swab_site != 'community_clinic') \
                     else SLACK_WEBHOOK_REPORTING_CHILDRENS
 
                 response = send_slack_post_request(record, url)
@@ -174,6 +178,13 @@ def send_slack_post_request(record: Any, url: str) -> requests.Response:
             "workbook": record.workbook,
             "sheet": record.sheet,
         }
+
+        if record.sample_origin:
+            data["manifest"]["sample_origin"] = record.sample_origin
+
+        if record.swab_site:
+            data["manifest"]["swab_site"] = record.swab_site
+
 
     payload = {
         "text": f":rotating_light: {record.lineage} detected",

--- a/lib/seattleflu/id3c/cli/command/reportable_conditions.py
+++ b/lib/seattleflu/id3c/cli/command/reportable_conditions.py
@@ -97,13 +97,13 @@ def notify(*, action: str):
                     LOG.info(f"No site found for presence_absence_id «{record.id}». " +
                         "Inferring site from manifest data.")
 
-                url = SLACK_WEBHOOK_REPORTING_GENERAL \
-                    if (record.site not in childrens_sites and
-                        record.sheet != 'SCH' and
-                        record.sample_origin != 'sch_retro' and
-                        record.swab_site != 'sch_ed' and
-                        record.swab_site != 'community_clinic') \
-                    else SLACK_WEBHOOK_REPORTING_CHILDRENS
+                url = SLACK_WEBHOOK_REPORTING_CHILDRENS \
+                    if (record.site in childrens_sites or
+                        record.sheet == 'SCH' or
+                        record.sample_origin == 'sch_retro' or
+                        record.swab_site == 'sch_ed' or
+                        record.swab_site == 'community_clinic') \
+                    else SLACK_WEBHOOK_REPORTING_GENERAL
 
                 response = send_slack_post_request(record, url)
 

--- a/schema/deploy/shipping/views@2019-09-30.sql
+++ b/schema/deploy/shipping/views@2019-09-30.sql
@@ -29,9 +29,7 @@ create or replace view shipping.reportable_condition_v1 as
         site.identifier as site,
         presence_absence.details->>'reporting_log' as reporting_log,
         sample.details->'_provenance'->>'workbook' as workbook,
-        sample.details->'_provenance'->>'sheet' as sheet,
-        sample.details->>'sample_origin' as sample_origin,
-        sample.details->>'swab_site' as swab_site
+        sample.details->'_provenance'->>'sheet' as sheet
 
     from warehouse.presence_absence
     join warehouse.target using (target_id)

--- a/schema/revert/shipping/views@2019-09-30.sql
+++ b/schema/revert/shipping/views@2019-09-30.sql
@@ -29,9 +29,7 @@ create or replace view shipping.reportable_condition_v1 as
         site.identifier as site,
         presence_absence.details->>'reporting_log' as reporting_log,
         sample.details->'_provenance'->>'workbook' as workbook,
-        sample.details->'_provenance'->>'sheet' as sheet,
-        sample.details->>'sample_origin' as sample_origin,
-        sample.details->>'swab_site' as swab_site
+        sample.details->'_provenance'->>'sheet' as sheet
 
     from warehouse.presence_absence
     join warehouse.target using (target_id)
@@ -97,38 +95,6 @@ create or replace view shipping.genomic_sequences_for_augur_build_v1 as
 comment on view shipping.genomic_sequences_for_augur_build_v1 is
     'View of genomic sequences for SFS augur build';
 
-
-create or replace view shipping.flu_assembly_jobs_v1 as
-
-    select sample.identifier as sfs_uuid,
-           sample.details ->> 'nwgc_id' as nwgc_id,
-           sequence_read_set.urls,
-           target.identifier as target,
-           o1.lineage as target_linked_organism,
-           coalesce(o2.lineage, o1.lineage) as assembly_job_organism,
-           sequence_read_set.details
-
-      from warehouse.sequence_read_set
-      join warehouse.sample using (sample_id)
-      join warehouse.presence_absence using (sample_id)
-      join warehouse.target using (target_id)
-      join warehouse.organism o1 using (organism_id)
-      -- Reason for o2 join: For pan-subtype targets like Flu_A_pan,
-      -- we want to spread out to the more specific lineages for assembly jobs.
-      -- Since this view is Flu specific, we are hard-coding it to spread just one level down.
-      left join warehouse.organism o2 on (o2.lineage ~ concat(o1.lineage::text, '.*{1}')::lquery)
-
-    where o1.lineage ~ 'Influenza.*'
-    and present
-    -- The sequence read set details currently holds the state of assembly jobs for each lineage.
-    -- So if null, then definitely no jobs have been completed.
-    -- If not null, then check if the assembly job organism matches any key in the sequence read set details.
-    and (sequence_read_set.details is null
-         or not sequence_read_set.details ? coalesce(o2.lineage, o1.lineage)::text)
-
-    order by sample.details ->> 'nwgc_id';
-
-comment on view shipping.flu_assembly_jobs_v1 is
-    'View of flu jobs that still need to be run through the assembly pipeline';
+drop view shipping.flu_assembly_jobs_v1;
 
 commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -23,3 +23,4 @@ shipping/views [shipping/views@2019-09-27] 2019-09-27T17:11:20Z Thomas Sibley <t
 warehouse/target/data [warehouse/target/data@2019-09-27b] 2019-09-30T22:08:52Z Kairsten Fay <kfay@fredhutch.org> # Link more targets to organisms
 @2019-09-30 2019-09-30T23:59:55Z Kairsten Fay <kfay@fredhutch.org> # Link more targets to organisms
 shipping/views [shipping/views@2019-09-30] 2019-10-18T16:23:26Z Jover Lee <joverlee@fredhutch.org> # Update reportable-conditions to include sample_origin and swab_site
+@2019-10-18 2019-10-18T16:32:08Z Jover Lee <joverlee@fredhutch.org> # Changes for 18 October 2019

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -22,3 +22,4 @@ shipping/views [shipping/views@2019-09-27] 2019-09-27T17:11:20Z Thomas Sibley <t
 @2019-09-27b 2019-09-27T17:14:15Z Thomas Sibley <tsibley@fredhutch.org> # second batch of changes for 27 Sept 2019
 warehouse/target/data [warehouse/target/data@2019-09-27b] 2019-09-30T22:08:52Z Kairsten Fay <kfay@fredhutch.org> # Link more targets to organisms
 @2019-09-30 2019-09-30T23:59:55Z Kairsten Fay <kfay@fredhutch.org> # Link more targets to organisms
+shipping/views [shipping/views@2019-09-30] 2019-10-18T16:23:26Z Jover Lee <joverlee@fredhutch.org> # Update reportable-conditions to include sample_origin and swab_site

--- a/schema/verify/shipping/views@2019-09-30.sql
+++ b/schema/verify/shipping/views@2019-09-30.sql
@@ -1,0 +1,26 @@
+-- Verify seattleflu/id3c-customizations:shipping/views on pg
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.reportable_condition_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.genomic_sequences_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.flu_assembly_jobs_v1');
+
+rollback;


### PR DESCRIPTION
This PR depends on https://github.com/seattleflu/id3c/pull/76 and https://github.com/seattleflu/specimen-manifests/pull/7

Update `shipping.reportable_condition_v1` to include `sample_origin` and `swab_site`. These are needed to infer `site` for samples without encounter data from 2019-2020. 

Update `reportable-conditions notify` logic to check `sample_origin` and `swab_site` to determine whether to report to GENERAL or SCH.