### PR TITLE
Sch year 1 clinical data

### DIFF
--- a/lib/seattleflu/id3c/cli/command/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/__init__.py
@@ -11,8 +11,10 @@ import logging
 import pandas as pd
 from typing import List
 
+
 # Load all ETL subcommands.
 __all__ = [
+    "etl",
     "clinical",
     "longitudinal",
     "reportable_conditions"

--- a/lib/seattleflu/id3c/cli/command/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/__init__.py
@@ -7,6 +7,117 @@ causes the core id3c.cli module to load this file at CLI runtime.
 By in turn loading our own individual commands here, we allow each command
 module to register itself via Click's decorators.
 """
-from . import (
-    reportable_conditions
-)
+import logging
+import pandas as pd
+from typing import List
+
+# Load all ETL subcommands.
+__all__ = [
+    "clinical",
+    "longitudinal",
+    "reportable_conditions"
+]
+
+
+LOG = logging.getLogger(__name__)
+
+
+def add_metadata(df: pd.DataFrame, filename: str) -> pd.DataFrame:
+    """ Adds a metadata column to a given DataFrame *df* for reporting """
+    df['_metadata'] = list(map(lambda index: {
+        'filename': filename,
+        'row': index + 2}, df.index))
+    return df
+
+
+def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
+    """ Trims leading and trailing whitespace from strings in *df* """
+    str_columns = df.columns[every_value_is_str_or_na(df)]
+
+    # Guard against AttributeErrors from entirely empty non-object dtype columns
+    str_columns = list(df[str_columns].select_dtypes(include='object'))
+
+    df[str_columns] = df[str_columns].apply(lambda column: column.str.strip())
+
+    return df
+
+
+def every_value_is_str_or_na(df):
+    """
+    Evaluates whether every value in the columns of a given DataFrame *df* is
+    either a string or NA.
+    """
+    return df.applymap(lambda col: isinstance(col, str) or pd.isna(col)).all()
+
+
+def barcode_quality_control(clinical_records: pd.DataFrame, output: str) -> None:
+    """ Perform quality control on barcodes """
+    missing_barcodes = missing_barcode(clinical_records)
+    duplicated_barcodes = duplicated_barcode(clinical_records)
+
+    print_problem_barcodes(pd.concat([missing_barcodes, duplicated_barcodes],
+                                 ignore_index=True), output)
+
+    assert len(duplicated_barcodes) == 0, "You have duplicated barcodes!"
+
+
+def missing_barcode(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Given a pandas DataFrame *df*, returns a DataFrame with missing barcodes and
+    a description of the problem.
+    """
+    missing_barcodes = df.loc[df['barcode'].isnull()].copy()
+    missing_barcodes['problem'] = 'Missing barcode'
+
+    return missing_barcodes
+
+
+def duplicated_barcode(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Given a pandas DataFrame *df*, returns a DataFrame with duplicated barcodes
+    and a description of the problem.
+    """
+    duplicates = pd.DataFrame(df.barcode.value_counts())
+    duplicates = duplicates[duplicates['barcode'] > 1]
+    duplicates = pd.Series(duplicates.index)
+
+    duplicated_barcodes = df[df['barcode'].isin(duplicates)].copy()
+    duplicated_barcodes['problem'] = 'Barcode is not unique'
+
+    return duplicated_barcodes
+
+
+def print_problem_barcodes(problem_barcodes: pd.DataFrame, output: str):
+    """
+    Given a pandas DataFrame of *problem_barcodes*, writes the data to
+    the log unless a filename *output* is given.
+    """
+    if output:
+        problem_barcodes.to_csv(output, index=False)
+    else:
+        problem_barcodes.apply(lambda x: LOG.warning(
+            f"{x['problem']} in row {x['_metadata']['row']} of file "
+            f"{x['_metadata']['filename']}, barcode {x['barcode']}"
+        ), axis=1)
+
+
+def group_true_values_into_list(long_subset: pd.DataFrame, stub: str,
+                                pid: List[str]) -> pd.DataFrame:
+    """
+    Given a long DataFrame *long_subset*, collapses rows with the same *pid*
+    such that every *pid* is represented once in the resulting DataFrame. True
+    values for each category in the given *stub* are collapsed into a
+    human-readable list.
+    """
+    long_subset.dropna(inplace=True)
+    long_subset[stub] = long_subset[stub].astype('bool')
+    true_subset = long_subset[long_subset[stub]]
+
+    return true_subset.groupby(pid + [stub]) \
+                      .agg(lambda x: x.tolist()) \
+                      .reset_index() \
+                      .drop(stub, axis=1) \
+                      .rename(columns={f'new_{stub}': stub})
+
+
+from . import *

--- a/lib/seattleflu/id3c/cli/command/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/__init__.py
@@ -42,7 +42,7 @@ def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def every_value_is_str_or_na(df):
+def every_value_is_str_or_na(df: pd.DataFrame):
     """
     Evaluates whether every value in the columns of a given DataFrame *df* is
     either a string or NA.

--- a/lib/seattleflu/id3c/cli/command/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/__init__.py
@@ -100,7 +100,7 @@ def print_problem_barcodes(problem_barcodes: pd.DataFrame, output: str):
         problem_barcodes.apply(lambda x: LOG.warning(
             f"{x['problem']} in row {x['_metadata']['row']} of file "
             f"{x['_metadata']['filename']}, barcode {x['barcode']}"
-        ), axis=1)
+        ), axis='columns')
 
 
 def group_true_values_into_list(long_subset: pd.DataFrame, stub: str,
@@ -118,7 +118,7 @@ def group_true_values_into_list(long_subset: pd.DataFrame, stub: str,
     return true_subset.groupby(pid + [stub]) \
                       .agg(lambda x: x.tolist()) \
                       .reset_index() \
-                      .drop(stub, axis=1) \
+                      .drop(stub, axis='columns') \
                       .rename(columns={f'new_{stub}': stub})
 
 

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -106,7 +106,7 @@ def parse_uw(uw_filename, uw_nwh_file, hmc_sch_file, output):
     clinical_records["age"] = clinical_records["age"].astype(pd.Int64Dtype())
 
     # Subset df to drop missing barcodes
-    clinical_records = clinical_records.loc[clinical_records['barcode'].notnull()]
+    clinical_records = drop_missing_rows(clinical_records, 'barcode')
 
     # Drop columns we're not tracking
     clinical_records = clinical_records[column_map.values()]
@@ -232,6 +232,12 @@ def generate_hash(identifier: str):
     new_hash.update(secret.encode("utf-8"))
     return new_hash.hexdigest()
 
+def drop_missing_rows(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """
+    Returns a filtered version of the given *df* where rows with ``null`` values
+    for the given *column* have been removed.
+    """
+    return df.loc[df[column].notnull()]
 
 @clinical.command("parse-sch")
 @click.argument("sch_filename", metavar = "<SCH Clinical Data filename>")

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -227,6 +227,10 @@ def generate_hash(identifier: str):
     variable.
     """
     secret = os.environ["PARTICIPANT_DEIDENTIFIER_SECRET"]
+
+    assert len(secret) > 0, "Empty *secret* provided!"
+    assert len(identifier) > 0, "Empty *identifier* provided!"
+
     new_hash = hashlib.sha256()
     new_hash.update(identifier.encode("utf-8"))
     new_hash.update(secret.encode("utf-8"))

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -43,11 +43,11 @@ def clinical():
 
 def parse_uw(uw_filename, uw_nwh_file, hmc_sch_file, output):
     """
-    Process and insert clinical data from UW.
+    Process clinical data from UW.
 
     Given a <UW Clinical Data filename> of an Excel document, selects specific
-    columns of interest and inserts the queried data into the
-    receiving.clinical table as a JSON document.
+    columns of interest and reformats the queried data into a stream of JSON
+    documents suitable for the "upload" sibling command.
 
     Uses <UW/NWH filename> and <HMC/SCH filename> to join clinical data to fill
     in SFS barcodes.
@@ -246,7 +246,7 @@ def drop_missing_rows(df: pd.DataFrame, column: str) -> pd.DataFrame:
 
 def parse_sch(sch_filename, output):
     """
-    Process and insert clinical data from SCH.
+    Process clinical data from SCH.
 
     All clinical records parsed are output to stdout as newline-delimited JSON
     records.  You will likely want to redirect stdout to a file.
@@ -330,7 +330,7 @@ def create_encounter_identifier(df: pd.DataFrame) -> pd.DataFrame:
 
 def parse_kp(kp_filename, kp_specimen_manifest_filename, output):
     """
-    Process and insert clinical data from KP.
+    Process clinical data from KP.
 
     All clinical records parsed are output to stdout as newline-delimited JSON
     records.  You will likely want to redirect stdout to a file.

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -272,19 +272,28 @@ def parse_sch(sch_filename, output):
     # Insert static value columns
     clinical_records["site"] = "SCH"
 
-    #Create encounter identifier(individual+encountered)
-    clinical_records["identifier"] = (clinical_records["individual"] + \
-                        clinical_records["encountered"].astype(str)).str.lower()
-
     # Placeholder columns for future data
     clinical_records["FluShot"] = None
     clinical_records["Race"] = None
     clinical_records["HispanicLatino"] = None
     clinical_records["MedicalInsurace"] = None
+
+    clinical_records = create_encounter_identifier(clinical_records)
     clinical_records = remove_pii(clinical_records)
 
     dump_ndjson(clinical_records)
 
+
+
+def create_encounter_identifier(df: pd.DataFrame) -> pd.DataFrame:
+    """ Creates an encounter identifier column on a given *df*. Return the
+    modified DataFrame.
+    """
+    df["identifier"] = (
+        df["individual"] + df["encountered"].astype(str)
+        ).str.lower()
+
+    return df
 
 
 @clinical.command("parse-kp")
@@ -338,10 +347,7 @@ def parse_kp(kp_filename, kp_specimen_manifest_filename, output):
     # Insert static value columns
     clinical_records["site"] = "KP"
 
-    #Create encounter identifier (individual + encountered)
-    clinical_records["identifier"] = (clinical_records["individual"] + \
-        clinical_records["encountered"].astype(str)).str.lower()
-
+    clinical_records = create_encounter_identifier(clinical_records)
     clinical_records = remove_pii(clinical_records)
 
     # Placeholder columns for future data.

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -1,0 +1,465 @@
+"""
+Parse and upload clinical data.
+
+Clinical data will contain PII (personally identifiable information) and
+unnecessary information that does not need to be stored. This process will only
+pull out specific columns of interest that will then be stored in the receiving
+schema of ID3C.
+"""
+import click
+import hashlib
+import logging
+import os
+import re
+import pandas as pd
+import id3c.db as db
+from math import ceil
+from id3c.db.session import DatabaseSession
+from id3c.cli import cli
+from id3c.cli.command import dump_ndjson
+from . import (
+    add_metadata,
+    barcode_quality_control,
+    trim_whitespace,
+    group_true_values_into_list,
+)
+
+
+LOG = logging.getLogger(__name__)
+
+
+@cli.group("clinical", help = __doc__)
+def clinical():
+    pass
+
+# UW Clinical subcommand
+@clinical.command("parse-uw")
+@click.argument("uw_filename", metavar = "<UW Clinical Data filename>")
+@click.argument("uw_nwh_file", metavar="<UW/NWH filename>")
+@click.argument("hmc_sch_file", metavar="<HMC/SCH filename>")
+@click.option("-o", "--output", metavar="<output filename>",
+    help="The filename for the output of missing barcodes")
+
+
+def parse_uw(uw_filename, uw_nwh_file, hmc_sch_file, output):
+    """
+    Process and insert clinical data from UW.
+
+    Given a <UW Clinical Data filename> of an Excel document, selects specific
+    columns of interest and inserts the queried data into the
+    receiving.clinical table as a JSON document.
+
+    Uses <UW/NWH filename> and <HMC/SCH filename> to join clinical data to fill
+    in SFS barcodes.
+
+    <UW/NWH filename> is the filepath to the data containing
+    manifests of the barcodes from UWMC and NWH Samples.
+
+    <HMC/SCH filename> is the filepath to the data containing manifests of the
+    barcodes from HMC and SCH Retrospective Samples.
+
+    <output filename> is the desired filepath of the output CSV of problematic
+    barcodes encountered while parsing. If not provided, the problematic
+    barcodes print to the log.
+
+    All clinical records parsed are output to stdout as newline-delimited JSON
+    records.  You will likely want to redirect stdout to a file.
+    """
+    clinical_records, uw_manifest, nwh_manifest, hmc_manifest = load_data(uw_filename,
+        uw_nwh_file, hmc_sch_file)
+    clinical_records = create_unique_identifier(clinical_records)
+    clinical_records = standardize_identifiers(clinical_records)
+
+    #Add barcode using manifests
+    master_ref = hmc_manifest.append([uw_manifest, nwh_manifest], ignore_index=True)
+    master_ref = standardize_identifiers(master_ref)
+    master_ref['Barcode ID'] = master_ref['Barcode ID'].str.lower()
+
+    #Join on MRN, Accession and Collection date
+    clinical_records = clinical_records.merge(master_ref, how='left',
+                  on=['MRN', 'Accession', 'Collection date'])
+
+    # Standardize names of columns that will be added to the database
+    column_map = {
+        'Age': 'age',
+        'Barcode ID': 'barcode',
+        'EthnicGroup': 'HispanicLatino',
+        'Fac': 'site',
+        'FinClass': 'MedicalInsurance',
+        'LabDtTm': 'encountered',
+        'PersonID': 'individual',
+        'Race': 'Race',
+        'Sex': 'AssignedSex',
+        'census_tract': 'census_tract',
+        'fluvaccine': 'FluShot',
+        'identifier': 'identifier',
+    }
+
+    clinical_records = clinical_records.rename(columns=column_map)
+
+    barcode_quality_control(clinical_records, output)
+
+    # Convert dtypes
+    clinical_records["encountered"] = pd.to_datetime(clinical_records["encountered"])
+    # Age must be converted to Int64 dtype because pandas does not support NaNs
+    # with normal type 'int'
+    clinical_records["age"] = clinical_records["age"].astype(pd.Int64Dtype())
+
+    # Subset df to drop missing barcodes
+    clinical_records = clinical_records.loc[clinical_records['barcode'].notnull()]
+
+    # Drop columns we're not tracking
+    clinical_records = clinical_records[column_map.values()]
+
+    # Remove PII
+    clinical_records['age'] = clinical_records['age'].apply(age_ceiling)
+    clinical_records['individual'] = clinical_records['individual'].apply(generate_hash)
+    clinical_records['identifier'] = clinical_records['identifier'].apply(generate_hash)
+
+    dump_ndjson(clinical_records)
+
+
+def load_data(uw_filename: str, uw_nwh_file: str, hmc_sch_file: str):
+    """
+    Returns a pandas DataFrame containing clinical records from UW given the
+    *uw_filename*.
+
+    Returns a pandas DataFrame containing barcode manifest data from UWMC & NWH
+    and SCH given the two filepaths *uw_nwh_file* and *hmc_sch_file*,
+    respectively.
+    """
+    clinical_records = load_uw_metadata(uw_filename, date='Collection.Date')
+
+    uw_manifest = load_uw_manifest_data(uw_nwh_file, 'UWMC', 'Collection Date')
+    nwh_manifest = load_uw_manifest_data(uw_nwh_file, 'NWH',
+                                      'Collection Date (per tube)')
+    hmc_manifest = load_uw_manifest_data(hmc_sch_file, 'HMC', 'Collection date')
+
+    return clinical_records, uw_manifest, nwh_manifest, hmc_manifest
+
+def load_uw_metadata(uw_filename: str, date: str) -> pd.DataFrame:
+    """
+    Given a filename *uw_filename*, returns a pandas DataFrame containing
+    clinical metadata.
+
+    Standardizes the collection date column with some hard-coded logic that may
+    need to be updated in the future.
+    Removes leading and trailing whitespace from str-type columns.
+    """
+    dtypes = {'census_tract': 'str'}
+    dates = ['Collection.Date']
+    na_values = ['Unknown']
+
+    if uw_filename.endswith('.csv'):
+        df = pd.read_csv(uw_filename, na_values=na_values, parse_dates=dates,
+                         dtype=dtypes)
+    else:
+        df = pd.read_excel(uw_filename, na_values=na_values, parse_dates=dates,
+                           dtype=dtypes)
+
+    df = df.rename(columns={date: 'Collection date'})
+    df = trim_whitespace(df)
+    df = add_metadata(df, uw_filename)
+
+    return df
+
+
+def load_uw_manifest_data(filename: str, sheet_name: str, date: str) -> pd.DataFrame:
+    """
+    Given a *filename* and *sheet_name*, returns a pandas DataFrame containing
+    barcode manifest data.
+
+    Renames collection *date* and barcode columns with some hard-coded logic
+    that may need to be updated in the future.
+    Removes leading and trailing whitespace from str-type columns.
+    """
+    barcode = 'Barcode ID (Sample ID)'
+    dtypes = {barcode: 'str'}
+
+    df = pd.read_excel(filename, sheet_name=sheet_name, keep_default_na=False,
+        na_values=['NA', '', 'Unknown', 'NULL'], dtype=dtypes)
+
+    rename_map = {
+        barcode: 'Barcode ID',
+        date: 'Collection date',
+    }
+
+    df = df.rename(columns=rename_map)
+    df = trim_whitespace(df)
+
+    return df[['Barcode ID', 'MRN', 'Collection date', 'Accession']]
+
+
+def create_unique_identifier(df: pd.DataFrame):
+    """Generate a unique identifier for each encounter and drop duplicates"""
+    df['identifier'] = (df['labMRN'] + df['LabAccNum'] + \
+                        df['Collection date'].astype(str)
+                        ).str.lower()
+    return df.drop_duplicates(subset="identifier")
+
+
+def standardize_identifiers(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert all to lower case for matching purposes"""
+    df['MRN'] = df['MRN'].str.lower()
+    df['Accession'] = df['Accession'].str.lower()
+    return df
+
+
+def age_ceiling(age: float, max_age=90) -> float:
+    """
+    Given an *age*, returns the same *age* unless it exceeds the *max_age*, in
+    which case the *max_age* is returned.
+    """
+    return min(age, max_age)
+
+def generate_hash(identifier: str):
+    """
+    Generate hash for *identifier* that is linked to identifiable records.
+    Must provide a "PARTICIPANT_DEIDENTIFIER_SECRET" as an OS environment
+    variable.
+    """
+    secret = os.environ["PARTICIPANT_DEIDENTIFIER_SECRET"]
+    new_hash = hashlib.sha256()
+    new_hash.update(identifier.encode("utf-8"))
+    new_hash.update(secret.encode("utf-8"))
+    return new_hash.hexdigest()
+
+
+@clinical.command("parse-sch")
+@click.argument("sch_filename", metavar = "<SCH Clinical Data filename>")
+@click.option("-o", "--output", metavar="<output filename>",
+    help="The filename for the output of missing barcodes")
+
+def parse_sch(sch_filename, output):
+    """
+    Process and insert clinical data from SCH.
+
+    All clinical records parsed are output to stdout as newline-delimited JSON
+    records.  You will likely want to redirect stdout to a file.
+    """
+    dtypes = {'census_tract': 'str'}
+    clinical_records = pd.read_csv(sch_filename, dtype=dtypes)
+    clinical_records = trim_whitespace(clinical_records)
+    clinical_records = add_metadata(clinical_records, sch_filename)
+
+    # Standardize column names
+    column_map = {
+        "pat_id2": "individual",
+        "study_id": "barcode",
+        "drawndate": "encountered",
+        "age": "age",
+        "sex": "AssignedSex",
+        "census_tract": "census_tract",
+    }
+    clinical_records = clinical_records.rename(columns=column_map)
+
+    barcode_quality_control(clinical_records, output)
+
+    # Drop unnecessary columns
+    clinical_records = clinical_records[column_map.values()]
+
+    # Convert dtypes
+    clinical_records["encountered"] = pd.to_datetime(clinical_records["encountered"])
+
+    # Insert static value columns
+    clinical_records["site"] = "SCH"
+
+    #Create encounter identifier(individual+encountered)
+    clinical_records["identifier"] = (clinical_records["individual"] + \
+                        clinical_records["encountered"].astype(str)).str.lower()
+
+    # Remove PII
+    clinical_records['age'] = clinical_records['age'].apply(age_ceiling)
+    clinical_records["individual"] = clinical_records["individual"].apply(generate_hash)
+    clinical_records["identifier"] = clinical_records["identifier"].apply(generate_hash)
+
+    # Placeholder columns for future data
+    clinical_records["FluShot"] = None
+    clinical_records["Race"] = None
+    clinical_records["HispanicLatino"] = None
+    clinical_records["MedicalInsurace"] = None
+
+    dump_ndjson(clinical_records)
+
+
+
+@clinical.command("parse-kp")
+@click.argument("kp_filename", metavar = "<KP Clinical Data filename>")
+@click.argument("kp_specimen_manifest_filename", metavar = "<KP Specimen Manifest filename>")
+@click.option("-o", "--output", metavar="<output filename>",
+    help="The filename for the output of missing barcodes")
+
+def parse_kp(kp_filename, kp_specimen_manifest_filename, output):
+    """
+    Process and insert clinical data from KP.
+
+    All clinical records parsed are output to stdout as newline-delimited JSON
+    records.  You will likely want to redirect stdout to a file.
+    """
+    clinical_records = pd.read_csv(kp_filename)
+    clinical_records.columns = clinical_records.columns.str.lower()
+
+    clinical_records = trim_whitespace(clinical_records)
+    clinical_records = add_metadata(clinical_records, kp_filename)
+    clinical_records = add_kp_manifest_data(clinical_records, kp_specimen_manifest_filename)
+
+    clinical_records = convert_numeric_columns_to_binary(clinical_records)
+    clinical_records = rename_symptoms_columns(clinical_records)
+    clinical_records = collapse_columns(clinical_records, 'symptom')
+    clinical_records = collapse_columns(clinical_records, 'race')
+
+    clinical_records['FluShot'] = clinical_records['fluvaxdt'].notna()
+
+    column_map = {  # Missing census_tract
+        "enrollid": "individual",
+        "enrolldate": "encountered",
+        "barcode": "barcode",
+        "age": "age",
+        "sex": "AssignedSex",
+        "race": "Race",
+        "hispanic": "HispanicLatino",
+        "symptom": "Symptoms",
+        "FluShot": "FluShot",
+    }
+    clinical_records = clinical_records.rename(columns=column_map)
+
+    barcode_quality_control(clinical_records, output)
+
+    # Drop unnecessary columns
+    clinical_records = clinical_records[column_map.values()]
+
+    # Convert dtypes
+    clinical_records["encountered"] = pd.to_datetime(clinical_records["encountered"])
+
+    # Insert static value columns
+    clinical_records["site"] = "KP"
+
+    #Create encounter identifier (individual + encountered)
+    clinical_records["identifier"] = (clinical_records["individual"] + \
+        clinical_records["encountered"].astype(str)).str.lower()
+
+    # Remove PII
+    clinical_records['age'] = clinical_records['age'].apply(age_ceiling)
+    clinical_records["individual"] = clinical_records["individual"].apply(generate_hash)
+    clinical_records["identifier"] = clinical_records["identifier"].apply(generate_hash)
+
+    # Placeholder columns for future data.
+    # See https://seattle-flu-study.slack.com/archives/CCAA9RBFS/p1568156642033700?thread_ts=1568145908.029300&cid=CCAA9RBFS
+    clinical_records["MedicalInsurace"] = None
+
+    dump_ndjson(clinical_records)
+
+
+def add_kp_manifest_data(df: pd.DataFrame, manifest_filename: str) -> pd.DataFrame:
+    """
+    Join the specimen manifest data from the given *manifest_filename* with the
+    given clinical records DataFrame *df*
+    """
+    barcode = 'Barcode ID (Sample ID)'
+    dtypes = {barcode: str}
+
+    manifest_data = pd.read_excel(manifest_filename, sheet_name='KP', dtype=dtypes)
+
+    regex = re.compile(r"^KP-([0-9]{6,})-[0-9]$", re.IGNORECASE)
+    manifest_data.kp_id = manifest_data.kp_id.apply(lambda x: regex.sub('WA\\1', x))
+
+    rename_map = {
+        barcode: 'barcode',
+        'kp_id': 'enrollid',
+    }
+
+    manifest_data = manifest_data.rename(columns=rename_map)
+    manifest_data = trim_whitespace(manifest_data)
+
+    return df.merge(manifest_data[['barcode', 'enrollid']], how='left')
+
+
+def convert_numeric_columns_to_binary(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    In a given DataFrame *df* of clinical records, convert a hard-coded list of
+    columns from numeric coding to binary.
+
+    See Kaiser Permanente data dictionary for details
+    """
+    numeric_columns = [
+        'runnynose',
+        'hispanic',
+        'racewhite',
+        'raceblack',
+        'raceasian',
+        'raceamerind',
+        'racenativehi',
+    ]
+    for col in numeric_columns:
+        df.loc[df[col] > 1, col] = None
+
+    return df
+
+
+def rename_symptoms_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """ Renames the hard-coded symptoms columns in a given DataFrame *df* """
+    symptoms_columns = [
+        'fever',
+        'sorethroat',
+        'runnynose',
+        'cough'
+    ]
+
+    symptoms_map = {}
+    for symptom in symptoms_columns:
+        symptoms_map[symptom] = 'symptom' + symptom
+
+    return df.rename(columns=symptoms_map)
+
+
+def collapse_columns(df: pd.DataFrame, stub: str, pid='enrollid') -> pd.DataFrame:
+    """
+    Given a pandas DataFrame *df* of clinical records, collapses the 0/1
+    encoding of multiple race options into a single array in a resulting
+    column called "Race". Removes the original "Race*" option columns. Returns
+    the new DataFrame.
+    """
+    stub_data = df.filter(regex=f'{pid}|{stub}*', axis=1)
+    stub_columns = list(stub_data)
+    stub_columns.remove(pid)
+
+    df = df.drop(columns=stub_columns)
+
+    stub_data_long = pd.wide_to_long(stub_data, stub, i=pid, j=f"new_{stub}",
+                        suffix='\\w+').reset_index()
+
+    stub_data_new = group_true_values_into_list(stub_data_long, stub, [pid])
+
+    return df.merge(stub_data_new, how='left')
+
+
+@clinical.command("upload")
+@click.argument("clinical_file",
+    metavar = "<clinical.ndjson>",
+    type = click.File("r"))
+
+def upload(clinical_file):
+    """
+    Upload clinical records into the database receiving area.
+
+    <clinical.ndjson> must be a newline-delimited JSON file produced by this
+    command's sibling commands.
+
+    Once records are uploaded, the clinical ETL routine will reconcile the
+    clinical records with known sites, individuals, encounters and samples.
+    """
+    db = DatabaseSession()
+
+    try:
+        LOG.info(f"Copying clinical records from {clinical_file.name}")
+
+        row_count = db.copy_from_ndjson(("receiving", "clinical", "document"), clinical_file)
+
+        LOG.info(f"Received {row_count:,} clinical records")
+        LOG.info("Committing all changes")
+        db.commit()
+
+    except:
+        LOG.info("Rolling back all changes; the database will not be modified")
+        db.rollback()
+        raise

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -111,10 +111,8 @@ def parse_uw(uw_filename, uw_nwh_file, hmc_sch_file, output):
     # Drop columns we're not tracking
     clinical_records = clinical_records[column_map.values()]
 
-    # Remove PII
-    clinical_records['age'] = clinical_records['age'].apply(age_ceiling)
-    clinical_records['individual'] = clinical_records['individual'].apply(generate_hash)
-    clinical_records['identifier'] = clinical_records['identifier'].apply(generate_hash)
+    clinical_records = remove_pii(clinical_records)
+
 
     dump_ndjson(clinical_records)
 
@@ -204,6 +202,16 @@ def standardize_identifiers(df: pd.DataFrame) -> pd.DataFrame:
     df['Accession'] = df['Accession'].str.lower()
     return df
 
+def remove_pii(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Remove personally identifiable information from a given *df*.
+    Return the new DataFrame.
+    """
+    df['age'] = df['age'].apply(age_ceiling)
+    df["individual"] = df["individual"].apply(generate_hash)
+    df["identifier"] = df["identifier"].apply(generate_hash)
+
+    return df
 
 def age_ceiling(age: float, max_age=90) -> float:
     """
@@ -268,16 +276,12 @@ def parse_sch(sch_filename, output):
     clinical_records["identifier"] = (clinical_records["individual"] + \
                         clinical_records["encountered"].astype(str)).str.lower()
 
-    # Remove PII
-    clinical_records['age'] = clinical_records['age'].apply(age_ceiling)
-    clinical_records["individual"] = clinical_records["individual"].apply(generate_hash)
-    clinical_records["identifier"] = clinical_records["identifier"].apply(generate_hash)
-
     # Placeholder columns for future data
     clinical_records["FluShot"] = None
     clinical_records["Race"] = None
     clinical_records["HispanicLatino"] = None
     clinical_records["MedicalInsurace"] = None
+    clinical_records = remove_pii(clinical_records)
 
     dump_ndjson(clinical_records)
 
@@ -338,10 +342,7 @@ def parse_kp(kp_filename, kp_specimen_manifest_filename, output):
     clinical_records["identifier"] = (clinical_records["individual"] + \
         clinical_records["encountered"].astype(str)).str.lower()
 
-    # Remove PII
-    clinical_records['age'] = clinical_records['age'].apply(age_ceiling)
-    clinical_records["individual"] = clinical_records["individual"].apply(generate_hash)
-    clinical_records["identifier"] = clinical_records["identifier"].apply(generate_hash)
+    clinical_records = remove_pii(clinical_records)
 
     # Placeholder columns for future data.
     # See https://seattle-flu-study.slack.com/archives/CCAA9RBFS/p1568156642033700?thread_ts=1568145908.029300&cid=CCAA9RBFS

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -308,7 +308,7 @@ def add_insurance(df: pd.DataFrame) -> pd.DataFrame:
         insurances = [ series[i] for i in insurance_columns if not pd.isna(series[i])]
         return list(set(insurances))
 
-    df['MedicalInsurance'] = df.apply(insurance, axis=1)
+    df['MedicalInsurance'] = df.apply(insurance, axis='columns')
     return df
 
 def create_encounter_identifier(df: pd.DataFrame) -> pd.DataFrame:
@@ -452,7 +452,7 @@ def collapse_columns(df: pd.DataFrame, stub: str, pid='enrollid') -> pd.DataFram
     column called "Race". Removes the original "Race*" option columns. Returns
     the new DataFrame.
     """
-    stub_data = df.filter(regex=f'{pid}|{stub}*', axis=1)
+    stub_data = df.filter(regex=f'{pid}|{stub}*', axis='columns')
     stub_columns = list(stub_data)
     stub_columns.remove(pid)
 

--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -64,7 +64,7 @@ def race(races: Optional[Any]) -> list:
         return [None]
 
     if not isinstance(races, list):
-        races = [races]
+        races = races.split("|")
 
     # Keys must be lowercase for case-insensitive lookup
     race_map = {
@@ -72,6 +72,7 @@ def race(races: Optional[Any]) -> list:
         "american indian or alaska native": "americanIndianOrAlaskaNative",
         "amerind": "americanIndianOrAlaskaNative",
         "native_american": "americanIndianOrAlaskaNative",
+        "indian": "americanIndianOrAlaskaNative",
 
         "asian": "asian",
 
@@ -81,16 +82,20 @@ def race(races: Optional[Any]) -> list:
 
         "nativehawaiian": "nativeHawaiian",
         "native hawaiian or other pacific islander": "nativeHawaiian",
+        "native hawaiian or other pacific islande": "nativeHawaiian",
+        "hawaiian-pacislander": "nativeHawaiian",
         "nativehi": "nativeHawaiian",
         "native_hawaiian": "nativeHawaiian",
 
         "white": "white",
 
         "other": "other",
+        "other race": "other",
         "multiple races": "other",
 
         "refused": None,
         "prefer not to say": None,
+        "did not wish to indicate": None,
         "unknown": None,
     }
 

--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -71,6 +71,7 @@ def race(races: Optional[Any]) -> list:
         "americanindianoralaskanative": "americanIndianOrAlaskaNative",
         "american indian or alaska native": "americanIndianOrAlaskaNative",
         "amerind": "americanIndianOrAlaskaNative",
+        "native_american": "americanIndianOrAlaskaNative",
 
         "asian": "asian",
 
@@ -81,6 +82,7 @@ def race(races: Optional[Any]) -> list:
         "nativehawaiian": "nativeHawaiian",
         "native hawaiian or other pacific islander": "nativeHawaiian",
         "nativehi": "nativeHawaiian",
+        "native_hawaiian": "nativeHawaiian",
 
         "white": "white",
 
@@ -89,6 +91,7 @@ def race(races: Optional[Any]) -> list:
 
         "refused": None,
         "prefer not to say": None,
+        "unknown": None,
     }
 
     assert set(race_map.keys()) == set(map(str.lower, race_map.keys()))

--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -1,0 +1,119 @@
+"""
+Run ETL routines
+"""
+import logging
+import re
+from typing import Any, Optional
+
+
+LOG = logging.getLogger(__name__)
+
+
+def race(races: Optional[Any]) -> list:
+    """
+    Given one or more *races*, returns the matching race identifier found in
+    Audere survey data.
+
+    Single values may be passed:
+
+    >>> race("OTHER")
+    ['other']
+
+    A list of values may also be passed:
+
+    >>> race(["ASIAN", "bLaCk", "white"])
+    ['asian', 'blackOrAfricanAmerican', 'white']
+
+    Leading and trailing space is ignored:
+
+    >>> race("   amerind ")
+    ['americanIndianOrAlaskaNative']
+
+    Internal runs of whitespace are collapsed during comparison:
+
+    >>> race("Native  Hawaiian or other     pacific islander")
+    ['nativeHawaiian']
+
+    but not completely ignored:
+
+    >>> race("whi te")
+    Traceback (most recent call last):
+        ...
+    id3c.cli.command.etl.UnknownRaceError: Unknown race name «whi te»
+
+    ``None`` may be passed for convenience with :meth:`dict.get`.
+
+    >>> race(None)
+    [None]
+
+    An :class:`UnknownRaceError` is raised when an unknown value is
+    encountered:
+
+    >>> race("foobarbaz")
+    Traceback (most recent call last):
+        ...
+    id3c.cli.command.etl.UnknownRaceError: Unknown race name «foobarbaz»
+
+    >>> race(["white", "nonsense", "other"])
+    Traceback (most recent call last):
+        ...
+    id3c.cli.command.etl.UnknownRaceError: Unknown race name «nonsense»
+    """
+    if races is None:
+        LOG.debug("No race response found.")
+        return [None]
+
+    if not isinstance(races, list):
+        races = [races]
+
+    # Keys must be lowercase for case-insensitive lookup
+    race_map = {
+        "americanindianoralaskanative": "americanIndianOrAlaskaNative",
+        "american indian or alaska native": "americanIndianOrAlaskaNative",
+        "amerind": "americanIndianOrAlaskaNative",
+
+        "asian": "asian",
+
+        "blackorafricanamerican": "blackOrAfricanAmerican",
+        "black or african american": "blackOrAfricanAmerican",
+        "black": "blackOrAfricanAmerican",
+
+        "nativehawaiian": "nativeHawaiian",
+        "native hawaiian or other pacific islander": "nativeHawaiian",
+        "nativehi": "nativeHawaiian",
+
+        "white": "white",
+
+        "other": "other",
+        "multiple races": "other",
+
+        "refused": None,
+        "prefer not to say": None,
+    }
+
+    assert set(race_map.keys()) == set(map(str.lower, race_map.keys()))
+
+    def standardize_whitespace(string):
+        return re.sub(r"\s+", " ", string.strip())
+
+    def standardize_race(race):
+        try:
+            return race_map[standardize_whitespace(race).lower()]
+        except KeyError:
+            raise UnknownRaceError(f"Unknown race name «{race}»") from None
+
+    return list(map(standardize_race, races))
+
+
+class UnknownRaceError(ValueError):
+    """
+    Raised by :function:`race` if its provided *race_name* is not among the set
+    of expected values.
+    """
+    pass
+
+
+from . import (
+    clinical,
+    longitudinal,
+)

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -211,9 +211,13 @@ def hispanic_latino(ethnic_group: Optional[Any]) -> list:
 
     ethnic_map = {
         "Not Hispanic or Latino": "no",
+        "Non-Hispanic/Latino": "no",
         "Hispanic or Latino": "yes",
+        "Hispanic/Latino": "yes",
         0.0: "no",
         1.0: "yes",
+        "Patient Refused/Did Not Wish To Indicate": None,
+        "Unknown": None,
     }
 
     if ethnic_group not in ethnic_map:
@@ -258,6 +262,8 @@ def insurance(insurance_response: Optional[Any]) -> list:
         "medicare": "government",
         "tricare": "government",
         "other": "other",
+        "unknown": None,
+
     }
 
     def standardize_insurance(insurance):

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -245,19 +245,29 @@ def insurance(insurance_response: Optional[Any]) -> list:
     Given an *insurance_response*, returns corresponding insurance
     identifier.
     """
+    if not type(isinstance(insurance_response, list)):
+        insurance_response = [ insurance_response ]
+
     if insurance_response is None:
         LOG.debug("No insurance response found.")
         return [None]
 
     insurance_map = {
-        "Commercial": "privateInsurance",
-        "Medicaid": "government",
-        "Medicare": "government",
-        "Tricare": "government",
-        "Other": "other"
+        "commercial": "privateInsurance",
+        "medicaid": "government",
+        "medicare": "government",
+        "tricare": "government",
+        "other": "other",
     }
 
-    return [insurance_map.get(insurance_response, None)]
+    def standardize_insurance(insurance):
+        try:
+            insurance = insurance.lower()
+            return insurance if insurance in insurance_map.values() else insurance_map[insurance]
+        except KeyError:
+            raise Exception(f"Unknown insurance name «{insurance}»") from None
+
+    return list(map(standardize_insurance, insurance_response))
 
 
 def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -1,0 +1,301 @@
+"""
+Process clinical documents into the relational warehouse.
+"""
+import click
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+from id3c.cli.command import with_database_session
+from id3c.db import find_identifier
+from id3c.db.session import DatabaseSession
+from id3c.db.datatypes import Json
+from id3c.cli.command.etl import (
+    etl,
+
+    age,
+    age_to_delete,
+    find_or_create_site,
+    find_sample,
+    find_location,
+    update_sample,
+    upsert_encounter,
+    upsert_individual,
+    upsert_encounter_location,
+
+    SampleNotFoundError,
+    UnknownEthnicGroupError,
+    UnknownFluShotResponseError,
+    UnknownSiteError,
+)
+from . import race
+
+
+LOG = logging.getLogger(__name__)
+
+
+# This revision number is stored in the processing_log of each clinical
+# record when the clinical record is successfully processed by this ETL
+# routine. The routine finds new-to-it records to process by looking for
+# clinical records lacking this revision number in their log.  If a
+# change to the ETL routine necessitates re-processing all clinical records,
+# this revision number should be incremented.
+REVISION = 3
+
+
+@etl.command("clinical", help = __doc__)
+@with_database_session
+
+def etl_clinical(*, db: DatabaseSession):
+    LOG.debug(f"Starting the clinical ETL routine, revision {REVISION}")
+
+    # Fetch and iterate over clinical records that aren't processed
+    #
+    # Rows we fetch are locked for update so that two instances of this
+    # command don't try to process the same clinical records.
+    LOG.debug("Fetching unprocessed clinical records")
+
+    clinical = db.cursor("clinical")
+    clinical.execute("""
+        select clinical_id as id, document
+          from receiving.clinical
+         where not processing_log @> %s
+         order by id
+           for update
+        """, (Json([{ "revision": REVISION }]),))
+
+    for record in clinical:
+        with db.savepoint(f"clinical record {record.id}"):
+            LOG.info(f"Processing clinical record {record.id}")
+
+            # Check validity of barcode
+            received_sample_identifier = sample_identifier(db,
+                record.document["barcode"])
+
+            # Skip row if no matching identifier found
+            if received_sample_identifier is None:
+                LOG.info("Skipping due to unknown barcode " + \
+                          f"{record.document['barcode']}")
+                mark_skipped(db, record.id)
+                continue
+
+            # Check sample exists in database
+            sample = find_sample(db,
+                identifier = received_sample_identifier)
+
+            # Skip row if sample does not exist
+            if sample is None:
+                LOG.info("Skipping due to missing sample with identifier " + \
+                            f"{received_sample_identifier}")
+                mark_skipped(db, record.id)
+                continue
+
+            # Most of the time we expect to see existing sites so a
+            # select-first approach makes the most sense to avoid useless
+            # updates.
+            site = find_or_create_site(db,
+                identifier = site_identifier(record.document["site"]),
+                details    = {"type": "retrospective"})
+
+
+            # Most of the time we expect to see new individuals and new
+            # encounters, so an insert-first approach makes more sense.
+            # Encounters we see more than once are presumed to be
+            # corrections.
+            individual = upsert_individual(db,
+                identifier  = record.document["individual"],
+                sex         = sex(record.document["AssignedSex"]))
+
+            encounter = upsert_encounter(db,
+                identifier      = record.document["identifier"],
+                encountered     = record.document["encountered"],
+                individual_id   = individual.id,
+                site_id         = site.id,
+                age             = age(record.document),
+                details         = encounter_details(record.document))
+
+            sample = update_sample(db,
+                sample = sample,
+                encounter_id = encounter.id)
+
+            # Link encounter to a Census tract, if we have it
+            tract_identifier = record.document.get("census_tract")
+
+            if tract_identifier:
+                # Special-case float-like identifiers in earlier date
+                tract_identifier = re.sub(r'\.0$', '', str(tract_identifier))
+
+                tract = find_location(db, "tract", tract_identifier)
+                assert tract, f"Tract «{tract_identifier}» is unknown"
+
+                upsert_encounter_location(db,
+                    encounter_id = encounter.id,
+                    relation = "residence",
+                    location_id = tract.id)
+
+            mark_processed(db, record.id, {"status": "processed"})
+
+            LOG.info(f"Finished processing clinical record {record.id}")
+
+
+def site_identifier(site_name: str) -> str:
+    """
+    Given a *site_name*, returns its matching site identifier.
+    """
+    if not site_name:
+        LOG.debug("No site name found")
+        return "Unknown"  # TODO
+
+    site_name = site_name.upper()
+
+    site_map = {
+        "UWMC": "RetrospectiveUWMedicalCenter",
+        "HMC": "RetrospectiveHarborview",
+        "NWH":"RetrospectiveNorthwest",
+        "UWNC": "RetrospectiveUWMedicalCenter",
+        "SCH": "RetrospectiveChildrensHospitalSeattle",
+        "KP": "KaiserPermanente",
+    }
+    if site_name not in site_map:
+        raise UnknownSiteError(f"Unknown site name «{site_name}»")
+
+    return site_map[site_name]
+
+def sex(sex_name) -> str:
+    """
+    Given a *sex_name*, returns its matching sex identifier.
+    """
+    if type(sex_name) is str:
+        sex_name = sex_name.upper()
+
+    sex_map = {
+        "M": "male",
+        "F": "female",
+        1.0: "male",
+        0.0: "female"
+    }
+
+    return sex_map.get(sex_name, "other")
+
+
+def encounter_details(document: dict) -> dict:
+    """
+    Describe encounter details in a simple data structure designed to be used
+    from SQL.
+    """
+    return {
+            "age": age_to_delete(document.get("age")), # XXX TODO: Remove age from details
+
+            # XXX TODO: Remove locations from details
+            "locations": {
+                "home": {
+                    "region": document.get("census_tract"),
+                }
+            },
+            "responses": {
+                "Race": race(document.get("Race")),
+                "FluShot": flu_shot(document.get("FluShot")),
+                "AssignedSex": [sex(document.get("AssignedSex"))],
+                "HispanicLatino": hispanic_latino(document.get("HispanicLatino")),
+                "MedicalInsurance": insurance(document.get("MedicalInsurance"))
+            },
+        }
+
+def hispanic_latino(ethnic_group: Optional[Any]) -> list:
+    """
+    Given an *ethnic_group*, returns yes/no value for HispanicLatino key.
+    """
+    if ethnic_group is None:
+        LOG.debug("No ethnic group response found.")
+        return [None]
+
+    ethnic_map = {
+        "Not Hispanic or Latino": "no",
+        "Hispanic or Latino": "yes",
+        0.0: "no",
+        1.0: "yes",
+    }
+
+    if ethnic_group not in ethnic_map:
+        raise UnknownEthnicGroupError(f"Unknown ethnic group «{ethnic_group}»")
+
+    return [ethnic_map[ethnic_group]]
+
+def flu_shot(flu_shot_response: Optional[Any]) -> list:
+    """
+    Given a *flu_shot_response*, returns yes/no value for FluShot key.
+    """
+    if flu_shot_response is None:
+        LOG.debug("No flu shot response found.")
+        return [None]
+
+    flu_shot_map = {
+        0.0 : "no",
+        1.0 : "yes"
+    }
+
+    if flu_shot_response not in flu_shot_map:
+        raise UnknownFluShotResponseError(
+            f"Unknown flu shot response «{flu_shot_response}»")
+
+    return [flu_shot_map[flu_shot_response]]
+
+def insurance(insurance_response: Optional[Any]) -> list:
+    """
+    Given an *insurance_response*, returns corresponding insurance
+    identifier.
+    """
+    if insurance_response is None:
+        LOG.debug("No insurance response found.")
+        return [None]
+
+    insurance_map = {
+        "Commercial": "privateInsurance",
+        "Medicaid": "government",
+        "Medicare": "government",
+        "Tricare": "government",
+        "Other": "other"
+    }
+
+    return [insurance_map.get(insurance_response, None)]
+
+
+def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:
+    """
+    Find corresponding UUID for scanned sample or collection barcode within
+    warehouse.identifier.
+
+    Will be sample barcode if from UW and collection barcode if from SCH.
+    """
+    identifier = find_identifier(db, barcode)
+
+    if identifier:
+        assert identifier.set_name == "samples" or \
+            identifier.set_name == "collections-seattleflu.org", \
+            f"Identifier found in set «{identifier.set_name}», not «samples»"
+
+    return identifier.uuid if identifier else None
+
+def mark_skipped(db, clinical_id: int) -> None:
+    LOG.debug(f"Marking clinical record {clinical_id} as skipped")
+    mark_processed(db, clinical_id, { "status": "skipped" })
+
+
+def mark_processed(db, clinical_id: int, entry: Mapping) -> None:
+    LOG.debug(f"Marking clinical document {clinical_id} as processed")
+
+    data = {
+        "clinical_id": clinical_id,
+        "log_entry": Json({
+            **entry,
+            "revision": REVISION,
+            "timestamp": datetime.now(timezone.utc),
+        }),
+    }
+
+    with db.cursor() as cursor:
+        cursor.execute("""
+            update receiving.clinical
+               set processing_log = processing_log || %(log_entry)s
+             where clinical_id = %(clinical_id)s
+            """, data)

--- a/lib/seattleflu/id3c/cli/command/etl/longitudinal.py
+++ b/lib/seattleflu/id3c/cli/command/etl/longitudinal.py
@@ -25,9 +25,9 @@ from id3c.cli.command.etl import (
     SampleNotFoundError,
     UnknownEthnicGroupError,
     UnknownFluShotResponseError,
-    UnknownRaceError,
     UnknownSiteError,
 )
+from . import race
 
 
 LOG = logging.getLogger(__name__)
@@ -234,33 +234,6 @@ def sex(document: dict) -> str:
     }
 
     return sex_map.get(sex_name, "other")
-
-
-def race(races: Optional[list]) -> list:
-    """
-    Given a *race_name*, returns the matching race identifier found in Audere
-    survey data.
-    """
-    if races is None:
-        LOG.debug("No race response found.")
-        return [None]
-
-    race_map = {
-        "native_american": "americanIndianOrAlaskaNative",
-        "asian": "asian",
-        "black": "blackOrAfricanAmerican",
-        "native_hawaiian": "nativeHawaiian",
-        "white": "white",
-        "other": "other",
-        "unknown": None,
-    }
-
-    for i in range(len(races)):
-        if races[i] not in race_map:
-            raise UnknownRaceError(f"Unknown race name «{races[i]}»")
-        races[i] = race_map[races[i]]
-
-    return races
 
 
 def hispanic_latino(document: dict) -> list:

--- a/lib/seattleflu/id3c/cli/command/etl/longitudinal.py
+++ b/lib/seattleflu/id3c/cli/command/etl/longitudinal.py
@@ -1,0 +1,383 @@
+"""
+Process longitudinal documents into the relational warehouse.
+"""
+import click
+import logging
+from itertools import chain
+from typing import Any, Mapping, Optional
+from datetime import datetime, timezone
+from id3c.cli.command import with_database_session
+from id3c.db import find_identifier
+from id3c.db.session import DatabaseSession
+from id3c.db.datatypes import Json
+from id3c.cli.command.etl import (
+    etl,
+
+    age,
+    age_to_delete,
+    find_or_create_site,
+    find_sample,
+    find_location,
+    update_sample,
+    upsert_encounter,
+    upsert_encounter_location,
+
+    SampleNotFoundError,
+    UnknownEthnicGroupError,
+    UnknownFluShotResponseError,
+    UnknownRaceError,
+    UnknownSiteError,
+)
+
+
+LOG = logging.getLogger(__name__)
+
+
+# This revision number is stored in the processing_log of each longitudinal
+# record when the longitudinal record is successfully processed by this ETL
+# routine. The routine finds new-to-it records to process by looking for
+# longitudinal records lacking this revision number in their log.  If a
+# change to the ETL routine necessitates re-processing all longitudinal records,
+# this revision number should be incremented.
+REVISION = 3
+
+
+@etl.command("longitudinal", help = __doc__)
+@with_database_session
+
+def etl_longitudinal(*, db: DatabaseSession):
+    LOG.debug(f"Starting the longitudinal ETL routine, revision {REVISION}")
+
+    # Fetch and iterate over longitudinal records that aren't processed
+    #
+    # Rows we fetch are locked for update so that two instances of this
+    # command don't try to process the same longitudinal records.
+    LOG.debug("Fetching unprocessed longitudinal records")
+
+    longitudinal = db.cursor("longitudinal")
+    longitudinal.execute("""
+        select longitudinal_id as id, document
+          from receiving.longitudinal
+         where not processing_log @> %s
+         order by id
+           for update
+        """, (Json([{ "revision": REVISION }]),))
+
+    for record in longitudinal:
+        with db.savepoint(f"longitudinal record {record.id}"):
+            LOG.info(f"Processing longitudinal record {record.id}")
+
+            # Check validity of barcode
+            received_sample_identifier = sample_identifier(db,
+                                                           record.document)
+
+            # Check sample exists in database
+            if received_sample_identifier:
+                sample = find_sample(db,
+                    identifier = received_sample_identifier)
+            else:
+                sample = None
+
+
+            # Most of the time we expect to see existing sites so a
+            # select-first approach makes the most sense to avoid useless
+            # updates.
+            site = find_or_create_site(db,
+                identifier = site_identifier(record.document),
+                details    = {"type": record.document['type']})
+
+
+            # Most of the time we expect to see existing individuals and new
+            # encounters.
+            # Encounters we see more than once are presumed to be
+            # corrections.
+            individual = find_or_create_individual(db,
+                identifier  = record.document["individual"],
+                sex         = sex(record.document))
+
+            encounter = upsert_encounter(db,
+                identifier      = record.document["identifier"],
+                encountered     = record.document["encountered"],
+                individual_id   = individual.id,
+                site_id         = site.id,
+                age             = age(record.document),
+                details         = encounter_details(record.document))
+
+            if sample:
+                sample = update_sample(db,
+                    sample = sample,
+                    encounter_id = encounter.id)
+
+            # Link encounter to a Census tract, if we have it
+            tract_identifier = record.document.get("census_tract")
+
+            if tract_identifier:
+                tract = find_location(db, "tract", str(tract_identifier))
+                assert tract, f"Tract «{tract_identifier}» is unknown"
+
+                upsert_encounter_location(db,
+                    encounter_id = encounter.id,
+                    relation = "residence",
+                    location_id = tract.id)
+
+            mark_processed(db, record.id, {"status": "processed"})
+
+            LOG.info(f"Finished processing longitudinal record {record.id}")
+
+
+def sample_identifier(db: DatabaseSession, document: dict) -> Optional[str]:
+    """
+    Given a *document*, find corresponding UUID for scanned sample or collection
+    barcode within warehouse.identifier.
+    """
+    barcode = document.get('barcode')
+
+    if not barcode:
+        return None
+
+    identifier = find_identifier(db, barcode)
+    set_name = 'collections-seattleflu.org'
+
+    if identifier:
+        assert identifier.set_name == set_name, \
+            f"Identifier found in set «{identifier.set_name}», not «{set_name}»"
+
+    return identifier.uuid if identifier else None
+
+
+def site_identifier(document: dict) -> str:
+    """
+    Given a *document*, parses the site and returns its matching site identifier.
+    """
+    site_name = document.get('site')
+
+    site_map = {
+        1: "HutchKids",
+        2: "WestCampusChildCareCenter"
+    }
+    if site_name not in site_map:
+        raise UnknownSiteError(f"Unknown site name «{site_name}»")
+
+    return site_map[site_name]
+
+
+def encounter_details(document: dict) -> dict:
+    """
+    Describe encounter details in a simple data structure designed to be used
+    from SQL.
+    """
+    return {
+            "age": age_to_delete(document.get("age")), # XXX TODO: Remove age from details
+
+            # XXX TODO: Remove locations from details
+            "locations": {
+                "home": {
+                    "region": document.get("census_tract"),
+                }
+            },
+            "responses": {
+                "Race": race(document.get("Race")),
+                "FluShot": flu_shot(document),
+                "AssignedSex": [sex(document)],
+                "HispanicLatino": hispanic_latino(document),
+                "MedicalInsurance": insurance(document),
+                "Symptoms": symptoms(document),
+            },
+        }
+
+
+def find_or_create_individual(db: DatabaseSession, identifier: str, sex: str,
+                              details: dict=None) -> Any:
+    """
+    Select indinvidual by *identifier*, or insert it if it doesn't exist.
+    """
+    LOG.debug(f"Looking up individual «{identifier}»")
+
+    individual = db.fetch_row("""
+        select individual_id as id, identifier
+          from warehouse.individual
+         where identifier = %s
+        """, (identifier,))
+
+    if individual:
+        LOG.info(f"Found individual {individual.id} «{individual.identifier}»")
+    else:
+        LOG.debug(f"individual «{identifier}» not found, adding")
+
+        data = {
+            "identifier": identifier,
+            "sex": sex,
+            "details": Json(details),
+        }
+
+        individual = db.fetch_row("""
+            insert into warehouse.individual (identifier, sex, details)
+                values (%(identifier)s, %(sex)s, %(details)s)
+            returning individual_id as id, identifier
+            """, data)
+
+        LOG.info(f"Created individual {individual.id} «{individual.identifier}»")
+
+    return individual
+
+
+def sex(document: dict) -> str:
+    """
+    Given a *document*, parses the sex name and returns its matching sex
+    identifier.
+    """
+    sex_name = document.get("AssignedSex")
+
+    sex_map: Mapping[Any, str] = {
+        1: "male",
+        2: "female"
+    }
+
+    return sex_map.get(sex_name, "other")
+
+
+def race(races: Optional[list]) -> list:
+    """
+    Given a *race_name*, returns the matching race identifier found in Audere
+    survey data.
+    """
+    if races is None:
+        LOG.debug("No race response found.")
+        return [None]
+
+    race_map = {
+        "native_american": "americanIndianOrAlaskaNative",
+        "asian": "asian",
+        "black": "blackOrAfricanAmerican",
+        "native_hawaiian": "nativeHawaiian",
+        "white": "white",
+        "other": "other",
+        "unknown": None,
+    }
+
+    for i in range(len(races)):
+        if races[i] not in race_map:
+            raise UnknownRaceError(f"Unknown race name «{races[i]}»")
+        races[i] = race_map[races[i]]
+
+    return races
+
+
+def hispanic_latino(document: dict) -> list:
+    """
+    Given a *document*, returns yes/no value for its HispanicLatino key.
+    """
+    ethnic_group = document.get("HispanicLatino")
+
+    if ethnic_group is None:
+        LOG.debug("No ethnic group response found.")
+        return [None]
+
+    ethnic_map = {
+        1: "yes",
+        2: "no",
+        3: None,
+    }
+
+    if ethnic_group not in ethnic_map:
+        raise UnknownEthnicGroupError(f"Unknown ethnic group «{ethnic_group}»")
+
+    return [ethnic_map[ethnic_group]]
+
+
+def flu_shot(document: dict) -> list:
+    """
+    Given a *document*, returns a 'yes', 'no', or 'doNotKnow' value for its
+    'FluShot' key.
+    """
+    flu_shot_response = document.get("FluShot")
+    if flu_shot_response is None:
+        LOG.debug("No flu shot response found.")
+        return [None]
+
+    flu_shot_map = {
+        1: "yes",
+        2: "no",
+        3: "doNotKnow",
+    }
+
+    if flu_shot_response not in flu_shot_map:
+        raise UnknownFluShotResponseError(
+            f"Unknown flu shot response «{flu_shot_response}»")
+
+    return [flu_shot_map[flu_shot_response]]
+
+
+def insurance(document: dict) -> list:
+    """
+    Given a dict, parses its insurance response and returns a corresponding
+    insurance identifier.
+    """
+    insurance_response = document.get("MedicalInsurance")
+
+    if insurance_response is None:
+        LOG.debug("No insurance response found.")
+        return [None]
+
+    insurance_map = {
+        1: "privateInsurance",
+        2: "governmentInsurance",
+        3: "noInsurance",
+    }
+
+    return [insurance_map.get(insurance_response, None)]
+
+
+def symptoms(document: dict) -> list:
+    """
+    Given a *document*, combines the unique parent-reported and RN-reported
+    symptoms into a list.
+    """
+    parent_reported_symptoms = document.get("sx_specific") or []
+    rn_reported_symptoms = document.get("rn_sx") or []
+
+    symptoms = parent_reported_symptoms + rn_reported_symptoms
+
+    symptoms_map = {
+        "ear_pain": ["earPainOrDischarge"],
+        "fever": ["feelingFeverish"],
+        "headache": ["headaches"],
+        "myalgia": ["muscleOrBodyAches"],
+        "ndv": ["nauseaOrVomiting", "diarrhea"],
+        "nvd": ["nauseaOrVomiting", "diarrhea"],
+        "runny_nose": ["runnyOrStuffyNose"],
+        "sore_throat": ["soreThroat"],
+        "wob": ["increasedTroubleBreathing"],
+        "cough": ["cough"],
+        "fatigue": ["fatigue"],
+        "rash": ["rash"],
+    }
+
+    def standardize_symptom(symptom):
+        try:
+            return symptoms_map[symptom]
+        except KeyError:
+            raise Exception(f"Unknown symptom name «{symptom}»") from None
+
+    # Deduplicate symptoms at the very end
+    return list(set(chain.from_iterable(map(standardize_symptom, symptoms))))
+
+
+def mark_processed(db, longitudinal_id: int, entry: Mapping) -> None:
+    LOG.debug(f"Marking longitudinal document {longitudinal_id} as processed")
+
+    data = {
+        "longitudinal_id": longitudinal_id,
+        "log_entry": Json({
+            **entry,
+            "revision": REVISION,
+            "timestamp": datetime.now(timezone.utc),
+        }),
+    }
+
+    with db.cursor() as cursor:
+        cursor.execute("""
+            update receiving.longitudinal
+               set processing_log = processing_log || %(log_entry)s
+             where longitudinal_id = %(longitudinal_id)s
+            """, data)

--- a/lib/seattleflu/id3c/cli/command/longitudinal.py
+++ b/lib/seattleflu/id3c/cli/command/longitudinal.py
@@ -1,0 +1,390 @@
+"""
+Parse and upload longitudinal data.
+
+Longitudinal childcare data will contain PII (personally identifiable
+information) and unnecessary information that does not need to be stored. This
+process will only pull out specific columns of interest that will then be stored
+in the receiving schema of ID3C.
+"""
+import re
+import click
+import logging
+import numpy as np
+import pandas as pd
+import id3c.db as db
+from typing import List
+from itertools import combinations
+from id3c.db.session import DatabaseSession
+from id3c.cli import cli
+from id3c.cli.command import dump_ndjson
+from . import (
+    add_metadata,
+    barcode_quality_control,
+    group_true_values_into_list,
+    trim_whitespace,
+)
+
+
+LOG = logging.getLogger(__name__)
+
+
+@cli.group("longitudinal", help = __doc__)
+def longitudinal():
+    pass
+
+@longitudinal.command("parse")
+@click.argument("baseline_filename",
+    metavar = "<Longitudinal Childcare Data baseline (enrollments) filename>")
+@click.argument("weekly_filename",
+    metavar = "<Longitudinal Childcare Data weekly assessments filename>")
+@click.argument("survey_filename",
+    metavar = "<Longitudinal Childcare Data weekly surveys filename>")
+@click.option("-o", "--output",
+    metavar="<output filename>",
+    help="The filename for the output of missing barcodes")
+
+def parse(baseline_filename, weekly_filename, survey_filename, output):
+    """
+    Process and insert longitudinal childcare data from SCH.
+
+    Drops records with no encounter date that result after reshaping from wide
+    to long format.
+
+    All childcare records parsed are output to stdout as newline-delimited JSON
+    records.  You will likely want to redirect stdout to a file.
+    """
+    lnginal_records = format_and_merge_data(baseline_filename, weekly_filename,
+                                            survey_filename)
+
+    lnginal_records = weekly_assessments_wide_to_long(lnginal_records)
+    lnginal_records = select_all_that_apply_wide_to_long(lnginal_records)
+
+    lnginal_records = duplicate_audere_keys(lnginal_records)
+    lnginal_records = insert_static_values(lnginal_records)
+    lnginal_records = create_identifiers(lnginal_records)
+
+    lnginal_records = lnginal_records[lnginal_records.encountered.notnull()]
+
+    barcode_quality_control(lnginal_records, output)
+
+    dump_ndjson(lnginal_records)
+
+
+def format_and_merge_data(baseline_filename: str, weekly_filename: str,
+                          survey_filename: str) -> pd.DataFrame:
+    """
+    For each given filename, loads the related data, performs minimal processing
+    and renaming, and merges each dataset into one DataFrame that is returned.
+    """
+    baseline_records = load_data(baseline_filename)
+    weekly_records = load_data(weekly_filename)
+    survey_records = load_data(survey_filename)
+
+    baseline_records = rename_baseline_columns(baseline_records)
+
+    survey_records = rename_stub(survey_records, regex='^household_(?!ill)',
+                                 current_stub='household',
+                                 desired_stub='household_sx')
+
+    return merge_data(baseline_records, weekly_records, survey_records)
+
+
+def load_data(filename: str) -> pd.DataFrame:
+    """
+    Loads longitudinal childcare data from SCH from a given *filename*.
+
+    Removes leading and trailing whitespace from string columns in the
+    underlying data.
+    """
+    df = pd.read_csv(filename)
+    df = trim_whitespace(df)
+    df = add_metadata(df, filename)
+
+    return df
+
+
+def merge_data(baseline_records: pd.DataFrame, weekly_records: pd.DataFrame,
+               survey_records: pd.DataFrame) -> pd.DataFrame:
+    """
+    Given three DataFrames (*baseline_records*, *weekly_records*, and
+    *survey_records*) of longitudinal childcare data, merges them on the unique
+    person identifier (pid).
+
+    Raises a :class:`AssertionError` if the pid columns are missing in any
+    DataFrame or if there are duplicated columns between any two DataFrames
+    other than the pid and ``_metadata`` columns (added by a previous process).
+
+    The ``_metadata`` columns in *weekly_records* and *survey_records* receive
+    suffixes of ``_followup`` and ``_survey`` after merging, respectively.
+    """
+    pid = ['study_id']  # This harcoding may need to be updated in the future
+    merge_method = 'left'
+
+    for combo in combinations([baseline_records, weekly_records, survey_records], 2):
+        duplicated_columns = set(list(combo[0])).intersection(list(combo[1]))
+
+        expected_duplicates = set(pid + ['_metadata'])
+        assert duplicated_columns == expected_duplicates, \
+            f"""You are either missing {expected_duplicates} columns in your
+            dataset or have duplicated columns other than {expected_duplicates}
+            in your data."""
+
+    merged_data = baseline_records.merge(weekly_records, how=merge_method,
+                                         on=pid, suffixes=['', '_followup'])
+    merged_data = merged_data.merge(survey_records, how=merge_method,
+                                    on=pid, suffixes=['', '_survey'])
+
+    assert len(baseline_records) == len(merged_data), \
+        "Something went wrong when merging your files together."
+
+    return merged_data
+
+
+def rename_baseline_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Two columns in the longitudinal data are reported at baseline but do not
+    follow the stubnaming-convention of the follow-up columns. Rename these
+    columns in *df* to follow the weekly data naming conventions.
+
+    Note that baseline columns are named inconsistently. Some end with '_bl'.
+    Other contain '_bl_' in the middle of the column name. Handle both of these
+    cases.
+
+    Contains some hard-coded column names that may need to be updated in the
+    future.
+    """
+    df['swab_date_0'] = df['enroll_date']
+
+    rename_map = {
+        'enroll_date': 'assess_date_0',
+        'baseline_id': 'sample_id_0',
+    }
+
+    baseline_columns = list(df.filter(regex='_bl$|_bl_', axis=1))
+
+    for col in baseline_columns:
+        rename_map[col] = re.sub("_bl", "", col) + "_0"
+
+    return df.rename(columns=rename_map)
+
+
+def weekly_assessments_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Casts a given DataFrame *df* from wide to long on longitudinal data.
+
+    Contains some hard-coded column names that may need to be updated in the
+    future.
+
+    Raises a :class:`Exception` if after reshaping from wide-to-long, the
+    resulting time column (e.g. 'week') contains non-integer dtypes.
+    """
+    pid = ['study_id']
+    time = 'week'
+
+    df = rename_stub(df, regex='^swab_[0-9]+$', current_stub='swab',
+                     desired_stub='swab_collected')
+
+    stubnames = longitudinal_stubnames(df)
+
+    reshaped = pd.wide_to_long(df, stubnames, i=pid, j=time, sep="_",
+                              ).reset_index()
+
+    try:
+        reshaped[time] = reshaped[time].astype('int')
+    except ValueError:
+        raise Exception(f"""Expected the «{time}» column to contain only
+            integers after casting longitudinal data from wide-to-long.
+            Please check your stubnames and try again.""")
+
+    return reshaped
+
+
+def rename_stub(df: pd.DataFrame, regex: str, current_stub: str,
+                desired_stub: str) -> pd.DataFrame:
+    """
+    Renames *current_stub* columns in a given DataFrame *df* to a
+    *desired_stub*, using the given *regex* to capture the desired columns
+    to rename.
+
+    Motivation: useful for avoiding future DataFrame reshaping conflicts with
+    the original stubname.
+
+    For example, the stub "swab" in the original data is not sufficient for
+    capturing longitudinal data only related to "swab_x" columns; other distinct
+    "swab_*" stubs like "swab_date_x" would be artifically captured by the
+    "stub" swabname if the original stub were not converted to a longer or more
+    unique stubname like "swab_collected_x".
+    """
+    rename_map = {}
+
+    stub_columns = list(df.filter(regex=regex, axis=1))
+
+    for col in stub_columns:
+        rename_map[col] = re.sub(current_stub, desired_stub, col)
+
+    return df.rename(columns=rename_map)
+
+
+def longitudinal_stubnames(df: pd.DataFrame) -> List[str]:
+    """
+    Returns a list of the stubnames of longitudinal columns that have suffixes
+    indicating the week number of the study (e.g. 'swab_date_11').
+    """
+    stubnames = []
+    for column in list(df):
+        match = re.match(".*(?=_[0-9]+$)", column)
+        if match:
+            stubnames.append(match[0])
+
+    return list(set(stubnames))
+
+
+def select_all_that_apply_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Given a wide DataFrame *df*, collapses "Select All That Apply"-type
+    categorical survey responses with pseudo-one-hot-encoding format and
+    converts the responses into human-readable lists of equivalent logical
+    value.
+
+    Throws a :class:`AssertionError` if the number of rows in the resulting
+    DataFrame differs from the given *df*.
+
+    Contains hard-coded column names that may need to be updated in the future.
+    """
+
+    stubnames = [
+        "race", "feeding", "meds", "rn_sx", "sx_specific", "missed_impact",
+        "household_sx", "travel_type",
+    ]
+    pid = ['study_id'] + ['week']
+
+    stubbed_columns = list(df.filter(regex='|'.join(stubnames)))
+    reshaped_data = df.drop(stubbed_columns, axis=1)
+
+    for stub in stubnames:
+        true_values = collapse_wide_stubbed_columns(df, stub, pid)
+        if true_values is None:
+            continue
+
+        reshaped_data = reshaped_data.merge(true_values, how='left', on=pid)
+
+    assert len(df) == len(reshaped_data), f"You do not have a 1:1 merge on {pid}"
+
+    return reshaped_data
+
+
+def collapse_wide_stubbed_columns(df: pd.DataFrame, stub: str,
+                                  pid: List[str]) -> pd.DataFrame:
+    """
+    Takes a wide DataFrame *df* with columns partially matching the given
+    *stub*. For each row, collapses the values from the matching column-group
+    with the same *pid* into a list containing structurally different but
+    logically equivalent values as the original DataFrame.
+    """
+    stubset = df.filter(regex=f"{'|'.join(pid)}|{stub}_")
+    if set(list(stubset)) == set(pid):
+        LOG.warning(f"Stub {stub} not found in data")
+        return None
+
+    long_stubset = pd.wide_to_long(stubset, stub, i=pid, j=f"new_{stub}",
+                                   sep="_", suffix='\\w+'
+                                  ).reset_index()
+
+    return group_true_values_into_list(long_stubset, stub, pid)
+
+
+def duplicate_audere_keys(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    For a given DataFrame *df* of longitudinal data, duplicate every column
+    whose meaning is a 1:1 match with Audere data. The duplicated column will
+    match the Audere naming conventions for easier queries down the road.
+
+    Contains hard-coded column names that may need to be updated in the future.
+    """
+    sch_to_audere_map = {
+        "study_id": "individual",
+        "age": "age",
+        "sex": "AssignedSex",
+        "race": "Race",
+        "ethnicity": "HispanicLatino",
+        "insurance": "MedicalInsurance",
+        "home_type": "WhereLive",
+        "bedrooms": "Bedrooms",
+        "house_members": "PeopleInHousehold",
+        "smoking": "HouseholdSmoke",
+        "enroll_site": "site",
+        "flu_shot": "FluShot",
+        "illness_impact": "DailyInterference",
+        "travel_type": "ChildrensRecentTravel",
+        "sample_id": "barcode",
+        "assess_date": "encountered",  # Choose weekly assess date over survey date
+    }
+
+    for key in sch_to_audere_map:
+        try:
+            df[sch_to_audere_map[key]] = df[key]
+        except:
+            LOG.warning(f"Column {key} not found in the given data.")
+
+    return df
+
+
+def insert_static_values(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Inserts static values into a given DataFrame *df*.
+
+    Contains hard-coded column names that may need to be updated in the future.
+    """
+    HUTCH_KIDS = 1  # Site ID from the SCH childcare data dictionary
+
+    df["ChildrenNearChildren"] = "yes"
+    df["SchoolType"] = "childcareCenter"
+    df["ChildrenHutchKids"] = np.where(df['enroll_site'] == HUTCH_KIDS, 'yes', 'no')
+    df["type"] = "childcare"
+
+    return df
+
+
+def create_identifiers(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Creates a long, unique identifier for each individual and encounter in a
+    given DataFrame *df*.
+    Contains some hard-coded values that may need to be updated in the future.
+    """
+    df['individual'] = 'sch/year-1/childcare/' + df['study_id'].astype('str')
+    df['identifier'] = df['individual'] + '/' + df['week'].astype('str')
+
+    return df
+
+
+@longitudinal.command("upload")
+@click.argument("longitudinal_file",
+    metavar = "<longitudinal.ndjson>",
+    type = click.File("r"))
+
+def upload(longitudinal_file):
+    """
+    Upload longitudinal records into the database receiving area.
+
+    <longitudinal.ndjson> must be a newline-delimited JSON file produced by this
+    command's sibling commands.
+
+    Once records are uploaded, the longitudinal ETL routine will reconcile the
+    longitudinal records with known sites, individuals, encounters and samples.
+    """
+    db = DatabaseSession()
+
+    try:
+        LOG.info(f"Copying longitudinal records from {longitudinal_file.name}")
+
+        row_count = db.copy_from_ndjson(("receiving", "longitudinal", "document"),
+                                        longitudinal_file)
+
+        LOG.info(f"Received {row_count:,} longitudinal records")
+        LOG.info("Committing all changes")
+        db.commit()
+
+    except:
+        LOG.info("Rolling back all changes; the database will not be modified")
+        db.rollback()
+        raise

--- a/lib/seattleflu/id3c/cli/command/longitudinal.py
+++ b/lib/seattleflu/id3c/cli/command/longitudinal.py
@@ -160,7 +160,7 @@ def rename_baseline_columns(df: pd.DataFrame) -> pd.DataFrame:
         'baseline_id': 'sample_id_0',
     }
 
-    baseline_columns = list(df.filter(regex='_bl$|_bl_', axis=1))
+    baseline_columns = list(df.filter(regex='_bl$|_bl_', axis='columns'))
 
     for col in baseline_columns:
         rename_map[col] = re.sub("_bl", "", col) + "_0"
@@ -217,7 +217,7 @@ def rename_stub(df: pd.DataFrame, regex: str, current_stub: str,
     """
     rename_map = {}
 
-    stub_columns = list(df.filter(regex=regex, axis=1))
+    stub_columns = list(df.filter(regex=regex, axis='columns'))
 
     for col in stub_columns:
         rename_map[col] = re.sub(current_stub, desired_stub, col)
@@ -259,7 +259,7 @@ def select_all_that_apply_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
     pid = ['study_id'] + ['week']
 
     stubbed_columns = list(df.filter(regex='|'.join(stubnames)))
-    reshaped_data = df.drop(stubbed_columns, axis=1)
+    reshaped_data = df.drop(stubbed_columns, axis='columns')
 
     for stub in stubnames:
         true_values = collapse_wide_stubbed_columns(df, stub, pid)

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,14 @@ check_untyped_defs = True
 # Require functions with an annotated return type to be explicit about
 # potentially returning None (via Optional[…]).
 strict_optional = False
+
+# In the future maybe we can contribute typing stubs for these modules (either
+# complete stubs in the python/typeshed repo or partial stubs just in
+# this repo), but for now that's more work than we want to invest.  These
+# sections let us ignore missing stubs for specific modules without hiding all
+# missing errors like (--ignore-missing-imports).
+[mypy-numpy]
+ignore_missing_imports = True
+
+[mypy-pandas]
+ignore_missing_imports = True


### PR DESCRIPTION
This relies on changes in seattleflu/id3c/pull/88.

Move the clinical, etl clinical, longitudinal, and etl longitudinal commands (and related helper functions) from ID3C to ID3C-customizations.

Make necessary changes to `clinical` and `etl clinical` to ingest new SCH Year 1 data. 