### PR TITLE
Fix etl clinical sex bug

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -164,18 +164,29 @@ def site_identifier(site_name: str) -> str:
 def sex(sex_name) -> str:
     """
     Given a *sex_name*, returns its matching sex identifier.
+
+    Raises an :class:`Exception` if the given sex name is unknown.
     """
-    if type(sex_name) is str:
-        sex_name = sex_name.upper()
+    if not sex_name:
+        LOG.debug("No sex name found")
+        return None
 
     sex_map = {
-        "M": "male",
-        "F": "female",
+        "m": "male",
+        "f": "female",
         1.0: "male",
-        0.0: "female"
+        0.0: "female",
+        "other": "other",
     }
 
-    return sex_map.get(sex_name, "other")
+    def standardize_sex(sex):
+        try:
+            sex = sex.lower()
+            return sex if sex in sex_map.values() else sex_map[sex]
+        except KeyError:
+            raise Exception(f"Unknown sex name «{sex}»") from None
+
+    return standardize_sex(sex_name)
 
 
 def encounter_details(document: dict) -> dict:

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -248,6 +248,8 @@ def insurance(insurance_response: Optional[Any]) -> list:
     """
     Given an *insurance_response*, returns corresponding insurance
     identifier.
+
+    Raises an :class:`Exception` if the given insurance name is unknown.
     """
     if not type(isinstance(insurance_response, list)):
         insurance_response = [ insurance_response ]


### PR DESCRIPTION
We were previously converting unknown sex names to 'other' without raising a warning or error. 
Now, raise an Exception if an unknown sex name is provided to the `sex()` mapping function. 