### PR TITLE
Fix sch clinical bug

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -40,7 +40,7 @@ LOG = logging.getLogger(__name__)
 # clinical records lacking this revision number in their log.  If a
 # change to the ETL routine necessitates re-processing all clinical records,
 # this revision number should be incremented.
-REVISION = 3
+REVISION = 4
 
 
 @etl.command("clinical", help = __doc__)

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -181,7 +181,9 @@ def sex(sex_name) -> str:
 
     def standardize_sex(sex):
         try:
-            sex = sex.lower()
+            if isinstance(sex, str):
+                sex = sex.lower()
+
             return sex if sex in sex_map.values() else sex_map[sex]
         except KeyError:
             raise Exception(f"Unknown sex name «{sex}»") from None

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -273,10 +273,17 @@ def insurance(insurance_response: Optional[Any]) -> list:
 
     insurance_map = {
         "commercial": "privateInsurance",
+        "comm": "privateInsurance",
         "medicaid": "government",
         "medicare": "government",
         "tricare": "government",
+        "care": "government",
+        "caid": "government",
         "other": "other",
+        "self": "other",
+        "tce": "other",
+        "case rate": "other",
+        "wc": "other",
         "unknown": None,
 
     }


### PR DESCRIPTION
This PR reflects changes recently merged into master that make mapping sex and insurance names more strict. 

No longer will unknown names automatically be coded to "other", but rather they will raise an Exception.

This modified clinical ETL with a bump in revision number has been tested with a full run of `etl clinical` on a new clone of the production database. 