### PR TITLE
Add sites with details

### DIFF
--- a/schema/deploy/warehouse/site/data.sql
+++ b/schema/deploy/warehouse/site/data.sql
@@ -1,0 +1,45 @@
+-- Deploy seattleflu/id3c-customizations:warehouse/site/data to pg
+-- requires: seattleflu/schema:warehouse/site
+
+begin;
+
+insert into warehouse.site(identifier, details)
+    values
+        ('ChildrensHospitalBellevue',               '{"category": "clinic",     "type": "clinic"}'),
+        ('ChildrensHospitalSeattle',                '{"category": "clinic",     "type": "clinic"}'),
+        ('ChildrensSeaMar',                         '{"category": "clinic",     "type": "clinic"}'),
+        ('ColumbiaCenter',                          '{"category": "community",  "type": "workplace"}'),
+        ('Costco',                                  '{"category": "community",  "type": "workplace"}'),
+        ('DESC',                                    '{"category": "community",  "type": "shelter"}'),
+        ('FredHutchLobby',                          '{"category": "community",  "type": "workplace"}'),
+        ('Harborview',                              '{"category": "hospital",   "type": "longitudinalInpatient"}'),
+        ('HarborviewLobby',                         '{"category": "community",  "type": "workplace"}'),
+        ('HealthSciencesLobby',                     '{"category": "community",  "type": "collegeCampus"}'),
+        ('HealthSciencesRotunda',                   '{"category": "community",  "type": "collegeCampus"}'),
+        ('HUB',                                     '{"category": "community",  "type": "collegeCampus"}'),
+        ('HutchKids',                               '{"category": "community",  "type": "childcare"}'),
+        ('KaiserPermanente',                        '{"category": "clinic",     "type": "clinic"}'),
+        ('KingStreetStation',                       '{"category": "community",  "type": "publicSpace"}'),
+        ('PioneerSquare',                           '{"category": "clinic",     "type": "clinic"}'),
+        ('RetrospectiveChildrensHospitalSeattle',   '{"category": "hospital",   "type": "retrospective"}'),
+        ('RetrospectiveHarborview',                 '{"category": "hospital",   "type": "retrospective"}'),
+        ('RetrospectiveNorthwest',                  '{"category": "hospital",   "type": "retrospective"}'),
+        ('RetrospectiveUWMedicalCenter',            '{"category": "hospital",   "type": "retrospective"}'),
+        ('SeaTacDomestic',                          '{"category": "community",  "type": "publicSpace"}'),
+        ('SeaTacInternational',                     '{"category": "community",  "type": "publicSpace"}'),
+        ('SeattleCenter',                           '{"category": "community",  "type": "publicSpace"}'),
+        ('self-test',                               '{"category": "community",  "type": "home"}'),
+        ('StMartins',                               '{"category": "community",  "type": "shelter"}'),
+        ('swabNSend',                               '{"category": "community",  "type": "home"}'),
+        ('UWDaycare',                               '{"category": "community",  "type": "childcare"}'),
+        ('UWHallHealth',                            '{"category": "clinic",     "type": "clinic"}'),
+        ('UWSeaMar',                                '{"category": "clinic",     "type": "clinic"}'),
+        ('UWSuzzalloLibrary',                       '{"category": "community",  "type": "collegeCampus"}'),
+        ('WestCampusChildCareCenter',               '{"category": "community",  "type": "childcare"}'),
+        ('WestlakeMall',                            '{"category": "community",  "type": "publicSpace"}')
+
+    on conflict (identifier) do update
+        set details = coalesce(site.details, '{}') || EXCLUDED.details
+;
+
+commit;

--- a/schema/revert/warehouse/site/data.sql
+++ b/schema/revert/warehouse/site/data.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/id3c-customizations:warehouse/site/data from pg
+-- requires: seattleflu/schema:warehouse/site
+
+begin;
+
+-- No need to revert data.
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -42,3 +42,5 @@ shipping/views [shipping/views@2019-11-22] 2019-12-10T17:26:18Z Jover Lee <jover
 
 shipping/views [shipping/views@2019-12-10] 2020-01-10T19:29:25Z Jover Lee <joverlee@fredhutch.org> # Add FHIR encounter details view
 @2020-01-15 2020-01-15T17:37:25Z Jover Lee <joverlee@fredhutch.org> # Schema as of 15 Jan 2020
+
+warehouse/site/data [seattleflu/schema:warehouse/site] 2020-01-14T22:32:27Z Jover Lee <joverlee@fredhutch.org> # Add site with site details

--- a/schema/verify/warehouse/site/data.sql
+++ b/schema/verify/warehouse/site/data.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/id3c-customizations:warehouse/site/data on pg
+-- requires: seattleflu/schema:warehouse/site
+
+begin;
+
+-- No need to verify data.
+
+rollback;


### PR DESCRIPTION
Adds sites with the types and categories described here: https://docs.google.com/document/d/1SqAlXuZttDXDdrRqdeSS910ecrM737MNRacBXHd6ePg/edit

The only site that is not on here is `Unknown` which I'm not entirely sure what to do with.
Also, `KaiserPermanente` is labeled as `clinic` but we have it as `retrospective` 