### PR TITLE
clinical parse-sch: Rename test result column

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -218,7 +218,7 @@ def parse_sch(sch_filename, output):
 
     # Drop unnecessary columns
     columns_to_keep = list(column_map.values()) + [  # Test result columns
-        'adeno', 'chlamydia', 'corona_229e', 'corona_hku1', 'corona_nl63', 'corona_oc43',
+        'adeno', 'chlamydia', 'corona229e', 'corona_hku1', 'corona_nl63', 'corona_oc43',
         'flu_a_h3', 'flu_a_h1_2009', 'flu_b', 'flu_a', 'flu_a_h1', 'hmpv', 'mycoplasma',
         'paraflu_1_4', 'pertussis', 'rhino_ent', 'rsv'
     ]


### PR DESCRIPTION
In the most recent SCH monthly clinical data pull from 15 Jan 2020, one
of the test result columns changed names. Rename it in the parsing code
to avoid a KeyError.