### PR TITLE
Update metadata for augur build view

### DIFF
--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -560,3 +560,28 @@ comment on view shipping.observation_with_presence_absence_result_v2 is
   'Joined view of shipping.incidence_model_observation_v3 and shipping.presence_absence_result_v1';
 
 commit;
+
+create or replace view shipping.metadata_for_augur_build_v3 as
+
+    select sample as strain,
+            encountered_date as date,
+            'seattle' as region,
+            -- XXX TODO: Change to PUMA and neighborhoods
+            residence_census_tract as location,
+            'Seattle Flu Study' as authors,
+            age_range_coarse,
+            case
+                when age_range_coarse <@ '[0 mon, 18 years)'::intervalrange then 'child'
+                else 'adult'
+            end as age_category,
+            warehouse.site.details->>'category' as site_category,
+            residence_census_tract,
+            flu_shot,
+            sex
+
+      from shipping.incidence_model_observation_v2
+      join warehouse.encounter on encounter.identifier = incidence_model_observation_v2.encounter
+      join warehouse.site on site = site.identifier;
+
+comment on view shipping.metadata_for_augur_build_v3 is
+		'View of metadata necessary for SFS augur build';

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -564,7 +564,10 @@ commit;
 create or replace view shipping.metadata_for_augur_build_v3 as
 
     select sample.identifier as strain,
-            encountered_date as date,
+            coalesce(
+              encountered_date,
+              date_or_null(sample.details->>'date')
+            ) as date,
             'seattle' as region,
             -- XXX TODO: Change to PUMA and neighborhoods
             residence_census_tract as location,

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -563,7 +563,7 @@ commit;
 
 create or replace view shipping.metadata_for_augur_build_v3 as
 
-    select sample as strain,
+    select sample.identifier as strain,
             encountered_date as date,
             'seattle' as region,
             -- XXX TODO: Change to PUMA and neighborhoods
@@ -579,9 +579,11 @@ create or replace view shipping.metadata_for_augur_build_v3 as
             flu_shot,
             sex
 
-      from shipping.incidence_model_observation_v2
-      join warehouse.encounter on encounter.identifier = incidence_model_observation_v2.encounter
-      join warehouse.site on site = site.identifier;
+      from warehouse.sample
+      left join shipping.incidence_model_observation_v2 on sample.identifier = incidence_model_observation_v2.sample
+      left join warehouse.site on site.identifier = incidence_model_observation_v2.site
+
+     where sample.identifier is not null;
 
 comment on view shipping.metadata_for_augur_build_v3 is
 		'View of metadata necessary for SFS augur build';

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -52,7 +52,7 @@ drop view shipping.metadata_for_augur_build_v2;
 create or replace view shipping.metadata_for_augur_build_v2 as
 
     select sample as strain,
-            (encountered at time zone 'US/Pacific')::date as date,
+            cast(encountered as date) as date,
             'seattle' as region,
             -- XXX TODO: Change to PUMA and neighborhoods
             residence_census_tract as location,

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -57,6 +57,7 @@ create or replace view shipping.metadata_for_augur_build_v2 as
             -- XXX TODO: Change to PUMA and neighborhoods
             residence_census_tract as location,
             'Seattle Flu Study' as authors,
+            age_range_coarse,
             case
                 when age_range_coarse <@ '[0 mon, 18 years)'::intervalrange then 'child'
                 else 'adult'

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -566,7 +566,10 @@ create or replace view shipping.metadata_for_augur_build_v3 as
     select sample.identifier as strain,
             coalesce(
               encountered_date,
-              date_or_null(sample.details->>'date')
+              case
+                when date_or_null(sample.details->>'date') <= current_date
+                  then date_or_null(sample.details->>'date')
+              end
             ) as date,
             'seattle' as region,
             -- XXX TODO: Change to PUMA and neighborhoods

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -58,9 +58,9 @@ create or replace view shipping.metadata_for_augur_build_v2 as
             residence_census_tract as location,
             'Seattle Flu Study' as authors,
             age_range_coarse,
-            case
-                when age_range_coarse <@ '[0 mon, 18 years)'::intervalrange then 'child'
-                else 'adult'
+            case age_range_coarse <@ '[0 mon, 18 years)'::intervalrange
+                when 't' then 'child'
+                when 'f' then 'adult'
             end as age_category,
             case
                 when site_type in ('childrensHospital', 'childrensClinic', 'childrensHospital', 'clinic', 'hospital', 'retrospective') then 'clinical'
@@ -576,9 +576,9 @@ create or replace view shipping.metadata_for_augur_build_v3 as
             residence_census_tract as location,
             'Seattle Flu Study' as authors,
             age_range_coarse,
-            case
-                when age_range_coarse <@ '[0 mon, 18 years)'::intervalrange then 'child'
-                else 'adult'
+            case age_range_coarse <@ '[0 mon, 18 years)'::intervalrange
+                when 't' then 'child'
+                when 'f' then 'adult'
             end as age_category,
             warehouse.site.details->>'category' as site_category,
             residence_census_tract,

--- a/schema/deploy/shipping/views@2020-01-21.sql
+++ b/schema/deploy/shipping/views@2020-01-21.sql
@@ -48,11 +48,10 @@ create or replace view shipping.reportable_condition_v1 as
     order by encountered desc;
 
 
-drop view shipping.metadata_for_augur_build_v2;
 create or replace view shipping.metadata_for_augur_build_v2 as
 
-    select sample as strain,
-            (encountered at time zone 'US/Pacific')::date as date,
+    select  sample as strain,
+            encountered as date,
             'seattle' as region,
             -- XXX TODO: Change to PUMA and neighborhoods
             residence_census_tract as location,

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -558,4 +558,8 @@ create or replace view shipping.observation_with_presence_absence_result_v2 as
 comment on view shipping.observation_with_presence_absence_result_v2 is
   'Joined view of shipping.incidence_model_observation_v3 and shipping.presence_absence_result_v1';
 
+
+drop view shipping.metadata_for_augur_build_v3;
+
+
 commit;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -48,6 +48,7 @@ create or replace view shipping.reportable_condition_v1 as
     order by encountered desc;
 
 
+drop view shipping.metadata_for_augur_build_v2;
 create or replace view shipping.metadata_for_augur_build_v2 as
 
     select  sample as strain,
@@ -289,10 +290,10 @@ create or replace view shipping.incidence_model_observation_v1 as
            residence_census_tract,
            work_census_tract,
 
-           encounter_responses.flu_shot,
-           encounter_responses.symptoms,
-           encounter_responses.race,
-           encounter_responses.hispanic_or_latino,
+           coalesce(encounter_responses.flu_shot,fhir.vaccine) as flu_shot,
+           coalesce(encounter_responses.symptoms,fhir.symptoms) as symptoms,
+           coalesce(encounter_responses.race,fhir.race) as race,
+           coalesce(encounter_responses.hispanic_or_latino,fhir.hispanic_or_latino) as hispanic_or_latino,
 
            sample.identifier as sample
 
@@ -302,6 +303,7 @@ create or replace view shipping.incidence_model_observation_v1 as
       left join warehouse.sample using (encounter_id)
       left join shipping.age_bin_fine on age_bin_fine.range @> ceiling(age_in_years(age))::int
       left join shipping.age_bin_coarse on age_bin_coarse.range @> ceiling(age_in_years(age))::int
+      left join shipping.fhir_encounter_details_v1 as fhir using (encounter_id)
       left join (
           select encounter_id, hierarchy->'tract' as residence_census_tract
           from warehouse.encounter_location
@@ -383,10 +385,10 @@ create or replace view shipping.incidence_model_observation_v2 as
            residence_census_tract,
            work_census_tract,
 
-           encounter_responses.flu_shot,
-           encounter_responses.symptoms,
-           encounter_responses.race,
-           encounter_responses.hispanic_or_latino,
+           coalesce(encounter_responses.flu_shot,fhir.vaccine) as flu_shot,
+           coalesce(encounter_responses.symptoms,fhir.symptoms) as symptoms,
+           coalesce(encounter_responses.race,fhir.race) as race,
+           coalesce(encounter_responses.hispanic_or_latino,fhir.hispanic_or_latino) as hispanic_or_latino,
 
            sample.identifier as sample
 
@@ -396,6 +398,7 @@ create or replace view shipping.incidence_model_observation_v2 as
       left join warehouse.sample using (encounter_id)
       left join shipping.age_bin_fine_v2 on age_bin_fine_v2.range @> age
       left join shipping.age_bin_coarse_v2 on age_bin_coarse_v2.range @> age
+      left join shipping.fhir_encounter_details_v1 as fhir using (encounter_id)
       left join (
           select encounter_id, hierarchy->'tract' as residence_census_tract
           from warehouse.encounter_location
@@ -487,8 +490,8 @@ create or replace view shipping.incidence_model_observation_v3 as
 
            residence_census_tract,
 
-           encounter_responses.flu_shot,
-           encounter_responses.symptoms,
+           coalesce(encounter_responses.flu_shot,fhir.vaccine) as flu_shot,
+           coalesce(encounter_responses.symptoms,fhir.symptoms) as symptoms,
 
            sample.identifier as sample
 
@@ -498,6 +501,7 @@ create or replace view shipping.incidence_model_observation_v3 as
       left join warehouse.sample using (encounter_id)
       left join shipping.age_bin_fine_v2 on age_bin_fine_v2.range @> age
       left join shipping.age_bin_coarse_v2 on age_bin_coarse_v2.range @> age
+      left join shipping.fhir_encounter_details_v1 as fhir using (encounter_id)
       left join (
           select encounter_id, hierarchy->'tract' as residence_census_tract
           from warehouse.encounter_location

--- a/schema/revert/shipping/views@2020-01-21.sql
+++ b/schema/revert/shipping/views@2020-01-21.sql
@@ -48,11 +48,10 @@ create or replace view shipping.reportable_condition_v1 as
     order by encountered desc;
 
 
-drop view shipping.metadata_for_augur_build_v2;
 create or replace view shipping.metadata_for_augur_build_v2 as
 
-    select sample as strain,
-            (encountered at time zone 'US/Pacific')::date as date,
+    select  sample as strain,
+            encountered as date,
             'seattle' as region,
             -- XXX TODO: Change to PUMA and neighborhoods
             residence_census_tract as location,
@@ -290,10 +289,10 @@ create or replace view shipping.incidence_model_observation_v1 as
            residence_census_tract,
            work_census_tract,
 
-           coalesce(encounter_responses.flu_shot,fhir.vaccine) as flu_shot,
-           coalesce(encounter_responses.symptoms,fhir.symptoms) as symptoms,
-           coalesce(encounter_responses.race,fhir.race) as race,
-           coalesce(encounter_responses.hispanic_or_latino,fhir.hispanic_or_latino) as hispanic_or_latino,
+           encounter_responses.flu_shot,
+           encounter_responses.symptoms,
+           encounter_responses.race,
+           encounter_responses.hispanic_or_latino,
 
            sample.identifier as sample
 
@@ -303,7 +302,6 @@ create or replace view shipping.incidence_model_observation_v1 as
       left join warehouse.sample using (encounter_id)
       left join shipping.age_bin_fine on age_bin_fine.range @> ceiling(age_in_years(age))::int
       left join shipping.age_bin_coarse on age_bin_coarse.range @> ceiling(age_in_years(age))::int
-      left join shipping.fhir_encounter_details_v1 as fhir using (encounter_id)
       left join (
           select encounter_id, hierarchy->'tract' as residence_census_tract
           from warehouse.encounter_location
@@ -385,10 +383,10 @@ create or replace view shipping.incidence_model_observation_v2 as
            residence_census_tract,
            work_census_tract,
 
-           coalesce(encounter_responses.flu_shot,fhir.vaccine) as flu_shot,
-           coalesce(encounter_responses.symptoms,fhir.symptoms) as symptoms,
-           coalesce(encounter_responses.race,fhir.race) as race,
-           coalesce(encounter_responses.hispanic_or_latino,fhir.hispanic_or_latino) as hispanic_or_latino,
+           encounter_responses.flu_shot,
+           encounter_responses.symptoms,
+           encounter_responses.race,
+           encounter_responses.hispanic_or_latino,
 
            sample.identifier as sample
 
@@ -398,7 +396,6 @@ create or replace view shipping.incidence_model_observation_v2 as
       left join warehouse.sample using (encounter_id)
       left join shipping.age_bin_fine_v2 on age_bin_fine_v2.range @> age
       left join shipping.age_bin_coarse_v2 on age_bin_coarse_v2.range @> age
-      left join shipping.fhir_encounter_details_v1 as fhir using (encounter_id)
       left join (
           select encounter_id, hierarchy->'tract' as residence_census_tract
           from warehouse.encounter_location
@@ -490,8 +487,8 @@ create or replace view shipping.incidence_model_observation_v3 as
 
            residence_census_tract,
 
-           coalesce(encounter_responses.flu_shot,fhir.vaccine) as flu_shot,
-           coalesce(encounter_responses.symptoms,fhir.symptoms) as symptoms,
+           encounter_responses.flu_shot,
+           encounter_responses.symptoms,
 
            sample.identifier as sample
 
@@ -501,7 +498,6 @@ create or replace view shipping.incidence_model_observation_v3 as
       left join warehouse.sample using (encounter_id)
       left join shipping.age_bin_fine_v2 on age_bin_fine_v2.range @> age
       left join shipping.age_bin_coarse_v2 on age_bin_coarse_v2.range @> age
-      left join shipping.fhir_encounter_details_v1 as fhir using (encounter_id)
       left join (
           select encounter_id, hierarchy->'tract' as residence_census_tract
           from warehouse.encounter_location

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -49,5 +49,8 @@ shipping/views [shipping/views@2020-01-15 seattleflu/schema:shipping/views@2020-
 
 shipping/views [shipping/views@2020-01-15b] 2020-01-14T00:47:13Z Jover Lee <joverlee@fredhutch.org> # Update modeling views to use FHIR encounter details
 @2020-01-15c 2020-01-15T18:05:47Z Jover Lee <joverlee@fredhutch.org> # Schema as of later on 15 Jan 2020
+
 warehouse/target/data [warehouse/target/data@2020-01-15c] 2020-01-21T17:21:50Z Thomas Sibley <tsibley@fredhutch.org> # Link SNOMED CT targets to our organisms
 @2020-01-21 2020-01-21T17:24:50Z Thomas Sibley <tsibley@fredhutch.org> # schema as of 21 Jan 2020
+
+shipping/views [shipping/views@2020-01-21] 2020-01-22T23:40:54Z Kairsten Fay <kfay@fredhutch.org> # Update shipping.metadata_for_augur_build_v2 columns

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -53,4 +53,4 @@ shipping/views [shipping/views@2020-01-15b] 2020-01-14T00:47:13Z Jover Lee <jove
 warehouse/target/data [warehouse/target/data@2020-01-15c] 2020-01-21T17:21:50Z Thomas Sibley <tsibley@fredhutch.org> # Link SNOMED CT targets to our organisms
 @2020-01-21 2020-01-21T17:24:50Z Thomas Sibley <tsibley@fredhutch.org> # schema as of 21 Jan 2020
 
-shipping/views [shipping/views@2020-01-21] 2020-01-22T23:40:54Z Kairsten Fay <kfay@fredhutch.org> # Update shipping.metadata_for_augur_build_v2 columns
+shipping/views [shipping/views@2020-01-21] 2020-01-22T23:40:54Z Kairsten Fay <kfay@fredhutch.org> # Update shipping.metadata_for_augur_build_v2 columns and add new version

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -54,3 +54,4 @@ warehouse/target/data [warehouse/target/data@2020-01-15c] 2020-01-21T17:21:50Z T
 @2020-01-21 2020-01-21T17:24:50Z Thomas Sibley <tsibley@fredhutch.org> # schema as of 21 Jan 2020
 
 shipping/views [shipping/views@2020-01-21] 2020-01-22T23:40:54Z Kairsten Fay <kfay@fredhutch.org> # Update shipping.metadata_for_augur_build_v2 columns and add new version
+@2020-01-24 2020-01-21T23:28:05Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 24 Jan 2020

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -64,4 +64,9 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v2');
 
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v3');
+
 rollback;

--- a/schema/verify/shipping/views@2020-01-21.sql
+++ b/schema/verify/shipping/views@2020-01-21.sql
@@ -1,0 +1,67 @@
+-- Verify seattleflu/id3c-customizations:shipping/views on pg
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.reportable_condition_v1');
+
+-- Verify that the view has been dropped
+select 1/(count(*) = 0)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.genomic_sequences_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.flu_assembly_jobs_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_encounter_details_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v2');
+
+rollback;


### PR DESCRIPTION
Update the `metadata_for_augur_build_v2` to format dates in YYYY-MM-DD format.


Create new view from v2, `metadata_for_augur_build_v3`, that
1. coalesces encounter date with collection date from sample details 
2. uses the new 'category' option from `site.details`.

Addresses two aspects of [this issue](https://github.com/seattleflu/augur-build/issues/32) by reformatting dates and adding an `age_range_coarse` column.