### PR TITLE
redcap-det: Fallback to record id-based individual identifier generation

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -400,7 +400,7 @@ def generate_patient_hash(names: Iterable[str], gender: str, birth_date: str, po
         ]
 
     if missing(personal_information):
-        LOG.warning(f"All personal information is required to generate a robust patient hash; missing {missing(personal_information)}")
+        LOG.debug(f"All personal information is required to generate a robust patient hash; missing {missing(personal_information)}")
         return None
 
     return generate_hash("\N{UNIT SEPARATOR}".join(personal_information))

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -38,7 +38,7 @@ REQUIRED_INSTRUMENTS = [
 # REDCap DET records lacking this revision number in their log.  If a
 # change to the ETL routine necessitates re-processing all REDCap DET records,
 # this revision number should be incremented.
-REVISION = 2
+REVISION = 3
 
 
 @redcap_det.command_for_project(

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -142,7 +142,12 @@ def create_patient(record: dict) -> tuple:
         postal_code = participant_zipcode(record))
 
     if not patient_id:
-        return None, None
+        # Some piece of information was missing, so we couldn't generate a
+        # hash.  Fallback to treating this individual as always unique by using
+        # the REDCap record id.
+        patient_id = generate_hash(f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}")
+
+    LOG.debug(f"Generated individual identifier {patient_id}")
 
     patient_identifier = create_identifier(f"{SFS}/individual",patient_id)
     patient_resource = create_patient_resource([patient_identifier], gender)
@@ -183,8 +188,7 @@ def participant_zipcode(redcap_record: dict) -> str:
         address = determine_dorm_address(redcap_record['uw_dorm'])
         return address['zipcode']
 
-    LOG.warning(f"Could not extract zipcode from redcap record, using 'project_id-record_id' «{PROJECT_ID}-{redcap_record['record_id']}» instead")
-    return str(PROJECT_ID) + '-' + redcap_record['record_id']
+    return None
 
 
 def determine_vaccine_date(vaccine_year: str, vaccine_month: str) -> Optional[str]:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -25,7 +25,7 @@ from . import race
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 2
+REVISION = 3
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -205,7 +205,12 @@ def create_patient(record: dict) -> tuple:
         postal_code = record['home_zipcode_2'])
 
     if not patient_id:
-        return None, None
+        # Some piece of information was missing, so we couldn't generate a
+        # hash.  Fallback to treating this individual as always unique by using
+        # the REDCap record id.
+        patient_id = generate_hash(f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}")
+
+    LOG.debug(f"Generated individual identifier {patient_id}")
 
     patient_identifier = create_identifier(f"{INTERNAL_SYSTEM}/individual", patient_id)
     patient_resource = create_patient_resource([patient_identifier], gender)


### PR DESCRIPTION
Instead of special casing only zip code and bailing out if other pieces
of information are missing, take a best-effort approach and assume the
record represents a unique participant who hasn't participated
previously and won't participate again in the future.

This is a broadening of the logic we previously used for zip code, and I
think it makes more sense in the bigger picture.  I only realized it
when I was digging into noisy logs, though!  Those same noisy logs are
silenced since missing personal info is now less of an issue with this
more general fallback.