### PR TITLE
etl redcap-det kiosk: Add new site

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -518,7 +518,8 @@ def determine_site_name(redcap_record: dict) -> Optional[str]:
         'Westlake Center': 'WestlakeCenter',
         'King Street Station': 'KingStreetStation',
         'Westlake Light Rail Station': 'WestlakeLightRailStation',
-        'CapitolHillLightRailStation': 'CapitolHillLightRailStation'
+        'CapitolHillLightRailStation': 'CapitolHillLightRailStation',
+        'Capitol Hill Light Rail Station': 'CapitolHillLightRailStation',
     }
 
     if site not in site_name_map:


### PR DESCRIPTION
Add a new site for Capitol Hill Light Rail Station with spaces so that
the ETL doesn't break.


This is the minimal effort solution to fix the broken Kiosk ETL. The other solution I considered is to strip spaces from site names when comparing them to our `warehouse.site` identifier equivalent. Thoughts?