### PR TITLE
Add new Kiosk sites to warehouse

### DIFF
--- a/schema/deploy/warehouse/site/data@2020-01-30.sql
+++ b/schema/deploy/warehouse/site/data@2020-01-30.sql
@@ -5,7 +5,6 @@ begin;
 
 insert into warehouse.site(identifier, details)
     values
-        ('CapitolHillLightRailStation',             '{"category": "community",  "type": "publicSpace"}'),
         ('ChildrensHospitalBellevue',               '{"category": "clinic",     "type": "clinic"}'),
         ('ChildrensHospitalSeattle',                '{"category": "clinic",     "type": "clinic"}'),
         ('ChildrensSeaMar',                         '{"category": "clinic",     "type": "clinic"}'),
@@ -37,7 +36,6 @@ insert into warehouse.site(identifier, details)
         ('UWSeaMar',                                '{"category": "clinic",     "type": "clinic"}'),
         ('UWSuzzalloLibrary',                       '{"category": "community",  "type": "collegeCampus"}'),
         ('WestCampusChildCareCenter',               '{"category": "community",  "type": "childcare"}'),
-        ('WestlakeLightRailStation',                '{"category": "community",  "type": "publicSpace"}'),
         ('WestlakeMall',                            '{"category": "community",  "type": "publicSpace"}')
 
     on conflict (identifier) do update

--- a/schema/revert/warehouse/site/data.sql
+++ b/schema/revert/warehouse/site/data.sql
@@ -1,8 +1,11 @@
--- Revert seattleflu/id3c-customizations:warehouse/site/data from pg
+-- Deploy seattleflu/id3c-customizations:warehouse/site/data to pg
 -- requires: seattleflu/schema:warehouse/site
 
 begin;
 
--- No need to revert data.
+delete from warehouse.site
+  where identifier = 'CapitolHillLightRailStation'
+  or identifier = 'WestlakeLightRailStation'
+;
 
 commit;

--- a/schema/revert/warehouse/site/data@2020-01-30.sql
+++ b/schema/revert/warehouse/site/data@2020-01-30.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/id3c-customizations:warehouse/site/data to pg
+-- requires: seattleflu/schema:warehouse/site
+
+begin;
+
+-- No need to revert data.
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -57,3 +57,5 @@ shipping/views [shipping/views@2020-01-21] 2020-01-22T23:40:54Z Kairsten Fay <kf
 @2020-01-24 2020-01-21T23:28:05Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 24 Jan 2020
 warehouse/target/data [warehouse/target/data@2020-01-24] 2020-01-30T21:24:28Z Thomas Sibley <tsibley@fredhutch.org> # Add organism for 2019-nCoV
 @2020-01-30 2020-01-30T22:30:30Z Thomas Sibley <tsibley@fredhutch.org> # schema as of 30 Jan 2020
+
+warehouse/site/data [warehouse/site/data@2020-01-30] 2020-01-31T08:01:08Z Kairsten Fay <kfay@fredhutch.org> # Add new kiosk sites to warehouse

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -59,3 +59,5 @@ warehouse/target/data [warehouse/target/data@2020-01-24] 2020-01-30T21:24:28Z Th
 @2020-01-30 2020-01-30T22:30:30Z Thomas Sibley <tsibley@fredhutch.org> # schema as of 30 Jan 2020
 
 warehouse/site/data [warehouse/site/data@2020-01-30] 2020-01-31T08:01:08Z Kairsten Fay <kfay@fredhutch.org> # Add new kiosk sites to warehouse
+@2020-01-31 2020-01-31T08:05:32Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 31 Jan 2020
+

--- a/schema/verify/warehouse/site/data@2020-01-30.sql
+++ b/schema/verify/warehouse/site/data@2020-01-30.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/id3c-customizations:warehouse/site/data on pg
+-- requires: seattleflu/schema:warehouse/site
+
+begin;
+
+-- No need to verify data.
+
+rollback;


### PR DESCRIPTION
Add the Capitol Hill and Westlake light rail stations from the Kiosk ETL
to the warehouse.

Skip `WestlakeCenter` for now, because Izzy said in the #redcap channel
that we likely won't start enrolling participants there anytime soon, if
at all.