### PR TITLE
Add role to perform idle database disconnects

### DIFF
--- a/schema/deploy/roles/idle-session-disconnector/create.sql
+++ b/schema/deploy/roles/idle-session-disconnector/create.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/id3c-customizations:roles/idle-session-disconnector/create to pg
+
+begin;
+
+create role "idle-session-disconnector";
+
+comment on role "idle-session-disconnector" is
+    'For disconnecting idle database sessions';
+
+commit;

--- a/schema/deploy/roles/idle-session-disconnector/grants.sql
+++ b/schema/deploy/roles/idle-session-disconnector/grants.sql
@@ -1,0 +1,44 @@
+-- Deploy seattleflu/id3c-customizations:roles/idle-session-disconnector/grants to pg
+
+begin;
+
+revoke all on database :"DBNAME" from "idle-session-disconnector";
+revoke all on schema receiving, warehouse, shipping from "idle-session-disconnector";
+revoke all on all tables in schema receiving, warehouse, shipping from "idle-session-disconnector";
+
+grant connect on database :"DBNAME" to "idle-session-disconnector";
+
+-- Regular users cannot see the state of sessions that they don't own. Create a
+-- new view using security definer with limited columns that this role can
+-- access to see a session's state.
+create or replace function public.pg_stat_get_activity_nonsuperuser() returns table(
+    pid integer, usename name, application_name text, client_addr inet,
+    state_change timestamp with time zone, state text) as
+    $$
+    select
+        pid, usename, application_name, client_addr, state_change, state
+        from pg_catalog.pg_stat_activity;
+    $$
+    language sql
+    volatile
+    security definer
+    set search_path = pg_catalog;
+
+revoke execute
+    on function public.pg_stat_get_activity_nonsuperuser
+  from public;
+
+grant execute
+    on function public.pg_stat_get_activity_nonsuperuser
+    to "idle-session-disconnector";
+
+create or replace view public.pg_stat_activity_nonsuperuser as
+    select * from public.pg_stat_get_activity_nonsuperuser();
+
+grant select
+    on public.pg_stat_activity_nonsuperuser
+    to "idle-session-disconnector";
+
+grant pg_signal_backend to "idle-session-disconnector";
+
+commit;

--- a/schema/revert/roles/idle-session-disconnector/create.sql
+++ b/schema/revert/roles/idle-session-disconnector/create.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/id3c-customizations:roles/idle-session-disconnector/create from pg
+
+begin;
+
+drop role "idle-session-disconnector";
+
+commit;

--- a/schema/revert/roles/idle-session-disconnector/grants.sql
+++ b/schema/revert/roles/idle-session-disconnector/grants.sql
@@ -1,0 +1,23 @@
+-- Revert seattleflu/id3c-customizations:roles/idle-session-disconnector/grants from pg
+
+begin;
+
+revoke pg_signal_backend from "idle-session-disconnector";
+
+revoke select
+    on public.pg_stat_activity_nonsuperuser
+  from "idle-session-disconnector";
+
+drop view public.pg_stat_activity_nonsuperuser;
+
+revoke execute
+    on function public.pg_stat_get_activity_nonsuperuser
+  from "idle-session-disconnector";
+
+drop function public.pg_stat_get_activity_nonsuperuser;
+
+revoke all on database :"DBNAME" from "idle-session-disconnector";
+revoke all on all tables in schema public from "idle-session-disconnector";
+revoke all on schema public from "idle-session-disconnector";
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -66,3 +66,4 @@ roles/augur-build-exporter/grants [roles/augur-build-exporter/grants@2020-01-31]
 
 roles/idle-session-disconnector/create 2020-02-05T20:18:31Z Kairsten Fay <kfay@fredhutch.org> # Role for disconnecting idle database sessions
 roles/idle-session-disconnector/grants 2020-02-05T21:24:27Z Kairsten Fay <kfay@fredhutch.org> # Grants to idle-session-disconnector
+@2020-02-06 2020-02-07T00:23:48Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 6 Feb 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -62,3 +62,7 @@ warehouse/site/data [warehouse/site/data@2020-01-30] 2020-01-31T08:01:08Z Kairst
 @2020-01-31 2020-01-31T08:05:32Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 31 Jan 2020
 
 roles/augur-build-exporter/grants [roles/augur-build-exporter/grants@2020-01-31] 2020-02-04T01:24:17Z Kairsten Fay <kfay@fredhutch.org> # Update grants to augur-build-exporter for v3
+@2020-02-05 2020-02-05T20:14:15Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 5 Feb 2020
+
+roles/idle-session-disconnector/create 2020-02-05T20:18:31Z Kairsten Fay <kfay@fredhutch.org> # Role for disconnecting idle database sessions
+roles/idle-session-disconnector/grants 2020-02-05T21:24:27Z Kairsten Fay <kfay@fredhutch.org> # Grants to idle-session-disconnector

--- a/schema/verify/roles/idle-session-disconnector/create.sql
+++ b/schema/verify/roles/idle-session-disconnector/create.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/id3c-customizations:roles/idle-session-disconnector/create on pg
+
+begin;
+
+-- No real need to test that the user was created; the database would have
+-- thrown an error if it wasn't.
+
+rollback;

--- a/schema/verify/roles/idle-session-disconnector/grants.sql
+++ b/schema/verify/roles/idle-session-disconnector/grants.sql
@@ -1,0 +1,14 @@
+-- Verify seattleflu/id3c-customizations:roles/idle-session-disconnector/grants on pg
+
+begin;
+
+select 1/pg_catalog.has_database_privilege('idle-session-disconnector', :'DBNAME', 'connect')::int;
+select 1/pg_catalog.has_schema_privilege('idle-session-disconnector', 'public', 'usage')::int;
+select 1/pg_catalog.has_table_privilege('idle-session-disconnector', 'public.pg_stat_activity_nonsuperuser', 'select')::int;
+select 1/pg_catalog.has_function_privilege('idle-session-disconnector', 'public.pg_stat_get_activity_nonsuperuser()', 'execute')::int;
+
+select 1/(not pg_catalog.has_table_privilege('idle-session-disconnector', 'pg_catalog.pg_stat_activity', 'insert,update,delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('idle-session-disconnector', 'public.pg_stat_activity_nonsuperuser', 'insert,update,delete'))::int;
+select 1/(not pg_catalog.has_function_privilege('public', 'public.pg_stat_get_activity_nonsuperuser()', 'execute'))::int;
+
+rollback;


### PR DESCRIPTION
Create a new database role that has permissions to disconnect database
sessions. This role will eventually be used in a cron job on backoffice
for disconnecting sessions that have been idle for > 30 minutes.