### PR TITLE
etl redcap-det: add `meta.source` to FHIR Bundle

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -281,6 +281,7 @@ def create_questionnaire_response_item(question_id: str,
 
 def create_bundle_resource(bundle_id: str,
                            timestamp: str,
+                           source: str,
                            entries: List[dict]) -> dict:
     """
     Create bundle resource containing other resources following the FHIR format
@@ -290,6 +291,7 @@ def create_bundle_resource(bundle_id: str,
         "resourceType": "Bundle",
         "type": "collection",
         "id": bundle_id,
+        "meta": { "source": source },
         "timestamp": timestamp,
         "entry": entries
     })

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -126,6 +126,7 @@ def redcap_det_kisok(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_
     return create_bundle_resource(
         bundle_id = str(uuid4()),
         timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}",
         entries = list(filter(None, all_resource_entries))
     )
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -82,6 +82,7 @@ def redcap_det_swab_and_home_flu(*, db: DatabaseSession, cache: TTLCache, det: d
     return create_bundle_resource(
         bundle_id = str(uuid4()),
         timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}",
         entries = list(filter(None, resource_entries))
     )
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -84,6 +84,7 @@ def redcap_det_swab_n_send(*, db: DatabaseSession, cache: TTLCache, det: dict, r
     return create_bundle_resource(
         bundle_id = str(uuid4()),
         timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}",
         entries = list(filter(None, resource_entries))
     )
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -69,6 +69,7 @@ def redcap_det_uw_retrospectives(*,
     return create_bundle_resource(
         bundle_id = str(uuid4()),
         timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['barcode']}",
         entries = list(filter(None, resource_entries))
     )
 


### PR DESCRIPTION
[Meta.source](https://www.hl7.org/fhir/resource-definitions.html#Meta.source) can be used to document minimal amount of provenance infor for a FHIR Resource.

Adding provenence info to FHIR Bundles will help debugging issues.
The source is currently `{REDCAP_URL}/{PROJECT_ID}/{RECORD_ID}`