### PR TITLE
Row-level security for hCoV-19 results

### DIFF
--- a/dev/detect-rls-leaks
+++ b/dev/detect-rls-leaks
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+
+main() {
+    assert-testable-data
+    testable-views | parallel --keep-order leak-test
+}
+
+assert-testable-data() {
+    psql -q --set=ON_ERROR_STOP=yes <<<"
+        do \$\$
+        begin
+            assert exists (
+                select
+                    presence_absence_id
+                from
+                    warehouse.presence_absence
+                    join warehouse.target using (target_id)
+                where
+                    target.identifier in ('nCoV', 'COVID-19')
+            ), 'No sensitive data to test with';
+        end
+        \$\$
+    "
+}
+
+testable-views() {
+    psql -qtAF $'\t' --set=ON_ERROR_STOP=yes <<<"
+        select
+            format('%I.%I', schemaname, viewname)
+        from
+            pg_views
+        where
+            schemaname in ('public', 'receiving', 'warehouse', 'shipping')
+        and
+            (schemaname, viewname) not in (
+                ('public', 'pg_stat_activity_nonsuperuser'),
+                ('warehouse', 'address'),
+                ('warehouse', 'tract')
+            )
+        order by
+            schemaname,
+            viewname
+    "
+}
+
+leak-test() {
+    local view="$1"
+
+    if dump-view "$view" | grep -qiE 'nCoV|COVID-19|Human_coronavirus[.]2019'; then
+        not-ok "$view"
+    else
+        ok "$view"
+    fi
+}
+
+dump-view() {
+    psql -qtA --set=ON_ERROR_STOP=yes <<<"
+        set role reporter;
+        \\copy (table $1) to pstdout
+    "
+}
+
+ok() {
+    local green='\e[32m' reset='\e[0m'
+    printf "${green}    ok %s${reset}\n" "$*"
+    return 0
+}
+
+not-ok() {
+    local red='\e[31m' reset='\e[0m'
+    printf "${red}not ok %s${reset}\n" "$*"
+    return 1
+}
+
+export -f leak-test dump-view ok not-ok
+
+main "$@"

--- a/schema/deploy/policies.sql
+++ b/schema/deploy/policies.sql
@@ -1,0 +1,88 @@
+-- Deploy seattleflu/id3c-customizations:policies to pg
+-- requires: seattleflu/schema:warehouse/presence_absence
+-- requires: seattleflu/schema:roles/reporter
+-- requires: seattleflu/schema:roles/fhir-processor/create
+-- requires: seattleflu/schema:roles/presence-absence-processor
+-- requires: seattleflu/schema:shipping/views@2020-02-25
+-- requires: roles/reportable-condition-notifier/create
+-- requires: roles/hcov19-visibility/create
+
+begin;
+
+/* This change is intended to comprehensively describe our row-level security
+ * policies and be easily reworkable for future changes.  Statements should be
+ * idempotent.
+ */
+
+alter table warehouse.presence_absence
+    enable row level security;
+
+drop policy if exists "public: visible if not HCoV-19"
+    on warehouse.presence_absence;
+
+create policy "public: visible if not HCoV-19"
+    on warehouse.presence_absence
+    as permissive
+    for all to public using (
+        target_id not in (
+            select
+                target_id
+            from
+                warehouse.target
+                join warehouse.organism using (organism_id)
+            where
+                lineage <@ 'Human_coronavirus.2019'
+        )
+    )
+;
+
+drop policy if exists "hcov19-visibility: visible unconditionally"
+    on warehouse.presence_absence;
+
+create policy "hcov19-visibility: visible unconditionally"
+    on warehouse.presence_absence
+    as permissive
+    for all to "hcov19-visibility" using (true)
+;
+
+/* This grant seems more closely coupled to our policies than the roles
+ * themselves, so it lives here rather than adjacent to either the granted or
+ * grantee roles.
+ */
+grant "hcov19-visibility" to
+    "fhir-processor",
+    "presence-absence-processor",
+    "reportable-condition-notifier";
+
+/* Normal p/a results don't get HCoV-19 visibility.  We'll make
+ * separate views as necessary.
+ *
+ * XXX TODO: Statements are here since these are core views.  There's a bad
+ * interplay where the owner will revert back to postgres if the core views are
+ * dropped and re-created.  This is similar to ACLs interplay with
+ * shipping.reportable_condition_v1 I wrote about in
+ * schema/deploy/shipping/views.sql.
+ *   -trs, 7 March 2020
+ */
+alter view shipping.presence_absence_result_v1
+    owner to reporter;
+
+alter view shipping.presence_absence_result_v2
+    owner to reporter;
+
+/* Adjust ACLs on a core table.
+ *
+ * XXX TODO: Suffers a bad interplay with core ID3C if the roles/reporter
+ * change gets reworked, similar to the same situation with views referred to
+ * above.
+ *   -trs, 7 March 2020
+ */
+revoke all
+    on receiving.presence_absence
+    from reporter;
+
+grant select (presence_absence_id, received, processing_log)
+    on receiving.presence_absence
+    to reporter;
+
+commit;

--- a/schema/deploy/roles/hcov19-visibility/create.sql
+++ b/schema/deploy/roles/hcov19-visibility/create.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/id3c-customizations:roles/hcov19-visibility/create to pg
+
+begin;
+
+create role "hcov19-visibility";
+
+comment on role "hcov19-visibility" is
+    'Allows access to HCoV-19 presence/absence results';
+
+commit;

--- a/schema/deploy/shipping/views@2020-03-05b.sql
+++ b/schema/deploy/shipping/views@2020-03-05b.sql
@@ -47,26 +47,6 @@ create or replace view shipping.reportable_condition_v1 as
 
     order by encountered desc;
 
-/* The shipping.reportable_condition_v1 view needs hCoV-19 visibility, so
- * remains owned by postgres, but it should only be accessible by
- * reportable-condition-notifier.  Revoke existing grants to every other role.
- *
- * XXX FIXME: There is a bad interplay here if roles/x/grants is also reworked
- * in the future.  It's part of the broader bad interplay between views and
- * their grants.  I think it was a mistake to lump grants to each role in their
- * own change instead of scattering them amongst the changes that create/rework
- * tables and views and things that are granted on.  I made that choice
- * initially so that all grants for a role could be seen in a single
- * consolidated place, which would still be nice.  There's got to be a better
- * system for managing this (a single idempotent change script with all ACLs
- * that is always run after other changes? cleaner breaking up of sqitch
- * projects?), but I don't have time to think on it much now.  Luckily for us,
- * I think the core reporter role is unlikely to be reworked soon, but we
- * should be wary.
- *   -trs, 7 March 2020
- */
-revoke all on shipping.reportable_condition_v1 from reporter;
-
 
 drop view shipping.metadata_for_augur_build_v2;
 create or replace view shipping.metadata_for_augur_build_v2 as
@@ -148,11 +128,6 @@ create or replace view shipping.flu_assembly_jobs_v1 as
 
 comment on view shipping.flu_assembly_jobs_v1 is
     'View of flu jobs that still need to be run through the assembly pipeline';
-
--- Does not need HCoV-19 visibility and should filter it out
--- anyway, but be safe.
-alter view shipping.flu_assembly_jobs_v1 owner to reporter;
-
 
 
 create or replace view shipping.return_results_v1 as

--- a/schema/revert/policies.sql
+++ b/schema/revert/policies.sql
@@ -1,0 +1,39 @@
+-- Revert seattleflu/id3c-customizations:policies from pg
+-- requires: seattleflu/schema:warehouse/presence_absence
+-- requires: seattleflu/schema:roles/reporter
+-- requires: seattleflu/schema:roles/fhir-processor/create
+-- requires: seattleflu/schema:roles/presence-absence-processor
+-- requires: roles/reportable-condition-notifier/create
+-- requires: roles/hcov19-visibility/create
+
+begin;
+
+alter table warehouse.presence_absence
+    disable row level security;
+
+drop policy if exists "public: visible if not HCoV-19"
+    on warehouse.presence_absence;
+
+drop policy if exists "hcov19-visibility: visible unconditionally"
+    on warehouse.presence_absence;
+
+revoke "hcov19-visibility" from
+    "fhir-processor",
+    "presence-absence-processor",
+    "reportable-condition-notifier";
+
+alter view shipping.presence_absence_result_v1
+    owner to current_user;
+
+alter view shipping.presence_absence_result_v2
+    owner to current_user;
+
+revoke all
+    on receiving.presence_absence
+    from reporter;
+
+grant select
+    on receiving.presence_absence
+    to reporter;
+
+commit;

--- a/schema/revert/roles/hcov19-visibility/create.sql
+++ b/schema/revert/roles/hcov19-visibility/create.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/id3c-customizations:roles/hcov19-visibility/create from pg
+
+begin;
+
+drop role "hcov19-visibility";
+
+commit;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -47,6 +47,8 @@ create or replace view shipping.reportable_condition_v1 as
 
     order by encountered desc;
 
+grant select on shipping.reportable_condition_v1 to reporter;
+
 
 drop view shipping.metadata_for_augur_build_v2;
 create or replace view shipping.metadata_for_augur_build_v2 as
@@ -128,6 +130,8 @@ create or replace view shipping.flu_assembly_jobs_v1 as
 
 comment on view shipping.flu_assembly_jobs_v1 is
     'View of flu jobs that still need to be run through the assembly pipeline';
+
+alter view shipping.flu_assembly_jobs_v1 owner to current_user;
 
 
 create or replace view shipping.return_results_v1 as
@@ -669,7 +673,38 @@ comment on view shipping.sample_with_best_available_encounter_data_v1 is
     'Version 1 of view of warehoused samples and their best available encounter date and site details important for metrics calculations';
 
 
-drop view shipping.return_results_v2;
+create or replace view shipping.return_results_v2 as
+
+    select barcode,
+           case
+             when sample_id is null then 'notReceived'
+             when sample_id is not null and count(present) = 0 then 'processing'
+             when count(present) > 0 then 'complete'
+           end as status,
+           array_agg(distinct organism::text)
+            filter (where present and organism is not null)  as organisms_present,
+           array_agg(distinct organism::text)
+            filter (where not present and organism is not null) as organisms_absent
+
+      from warehouse.identifier
+      join warehouse.identifier_set using (identifier_set_id)
+      left join warehouse.sample on uuid::text = sample.collection_identifier
+      left join warehouse.encounter using (encounter_id)
+      left join shipping.presence_absence_result_v2 on sample.identifier = presence_absence_result_v2.sample
+
+    --These are all past and current collection identifier sets not including self-test
+    where identifier_set.name in ('collections-swab&send', 'collections-self-test')
+      and (organism is null or
+          -- We only return results for COVID-19, so omit all other presence/absence results
+          organism <@ '{"Human_coronavirus.2019"}'::ltree[])
+          -- We only want results collected after Izzy updated the REDCap consent form in swab & send.
+          -- This filter-by timestamp comes from REDCap
+      and coalesce(encountered, date_or_null(warehouse.sample.details->>'date')) > '2020-03-04 08:35:00-8'::timestamp with time zone
+    group by barcode, sample_id
+    order by barcode;
+
+comment on view shipping.return_results_v2 is
+    'Version 2 of view of barcodes and presence/absence results for return of results on website';
 
 
 commit;

--- a/schema/revert/shipping/views@2020-03-05b.sql
+++ b/schema/revert/shipping/views@2020-03-05b.sql
@@ -47,26 +47,6 @@ create or replace view shipping.reportable_condition_v1 as
 
     order by encountered desc;
 
-/* The shipping.reportable_condition_v1 view needs hCoV-19 visibility, so
- * remains owned by postgres, but it should only be accessible by
- * reportable-condition-notifier.  Revoke existing grants to every other role.
- *
- * XXX FIXME: There is a bad interplay here if roles/x/grants is also reworked
- * in the future.  It's part of the broader bad interplay between views and
- * their grants.  I think it was a mistake to lump grants to each role in their
- * own change instead of scattering them amongst the changes that create/rework
- * tables and views and things that are granted on.  I made that choice
- * initially so that all grants for a role could be seen in a single
- * consolidated place, which would still be nice.  There's got to be a better
- * system for managing this (a single idempotent change script with all ACLs
- * that is always run after other changes? cleaner breaking up of sqitch
- * projects?), but I don't have time to think on it much now.  Luckily for us,
- * I think the core reporter role is unlikely to be reworked soon, but we
- * should be wary.
- *   -trs, 7 March 2020
- */
-revoke all on shipping.reportable_condition_v1 from reporter;
-
 
 drop view shipping.metadata_for_augur_build_v2;
 create or replace view shipping.metadata_for_augur_build_v2 as
@@ -148,11 +128,6 @@ create or replace view shipping.flu_assembly_jobs_v1 as
 
 comment on view shipping.flu_assembly_jobs_v1 is
     'View of flu jobs that still need to be run through the assembly pipeline';
-
--- Does not need HCoV-19 visibility and should filter it out
--- anyway, but be safe.
-alter view shipping.flu_assembly_jobs_v1 owner to reporter;
-
 
 
 create or replace view shipping.return_results_v1 as
@@ -694,38 +669,7 @@ comment on view shipping.sample_with_best_available_encounter_data_v1 is
     'Version 1 of view of warehoused samples and their best available encounter date and site details important for metrics calculations';
 
 
-create or replace view shipping.return_results_v2 as
-
-    select barcode,
-           case
-             when sample_id is null then 'notReceived'
-             when sample_id is not null and count(present) = 0 then 'processing'
-             when count(present) > 0 then 'complete'
-           end as status,
-           array_agg(distinct organism::text)
-            filter (where present and organism is not null)  as organisms_present,
-           array_agg(distinct organism::text)
-            filter (where not present and organism is not null) as organisms_absent
-
-      from warehouse.identifier
-      join warehouse.identifier_set using (identifier_set_id)
-      left join warehouse.sample on uuid::text = sample.collection_identifier
-      left join warehouse.encounter using (encounter_id)
-      left join shipping.presence_absence_result_v2 on sample.identifier = presence_absence_result_v2.sample
-
-    --These are all past and current collection identifier sets not including self-test
-    where identifier_set.name in ('collections-swab&send', 'collections-self-test')
-      and (organism is null or
-          -- We only return results for COVID-19, so omit all other presence/absence results
-          organism <@ '{"Human_coronavirus.2019"}'::ltree[])
-          -- We only want results collected after Izzy updated the REDCap consent form in swab & send.
-          -- This filter-by timestamp comes from REDCap
-      and coalesce(encountered, date_or_null(warehouse.sample.details->>'date')) > '2020-03-04 08:35:00-8'::timestamp with time zone
-    group by barcode, sample_id
-    order by barcode;
-
-comment on view shipping.return_results_v2 is
-    'Version 2 of view of barcodes and presence/absence results for return of results on website';
+drop view shipping.return_results_v2;
 
 
 commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -97,3 +97,4 @@ roles/return-results-exporter/grants [roles/return-results-exporter/grants@2020-
 
 roles/hcov19-visibility/create 2020-03-05T18:51:44Z Thomas Sibley <tsibley@fredhutch.org> # Create hcov19-visibility role for RLS
 policies [seattleflu/schema:warehouse/presence_absence seattleflu/schema:roles/reporter seattleflu/schema:roles/fhir-processor/create seattleflu/schema:roles/presence-absence-processor seattleflu/schema:shipping/views@2020-02-25 roles/reportable-condition-notifier/create roles/hcov19-visibility/create] 2020-03-05T06:57:10Z Thomas Sibley <tsibley@fredhutch.org> # Row-level security policies
+shipping/views [shipping/views@2020-03-05b roles/hcov19-visibility/create] 2020-03-07T21:35:31Z Thomas Sibley <tsibley@fredhutch.org> # Lock down views

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -98,3 +98,4 @@ roles/return-results-exporter/grants [roles/return-results-exporter/grants@2020-
 roles/hcov19-visibility/create 2020-03-05T18:51:44Z Thomas Sibley <tsibley@fredhutch.org> # Create hcov19-visibility role for RLS
 policies [seattleflu/schema:warehouse/presence_absence seattleflu/schema:roles/reporter seattleflu/schema:roles/fhir-processor/create seattleflu/schema:roles/presence-absence-processor seattleflu/schema:shipping/views@2020-02-25 roles/reportable-condition-notifier/create roles/hcov19-visibility/create] 2020-03-05T06:57:10Z Thomas Sibley <tsibley@fredhutch.org> # Row-level security policies
 shipping/views [shipping/views@2020-03-05b roles/hcov19-visibility/create] 2020-03-07T21:35:31Z Thomas Sibley <tsibley@fredhutch.org> # Lock down views
+@2020-03-07 2020-03-07T21:43:11Z Thomas Sibley <tsibley@fredhutch.org> # Schema as of 2020-03-07

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -87,9 +87,13 @@ warehouse/site/data [warehouse/site/data@2020-02-21] 2020-02-25T22:07:52Z Kairst
 
 warehouse/target/data [warehouse/target/data@2020-02-26] 2020-03-03T19:31:35Z Jover Lee <joverlee@fredhutch.org> # Link nCov target to organism
 @2020-03-03 2020-03-03T22:46:29Z Jover Lee <joverlee@fredhutch.org> # Schema as of 03 March 2020
+
 warehouse/target/data [warehouse/target/data@2020-03-03] 2020-03-06T01:21:49Z Jover Lee <joverlee@fredhutch.org> # Add COVID-19 target and link to organism
 @2020-03-05 2020-03-06T01:34:53Z Jover Lee <joverlee@fredhutch.org> # Schema as of 05 March 2020
 
 shipping/views [shipping/views@2020-02-26] 2020-03-03T22:26:42Z Kairsten Fay <kfay@fredhutch.org> # Update RoR view for COVID-19
 roles/return-results-exporter/grants [roles/return-results-exporter/grants@2020-03-03] 2020-03-05T20:42:52Z Kairsten Fay <kfay@fredhutch.org> # Update return-results-exporter grants
 @2020-03-05b 2020-03-06T06:23:55Z Kairsten Fay <kfay@fredhutch.org> # Schema as of later on 05 Mar 2020
+
+roles/hcov19-visibility/create 2020-03-05T18:51:44Z Thomas Sibley <tsibley@fredhutch.org> # Create hcov19-visibility role for RLS
+policies [seattleflu/schema:warehouse/presence_absence seattleflu/schema:roles/reporter seattleflu/schema:roles/fhir-processor/create seattleflu/schema:roles/presence-absence-processor seattleflu/schema:shipping/views@2020-02-25 roles/reportable-condition-notifier/create roles/hcov19-visibility/create] 2020-03-05T06:57:10Z Thomas Sibley <tsibley@fredhutch.org> # Row-level security policies

--- a/schema/verify/policies.sql
+++ b/schema/verify/policies.sql
@@ -1,0 +1,68 @@
+-- Verify seattleflu/id3c-customizations:policies on pg
+-- requires: seattleflu/schema:warehouse/presence_absence
+-- requires: seattleflu/schema:roles/reporter
+-- requires: seattleflu/schema:roles/fhir-processor/create
+-- requires: seattleflu/schema:roles/presence-absence-processor
+-- requires: roles/reportable-condition-notifier/create
+-- requires: roles/hcov19-visibility/create
+
+begin;
+
+insert into warehouse.target (identifier, control, organism_id)
+    values
+        ('Measles', false, null),
+        ('nCoV', false, (select organism_id from warehouse.organism where lineage = 'Human_coronavirus.2019')),
+        ('COVID-19', false, (select organism_id from warehouse.organism where lineage = 'Human_coronavirus.2019'))
+    on conflict (identifier) do update set
+        organism_id = excluded.organism_id;
+
+with test_sample as (
+    insert into warehouse.sample (identifier)
+        values (uuid_generate_v4())
+        returning sample_id
+)
+insert into warehouse.presence_absence (identifier, sample_id, target_id, present)
+    select
+        uuid_generate_v4()::text,
+        sample_id,
+        target_id,
+        true
+    from
+        warehouse.target,
+        test_sample
+    where
+        target.identifier in ('Measles', 'nCoV', 'COVID-19')
+;
+
+do $$
+declare
+    expected_count integer;
+begin
+    select into expected_count count(*)
+        from warehouse.presence_absence
+        join warehouse.target using (target_id)
+        where target.identifier in ('nCoV', 'COVID-19');
+
+    assert expected_count >= 2;
+
+    set local role reporter;
+
+    assert 0 = (
+        select count(*)
+        from warehouse.presence_absence
+        join warehouse.target using (target_id)
+        where target.identifier in ('nCoV', 'COVID-19')
+    );
+
+    set local role "presence-absence-processor";
+
+    assert expected_count = (
+        select count(*)
+        from warehouse.presence_absence
+        join warehouse.target using (target_id)
+        where target.identifier in ('nCoV', 'COVID-19')
+    );
+end
+$$;
+
+rollback;

--- a/schema/verify/roles/hcov19-visibility/create.sql
+++ b/schema/verify/roles/hcov19-visibility/create.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/id3c-customizations:roles/hcov19-visibility/create on pg
+
+begin;
+
+set local role "hcov19-visibility";
+
+rollback;

--- a/schema/verify/shipping/views@2020-03-05b.sql
+++ b/schema/verify/shipping/views@2020-03-05b.sql
@@ -1,0 +1,83 @@
+-- Verify seattleflu/id3c-customizations:shipping/views on pg
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.reportable_condition_v1');
+
+-- Verify that the view has been dropped
+select 1/(count(*) = 0)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.genomic_sequences_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.flu_assembly_jobs_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_encounter_details_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.sample_with_best_available_encounter_data_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v2');
+
+
+rollback;


### PR DESCRIPTION
Details in commit messages.

I tested this locally by doing:

```sh
export PGDATABASE=seattleflu

./dev/detect-rls-leaks  # should show no testable data error

psql -qAt service=seattleflu-restricted -qAt \
  <<<"select document::jsonb from receiving.presence_absence order by received" \
  | pipenv run id3c receiving upload presence_absence -

LOG_LEVEL=warning pipenv run id3c etl presence-absence --commit

./dev/detect-rls-leaks  # should show red not ok failures

sqitch deploy dev

./dev/detect-rls-leaks  # should show all ok (plus some permission denied warnings)
```