### PR TITLE
Report hCoV-19

### DIFF
--- a/lib/seattleflu/id3c/cli/command/reportable_conditions.py
+++ b/lib/seattleflu/id3c/cli/command/reportable_conditions.py
@@ -67,6 +67,7 @@ def notify(*, action: str):
 
     SLACK_WEBHOOK_REPORTING_GENERAL = webhook("GENERAL")
     SLACK_WEBHOOK_REPORTING_CHILDRENS = webhook("CHILDRENS")
+    SLACK_WEBHOOK_REPORTING_HCOV19 = webhook("HCOV19")
 
     childrens_sites = get_childrens_sites(db)
 
@@ -97,13 +98,16 @@ def notify(*, action: str):
                     LOG.info(f"No site found for presence_absence_id «{record.id}». " +
                         "Inferring site from manifest data.")
 
-                url = SLACK_WEBHOOK_REPORTING_CHILDRENS \
-                    if (record.site in childrens_sites or
-                        record.sheet == 'SCH' or
-                        record.sample_origin == 'sch_retro' or
-                        record.swab_site == 'sch_ed' or
-                        record.swab_site == 'community_clinic') \
-                    else SLACK_WEBHOOK_REPORTING_GENERAL
+                if record.lineage == 'Human_coronavirus.2019':
+                    url = SLACK_WEBHOOK_REPORTING_HCOV19
+                elif (record.site in childrens_sites or
+                      record.sheet == 'SCH' or
+                      record.sample_origin == 'sch_retro' or
+                      record.swab_site == 'sch_ed' or
+                      record.swab_site == 'community_clinic'):
+                    url = SLACK_WEBHOOK_REPORTING_CHILDRENS
+                else:
+                    url = SLACK_WEBHOOK_REPORTING_GENERAL
 
                 response = send_slack_post_request(record, url)
 

--- a/lib/seattleflu/id3c/cli/command/reportable_conditions.py
+++ b/lib/seattleflu/id3c/cli/command/reportable_conditions.py
@@ -98,7 +98,10 @@ def notify(*, action: str):
                     LOG.info(f"No site found for presence_absence_id «{record.id}». " +
                         "Inferring site from manifest data.")
 
+                metabase_link = "https://backoffice.seattleflu.org/metabase/question/55"
+
                 if record.lineage == 'Human_coronavirus.2019':
+                    metabase_link = "https://backoffice.seattleflu.org/metabase/question/466"
                     url = SLACK_WEBHOOK_REPORTING_HCOV19
                 elif (record.site in childrens_sites or
                       record.sheet == 'SCH' or
@@ -109,7 +112,7 @@ def notify(*, action: str):
                 else:
                     url = SLACK_WEBHOOK_REPORTING_GENERAL
 
-                response = send_slack_post_request(record, url)
+                response = send_slack_post_request(record, url, metabase_link)
 
                 if response.status_code == 200:
                     mark_processed(db, record.id, {"status": "sent Slack notification"})
@@ -162,7 +165,7 @@ def get_childrens_sites(db) -> List:
     return [site.identifier for site in childrens_sites]
 
 
-def send_slack_post_request(record: Any, url: str) -> requests.Response:
+def send_slack_post_request(record: Any, url: str, metabase_link: str) -> requests.Response:
     """
     Sends a POST request to a channel-specific Slack webhook *url*. The payload
     of this POST request is composed using Slack blocks. These blocks provide
@@ -198,7 +201,7 @@ def send_slack_post_request(record: Any, url: str) -> requests.Response:
                 "type": "mrkdwn",
                 "text": dedent(f"""
                 :rotating_light: @channel {record.lineage} detected. \n
-                *<https://backoffice.seattleflu.org/metabase/question/55|Go to Metabase>*
+                *<{metabase_link}|Go to Metabase>*
                 """)
             }
         },

--- a/schema/deploy/warehouse/target/data.sql
+++ b/schema/deploy/warehouse/target/data.sql
@@ -126,6 +126,7 @@ with target_lineage (identifier, lineage) as (
         ('http://snomed.info/id/441345003',    'Influenza.B'),
         ('http://snomed.info/id/441278007',    'RSV')
 )
+
 insert into warehouse.target (identifier, organism_id, control)
 
     select identifier, organism_id, false

--- a/schema/deploy/warehouse/target/data@2020-03-09.sql
+++ b/schema/deploy/warehouse/target/data@2020-03-09.sql
@@ -18,7 +18,7 @@ insert into warehouse.organism (lineage, identifiers, details)
         ('Human_coronavirus.NL63',  'NCBITAXON => 277944',      null),
         ('Human_coronavirus.229E',  'NCBITAXON => 11137',       null),
         ('Human_coronavirus.OC43',  'NCBITAXON => 31631',       null),
-        ('Human_coronavirus.2019',  'NCBITAXON => 2697049',     '{"report_to_public_health": true}'),
+        ('Human_coronavirus.2019',  'NCBITAXON => 2697049',     '{"report_to_public_health": false}'),
         ('Human_metapneumovirus',   'NCBITAXON => 162145',      null),
         ('Human_parainfluenza',     null,                       null),
         ('Human_parainfluenza.1',   'NCBITAXON => 12730',       null),

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -106,3 +106,4 @@ warehouse/target/data [warehouse/target/data@2020-03-07] 2020-03-09T17:37:02Z Th
 policies [policies@2020-03-09] 2020-03-09T19:11:40Z Thomas Sibley <tsibley@fredhutch.org> # Allow hcov19-visibility to see receiving.presence_absence too
 
 warehouse/target/data [warehouse/target/data@2020-03-09] 2020-03-09T21:00:52Z Jover Lee <joverlee@fredhutch.org> # Mark hCoV-19 as reportable again
+@2020-03-09b 2020-03-09T21:09:59Z Jover Lee <joverlee@fredhutch.org> # Schema as of later on 9 March 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -104,3 +104,5 @@ shipping/views [shipping/views@2020-03-05b roles/hcov19-visibility/create roles/
 warehouse/target/data [warehouse/target/data@2020-03-07] 2020-03-09T17:37:02Z Thomas Sibley <tsibley@fredhutch.org> # Unmark hCoV-19 as reportable for now
 @2020-03-09 2020-03-09T17:48:08Z Thomas Sibley <tsibley@fredhutch.org> # schema as of 9 March 2020
 policies [policies@2020-03-09] 2020-03-09T19:11:40Z Thomas Sibley <tsibley@fredhutch.org> # Allow hcov19-visibility to see receiving.presence_absence too
+
+warehouse/target/data [warehouse/target/data@2020-03-09] 2020-03-09T21:00:52Z Jover Lee <joverlee@fredhutch.org> # Mark hCoV-19 as reportable again


### PR DESCRIPTION
Report hCoV-19 in a separate channel and provide a separate metabase url for hCoV-19 specific results.