### PR TITLE
Add hCoV-19 observation w/ presence-absence view

### DIFF
--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -757,11 +757,11 @@ create or replace view shipping.hcov19_observation_v1 as
     left join warehouse.location using (location_id)
     where
         lineage = 'Human_coronavirus.2019'
-        -- If no test results are available, select encounters on or after 1 March 2020
-        -- Because Mike said so
+        -- If no test results are available, select encounters on or after 22 Feb 2020.
+        -- Date chosen because of this tweet: https://mobile.twitter.com/trvrb/status/1237395936193605633
         or (
           lineage is null and
-          best_available_encounter_date >= '2020-03-01'::date
+          best_available_encounter_date >= '2020-02-22'::date
         )
         and (not control or control is null)
         and sample.details->>'sample_origin' != 'es'

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -816,8 +816,8 @@ create or replace view shipping.hcov19_observation_v1 as
 
 
 /* The shipping.hcov19_observation_v1 view needs hCoV-19 visibility, so
- * remains owned by postgres, but it should only be accessible by
- * reportable-condition-notifier.  Revoke existing grants to every other role.
+ * remains owned by postgres, but it should only be accessible by those with
+ * hcov19-visibility.  Revoke existing grants to every other role.
  *
  * XXX FIXME: There is a bad interplay here if roles/x/grants is also reworked
  * in the future.  It's part of the broader bad interplay between views and
@@ -834,6 +834,10 @@ create or replace view shipping.hcov19_observation_v1 as
  *   -trs, 7 March 2020
  */
 revoke all on shipping.hcov19_observation_v1 from reporter;
+
+grant select
+    on shipping.hcov19_observation_v1
+    to "hcov19-visibility";
 
 
 comment on view shipping.hcov19_observation_v1 is

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -768,6 +768,27 @@ create or replace view shipping.hcov19_observation_v1 as
     ;
 
 
+/* The shipping.hcov19_observation_v1 view needs hCoV-19 visibility, so
+ * remains owned by postgres, but it should only be accessible by
+ * reportable-condition-notifier.  Revoke existing grants to every other role.
+ *
+ * XXX FIXME: There is a bad interplay here if roles/x/grants is also reworked
+ * in the future.  It's part of the broader bad interplay between views and
+ * their grants.  I think it was a mistake to lump grants to each role in their
+ * own change instead of scattering them amongst the changes that create/rework
+ * tables and views and things that are granted on.  I made that choice
+ * initially so that all grants for a role could be seen in a single
+ * consolidated place, which would still be nice.  There's got to be a better
+ * system for managing this (a single idempotent change script with all ACLs
+ * that is always run after other changes? cleaner breaking up of sqitch
+ * projects?), but I don't have time to think on it much now.  Luckily for us,
+ * I think the core reporter role is unlikely to be reworked soon, but we
+ * should be wary.
+ *   -trs, 7 March 2020
+ */
+revoke all on shipping.hcov19_observation_v1 from reporter;
+
+
 comment on view shipping.hcov19_observation_v1 is
   'Custom view of hCoV-19 samples with presence-absence results and best available encounter data';
 

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -109,3 +109,4 @@ warehouse/target/data [warehouse/target/data@2020-03-09] 2020-03-09T21:00:52Z Jo
 @2020-03-09b 2020-03-09T21:09:59Z Jover Lee <joverlee@fredhutch.org> # Schema as of later on 9 March 2020
 
 shipping/views [shipping/views@2020-03-09 seattleflu/schema:warehouse/primary-encounter-location] 2020-03-10T02:53:04Z Kairsten Fay <kfay@fredhutch.org> # Add view for hCoV-19 results
+@2020-03-16 2020-03-16T18:41:47Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 16 March 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -107,3 +107,5 @@ policies [policies@2020-03-09] 2020-03-09T19:11:40Z Thomas Sibley <tsibley@fredh
 
 warehouse/target/data [warehouse/target/data@2020-03-09] 2020-03-09T21:00:52Z Jover Lee <joverlee@fredhutch.org> # Mark hCoV-19 as reportable again
 @2020-03-09b 2020-03-09T21:09:59Z Jover Lee <joverlee@fredhutch.org> # Schema as of later on 9 March 2020
+
+shipping/views [shipping/views@2020-03-09] 2020-03-10T02:53:04Z Kairsten Fay <kfay@fredhutch.org> # Add view for hCoV-19 results

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -108,4 +108,4 @@ policies [policies@2020-03-09] 2020-03-09T19:11:40Z Thomas Sibley <tsibley@fredh
 warehouse/target/data [warehouse/target/data@2020-03-09] 2020-03-09T21:00:52Z Jover Lee <joverlee@fredhutch.org> # Mark hCoV-19 as reportable again
 @2020-03-09b 2020-03-09T21:09:59Z Jover Lee <joverlee@fredhutch.org> # Schema as of later on 9 March 2020
 
-shipping/views [shipping/views@2020-03-09] 2020-03-10T02:53:04Z Kairsten Fay <kfay@fredhutch.org> # Add view for hCoV-19 results
+shipping/views [shipping/views@2020-03-09 seattleflu/schema:warehouse/primary-encounter-location] 2020-03-10T02:53:04Z Kairsten Fay <kfay@fredhutch.org> # Add view for hCoV-19 results

--- a/schema/verify/shipping/views@2020-03-09.sql
+++ b/schema/verify/shipping/views@2020-03-09.sql
@@ -79,10 +79,5 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.return_results_v2');
 
-select 1/(count(*) = 1)::int
-  from information_schema.views
- where array[table_schema, table_name]::text[]
-     = pg_catalog.parse_ident('shipping.hcov19_observation_v1');
-
 
 rollback;


### PR DESCRIPTION
Add a new similar to `observation_with_presence_absence_result` specific
to samples tested for hCoV-19.

Currently this view includes all non-control samples, with or without
encounter data, that have been tested for hCoV-19 and all encounters
since March 1, 2020.