### PR TITLE
Additional uw retro metadata

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -104,9 +104,6 @@ def race(races: Optional[Any]) -> list:
 
     assert set(race_map.keys()) == set(map(str.lower, race_map.keys()))
 
-    def standardize_whitespace(string):
-        return re.sub(r"\s+", " ", string.strip())
-
     def standardize_race(race):
         try:
             return race_map[standardize_whitespace(race).lower()]
@@ -114,6 +111,13 @@ def race(races: Optional[Any]) -> list:
             raise UnknownRaceError(f"Unknown race name «{race}»") from None
 
     return list(map(standardize_race, races))
+
+
+def standardize_whitespace(string: str) -> str:
+    """
+    Removes leading, trailing, and repeat whitespace from a given *string*.
+    """
+    return re.sub(r"\s+", " ", string.strip())
 
 
 class UnknownRaceError(ValueError):

--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -229,10 +229,7 @@ def create_encounter_resource(encounter_identifier: List[dict],
         "class": encounter_class,
         "identifier": encounter_identifier,
         "status": encounter_status,
-        "period": {
-            "start": encounter_date,
-            "end": encounter_date,
-        },
+        "period": period,
         "subject": patient_reference,
     }
 

--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -151,6 +151,7 @@ def create_encounter_resource(encounter_identifier: List[dict],
                               location_references: List[dict],
                               diagnosis: List[dict] = None,
                               contained: List[dict] = None,
+                              encounter_status = 'finished',
                               hospitalization: dict = None) -> dict:
     """
     Create encounter resource following the FHIR format
@@ -160,7 +161,7 @@ def create_encounter_resource(encounter_identifier: List[dict],
         "resourceType": "Encounter",
         "class": encounter_class,
         "identifier": encounter_identifier,
-        "status": "finished",
+        "status": encounter_status,
         "period": {
             "start": encounter_date,
             "end": encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -150,7 +150,8 @@ def create_encounter_resource(encounter_identifier: List[dict],
                               patient_reference: dict,
                               location_references: List[dict],
                               diagnosis: List[dict] = None,
-                              contained: List[dict] = None) -> dict:
+                              contained: List[dict] = None,
+                              hospitalization: dict = None) -> dict:
     """
     Create encounter resource following the FHIR format
     (http://www.hl7.org/implement/standards/fhir/encounter.html)
@@ -173,6 +174,8 @@ def create_encounter_resource(encounter_identifier: List[dict],
         encounter_resource["diagnosis"] = diagnosis
     if contained:
         encounter_resource["contained"] = contained
+    if hospitalization:
+        encounter_resource["hospitalization"] = hospitalization
 
     return encounter_resource
 

--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -4,7 +4,7 @@ REDCap DET ETL shared functions to create FHIR documents
 import logging
 import regex
 from itertools import filterfalse
-from typing import Iterable, NamedTuple, Optional, List
+from typing import Iterable, NamedTuple, Optional, List, Any
 from uuid import uuid4
 from datetime import datetime
 from id3c.cli.command.de_identify import generate_hash
@@ -12,6 +12,7 @@ from id3c.cli.command.de_identify import generate_hash
 
 LOG = logging.getLogger(__name__)
 
+SFS = "https://seattleflu.org"
 
 # CREATE FHIR RESOURCES
 def create_reference(reference_type: str = None,
@@ -440,3 +441,25 @@ def canonicalize_name(*parts: Iterable[str]) -> str:
         return collapse_whitespace(remove_non_word_chars(part)).strip().upper()
 
     return " ".join(map(canonicalize, parts))
+
+
+# XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
+# 3.8.  Until then, there's no reasonable way to type this data structure
+# better than Any.
+#   -trs, 24 Oct 2019
+observation_resource: Any = {
+    'resourceType': 'Observation',
+    'id': '',
+    'status': 'final',
+    'code': {
+        'coding': []
+    },
+    'valueBoolean': None,
+    'device': create_reference(
+        reference_type = 'Device',
+        identifier = create_identifier(
+            system = f'{SFS}/device',
+            value = 'Cepheid'
+        )
+    )
+}

--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -447,19 +447,24 @@ def canonicalize_name(*parts: Iterable[str]) -> str:
 # 3.8.  Until then, there's no reasonable way to type this data structure
 # better than Any.
 #   -trs, 24 Oct 2019
-observation_resource: Any = {
-    'resourceType': 'Observation',
-    'id': '',
-    'status': 'final',
-    'code': {
-        'coding': []
-    },
-    'valueBoolean': None,
-    'device': create_reference(
-        reference_type = 'Device',
-        identifier = create_identifier(
-            system = f'{SFS}/device',
-            value = 'Cepheid'
+def observation_resource(device: str) -> Any:
+    """
+    Returns a minimally-filled FHIR Observation Resource with a given
+    *device* value.
+    """
+    return {
+        'resourceType': 'Observation',
+        'id': '',
+        'status': 'final',
+        'code': {
+            'coding': []
+        },
+        'valueBoolean': None,
+        'device': create_reference(
+            reference_type = 'Device',
+            identifier = create_identifier(
+                system = f'{SFS}/device',
+                value = device
+            )
         )
-    )
-}
+    }

--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -54,14 +54,18 @@ def create_patient_resource(patient_identifier: List[dict], gender: str) -> dict
 def create_diagnostic_report(redcap_record:dict,
                              patient_reference: dict,
                              specimen_reference: dict,
+                             diagnostic_code: dict,
                              create_device_result_observation_resource: Callable) -> Optional[dict]:
     """
-    Create FHIR diagnostic report from given *redcap_record*. Attaches
-    observation resources to it using the given, device-specific
-    *create_device_result_observation_resource* function.
+    Create FHIR diagnostic report from given *redcap_record*.
 
     Links the generated diagnostic report to a specific *patient_reference* and
     *specimen_reference*.
+
+    Device-specific modifications are made with the given *diagnostic_code*
+    codeable concept for the diagnostic report and the
+    *create_device_result_observation_resource* function which attaches
+    observation resources to the diagnostic report.
     """
     clinical_results = create_device_result_observation_resource(redcap_record)
     if not clinical_results:
@@ -76,12 +80,6 @@ def create_diagnostic_report(redcap_record:dict,
         diagnostic_result_references.append(reference)
 
     collection_datetime = redcap_record['collection_date']
-
-    diagnostic_code = create_codeable_concept(
-        system = 'http://loinc.org',
-        code = '85476-0',
-        display = 'FLUAV and FLUBV and RSV pnl NAA+probe (Upper resp)'
-    )
 
     diagnostic_report_resource = create_diagnostic_report_resource(
         datetime = collection_datetime,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -289,27 +289,6 @@ def create_cepheid_result_observation_resource(redcap_record: dict) -> List[dict
     create observation resources for each result following the FHIR format
     (http://www.hl7.org/implement/standards/fhir/observation.html)
     """
-    # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
-    # 3.8.  Until then, there's no reasonable way to type this data structure
-    # better than Any.
-    #   -trs, 24 Oct 2019
-    observation_resource: Any = {
-        'resourceType': 'Observation',
-        'id': '',
-        'status': 'final',
-        'code': {
-            'coding': []
-        },
-        'valueBoolean': None,
-        'device': create_reference(
-            reference_type = 'Device',
-            identifier = create_identifier(
-                system = f'{SFS}/device',
-                value = 'Cepheid'
-            )
-        )
-    }
-
     code_map = {
         'Influenza A +': {
             'system': 'http://snomed.info/sct',

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -6,7 +6,6 @@ import re
 from uuid import uuid4
 from datetime import datetime
 from typing import Any, List, Optional, Tuple, Dict
-from copy import deepcopy
 from cachetools import TTLCache
 from id3c.db.session import DatabaseSession
 from id3c.cli.command.de_identify import generate_hash
@@ -317,7 +316,7 @@ def create_cepheid_result_observation_resource(redcap_record: dict) -> List[dict
     # Create observation resources for all potential results in Cepheid test
     diagnostic_results = {}
     for index, result in enumerate(code_map):
-        new_observation = deepcopy(observation_resource)
+        new_observation = observation_resource('Cepheid')
         new_observation['id'] = 'result-' + str(index+1)
         new_observation['code']['coding'] = [code_map[result]]
         diagnostic_results[result] = (new_observation)

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -70,10 +70,18 @@ def redcap_det_kisok(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_
     # to do the rapid flu test on site
     diagnostic_report_resource_entry = None
     if redcap_record['poc_yesno'] == 'Yes':
+
+        diagnostic_code = create_codeable_concept(
+            system = 'http://loinc.org',
+            code = '85476-0',
+            display = 'FLUAV and FLUBV and RSV pnl NAA+probe (Upper resp)'
+        )
+
         diagnostic_report_resource_entry = create_diagnostic_report(
             redcap_record,
             patient_reference,
             specimen_reference,
+            diagnostic_code,
             create_cepheid_result_observation_resource
         )
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -341,7 +341,8 @@ def create_encounter_class(redcap_record: dict) -> dict:
 def create_encounter_status(redcap_record: dict) -> str:
     """
     Returns an Encounter.status code from a given *redcap_record*. Defaults to
-    'finished' if no encounter status is found.
+    'finished' if no encounter status is found, because we can assume this
+    UW Retrospective encounter was an outpatient encounter.
 
     This attribute is required by FHIR for an Encounter resource.
     (https://www.hl7.org/fhir/encounter-definitions.html#Encounter.status)

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -477,6 +477,7 @@ def present(redcap_record: dict, test: str) -> Optional[bool]:
 
     test_result_map = {
         'Positive': True,
+        'Detected': True,
         'Negative': False,
         'None detected.': False,
         'Test not applicable': None,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -58,10 +58,17 @@ def redcap_det_uw_retrospectives(*,
 
     specimen_observation_entry = create_specimen_observation_entry(specimen_reference, patient_reference, encounter_reference)
 
+    diagnostic_code = create_codeable_concept(
+        system = 'http://loinc.org',
+        code = '60566-7',
+        display = 'Respiratory pathogens DNA and RNA 12b panel NAA+probe (Unsp spec)'
+    )
+
     diagnostic_report_resource_entry = create_diagnostic_report(
         redcap_record,
         patient_reference,
         specimen_reference,
+        diagnostic_code,
         create_clinical_result_observation_resource
     )
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -60,9 +60,8 @@ def redcap_det_uw_retrospectives(*,
     specimen_observation_entry = create_specimen_observation_entry(specimen_reference, patient_reference, encounter_reference)
 
     diagnostic_code = create_codeable_concept(
-        system = 'http://loinc.org',
-        code = '60566-7',
-        display = 'Respiratory pathogens DNA and RNA 12b panel NAA+probe (Unsp spec)'
+        system = f'{SFS}/presence-absence-panel',
+        code = 'uw-retrospective'
     )
 
     diagnostic_report_resource_entry = create_diagnostic_report(

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -61,7 +61,8 @@ def redcap_det_uw_retrospectives(*,
     diagnostic_report_resource_entry = create_diagnostic_report(
         redcap_record,
         patient_reference,
-        specimen_reference
+        specimen_reference,
+        create_clinical_result_observation_resource
     )
 
     resource_entries = [
@@ -395,48 +396,6 @@ def determine_questionnaire_items(record: dict) -> List[dict]:
         ))
 
     return questionnaire_items
-
-
-def create_diagnostic_report(redcap_record:dict,
-                             patient_reference: dict,
-                             specimen_reference: dict) -> Optional[dict]:
-    """
-    Create FHIR diagnostic report from given *redcap_record* and link to
-    specific *patient_reference* and *specimen_reference*
-    """
-    clinical_results = create_clinical_result_observation_resource(redcap_record)
-    if not clinical_results:
-        return None
-
-    diagnostic_result_references = []
-    for result in clinical_results:
-        reference = create_reference(
-            reference_type = 'Observation',
-            reference = '#' + result['id']
-        )
-        diagnostic_result_references.append(reference)
-
-    collection_datetime = redcap_record['collection_date']
-
-    diagnostic_code = create_codeable_concept(
-        system = 'http://loinc.org',
-        code = '85476-0',
-        display = 'FLUAV and FLUBV and RSV pnl NAA+probe (Upper resp)'
-    )
-
-    diagnostic_report_resource = create_diagnostic_report_resource(
-        datetime = collection_datetime,
-        diagnostic_code = diagnostic_code,
-        patient_reference  = patient_reference,
-        specimen_reference = specimen_reference,
-        result = diagnostic_result_references,
-        contained = clinical_results
-    )
-
-    return (create_resource_entry(
-        resource = diagnostic_report_resource,
-        full_url = generate_full_url_uuid()
-    ))
 
 
 def create_clinical_result_observation_resource(redcap_record: dict) -> Optional[List[dict]]:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -361,7 +361,7 @@ def create_encounter_status(redcap_record: dict) -> str:
     mapper = {
         'ARRIVED': 'arrived',
         'DISCHARGED': 'finished',
-        'LWBS': 'cancelled +',  # LWBS = left without being seen.
+        'LWBS': 'cancelled',  # LWBS = left without being seen.
     }
 
     if status not in mapper:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -433,16 +433,6 @@ def create_clinical_result_observation_resource(redcap_record: dict) -> Optional
             'code': '441278007',
             'display': 'Respiratory syncytial virus untyped strain present',
         },
-        '441344004': {
-            'system': 'http://snomed.info/sct',
-            'code': '441344004',
-            'display': 'Human parainfluenza virus present',
-        },
-        '186747009': {
-            'system': 'http://snomed.info/sct',
-            'code': '186747009',
-            'display': 'Coronavirus infection',  # NOT clinical finding
-        },
         '440925005': {
             'system': 'http://snomed.info/sct',
             'code': '440925005',

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -341,7 +341,7 @@ def create_encounter_class(redcap_record: dict) -> dict:
     # Default to 'AMB' if encounter_class not defined
     return create_coding(
         system = "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        code = encounter_class or 'AMB'
+        code = mapper.get(encounter_class, 'AMB')
     )
 
 


### PR DESCRIPTION
Extracts clinical test results, encounter status, encounter class, and discharge disposition from UW Retrospective data. 

Depends on https://github.com/seattleflu/id3c/pull/132. 

Note that, while the DiagnosticReport resources from clinical test result end up in `warehouse.presence_absence`, none of the other variables end up in encounter details. Should we change how our `warehouse.encounter` details document is structured? Should we add new columns to `warehouse.encounter`? Other thoughts?