### PR TITLE
etl redcap-det scan-en: add new lodging options

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -95,6 +95,10 @@ def locations(db: DatabaseSession, cache: TTLCache, record: dict) -> list:
         'shelter',
         'afl',
         'snf',
+        'ltc',
+        'be',
+        'pst',
+        'cf',
         'none'
     ]
 


### PR DESCRIPTION
Additional variables were added to the SCAN REDCap project for `housing_type`:
ltc, Long term care or rehab facility
afh, Adult family home
be, Inpatient or behavioral health residential center
pst, Permanent Supportive or transitional housing center
cf, Correctional facility

I've added ltc, be, pst, cf to our `lodging_options` list but I think afh falls under `residence`.
