### PR TITLE
Link new targets

### DIFF
--- a/schema/deploy/warehouse/target/data.sql
+++ b/schema/deploy/warehouse/target/data.sql
@@ -80,6 +80,8 @@ with target_lineage (identifier, lineage) as (
         ('CoV_229E_CoV_OC43',           'Human_coronavirus'),
         ('CoV_HKU1_CoV_NL63',           'Human_coronavirus'),
         ('COVID-19',                    'Human_coronavirus.2019'),
+        ('COVID-19_Orf1b',              'Human_coronavirus.2019'),
+        ('COVID-19-S_gene',             'Human_coronavirus.2019'),
         ('nCoV',                        'Human_coronavirus.2019'),
         ('CoV_HKU1',                    'Human_coronavirus.HKU1'),
         ('CoV_NL63',                    'Human_coronavirus.NL63'),

--- a/schema/deploy/warehouse/target/data@2020-03-24b.sql
+++ b/schema/deploy/warehouse/target/data@2020-03-24b.sql
@@ -80,6 +80,8 @@ with target_lineage (identifier, lineage) as (
         ('CoV_229E_CoV_OC43',           'Human_coronavirus'),
         ('CoV_HKU1_CoV_NL63',           'Human_coronavirus'),
         ('COVID-19',                    'Human_coronavirus.2019'),
+        ('COVID-19_Orf1b',              'Human_coronavirus.2019'),
+        ('COVID-19-S_gene',             'Human_coronavirus.2019'),
         ('nCoV',                        'Human_coronavirus.2019'),
         ('CoV_HKU1',                    'Human_coronavirus.HKU1'),
         ('CoV_NL63',                    'Human_coronavirus.NL63'),
@@ -121,13 +123,10 @@ with target_lineage (identifier, lineage) as (
         ('S. pneumoniae_APZTD4A',       'Streptococcus_pneumoniae'),
         ('S.pneumoniae',                'Streptococcus_pneumoniae'),
 
-        -- Snomed CT targets used by Ellume, Cepheid, UW Retros
-        ('http://snomed.info/id/440930009',        'Adenovirus'),
-        ('http://snomed.info/id/1240581000000104', 'Human_coronavirus.2019'),
-        ('http://snomed.info/id/181000124108',     'Influenza.A'),
-        ('http://snomed.info/id/441345003',        'Influenza.B'),
-        ('http://snomed.info/id/440925005',        'Rhinovirus'),
-        ('http://snomed.info/id/441278007',        'RSV')
+        -- Targets reported by Ellume & Cepheid using SNOMED CT
+        ('http://snomed.info/id/181000124108', 'Influenza.A'),
+        ('http://snomed.info/id/441345003',    'Influenza.B'),
+        ('http://snomed.info/id/441278007',    'RSV')
 )
 
 insert into warehouse.target (identifier, organism_id, control)

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -128,3 +128,4 @@ shipping/views [shipping/views@2020-03-24] 2020-03-24T19:06:10Z Kairsten Fay <kf
 @2020-03-24b 2020-03-24T19:31:48Z Kairsten Fay <kfay@fredhutch.org> # Schema as of later on 24 Mar 2020
 
 warehouse/target/data [warehouse/target/data@2020-03-24b] 2020-03-25T00:56:30Z Jover Lee <joverlee@fredhutch.org> # Link new targets (uw-retro & covid) to organisms
+@2020-03-24c 2020-03-25T01:00:57Z Jover Lee <joverlee@fredhutch.org> # Schema as of later on 24 March 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -126,3 +126,5 @@ shipping/views [shipping/views@2020-03-23] 2020-03-24T16:14:12Z Jover Lee <jover
 
 shipping/views [shipping/views@2020-03-24] 2020-03-24T19:06:10Z Kairsten Fay <kfay@fredhutch.org> # Update hcov19_observation date and add result timestamp to SCAN RoR
 @2020-03-24b 2020-03-24T19:31:48Z Kairsten Fay <kfay@fredhutch.org> # Schema as of later on 24 Mar 2020
+
+warehouse/target/data [warehouse/target/data@2020-03-24b] 2020-03-25T00:56:30Z Jover Lee <joverlee@fredhutch.org> # Link new targets (uw-retro & covid) to organisms


### PR DESCRIPTION
This includes new Snomed targets from UW retro pulls and the two new COVID targets from NWGC. 

I want to point out that the UW retros include hCoV-19 results. I don't think we want to be including these in our analyses/reporting?