### PR TITLE
etl redcap-det scan: Ingest 'able_to_test'

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -256,7 +256,8 @@ def create_specimen_resource(specimen_identifier: List[dict],
                              patient_reference: dict,
                              specimen_type: str,
                              received_datetime: str = None,
-                             collection_datetime: str = None) -> dict:
+                             collection_datetime: str = None,
+                             note: str = None) -> dict:
     """
     Create specimen resource following the FHIR format
     (http://www.hl7.org/implement/standards/fhir/specimen.html)
@@ -275,6 +276,9 @@ def create_specimen_resource(specimen_identifier: List[dict],
         specimen_resource["collection"] = {
             "collectedDateTime": collection_datetime
         }
+
+    if note:
+        specimen_resource["note"] = [{"text": note}]
 
     return specimen_resource
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -24,7 +24,7 @@ from . import race
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 2
+REVISION = 3
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -349,9 +349,12 @@ def create_specimen(record: dict, patient_reference: dict) -> tuple:
     # YYYY-MM-DD HH:MM:SS in REDCap
     received_time = record['samp_process_date'].split()[0] if record['samp_process_date'] else None
 
+    note = 'never-tested' if record['able_to_test'] == 'no' else None
+
     specimen_type = 'NSECR'  # Nasal swab.  TODO we may want shared mapping function
     specimen_resource = create_specimen_resource(
-        [specimen_identifier], patient_reference, specimen_type, received_time, collected_time
+        [specimen_identifier], patient_reference, specimen_type, received_time,
+        collected_time, note
     )
 
     return create_entry_and_reference(specimen_resource, "Specimen")


### PR DESCRIPTION
If a sample arrives in a condition that is unable to be tested, it will
be marked never_tested at unboxing.

If later during lab testing/processing it falls into the never_tested
category (such as a PCR fails), the REDCap record will be updated w/
"no" for the able_to_test variable.