### PR TITLE
Include `apartment_number` field in address

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -24,7 +24,7 @@ from . import race
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 3
+REVISION = 4
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -113,7 +113,7 @@ def locations(db: DatabaseSession, cache: TTLCache, record: dict) -> list:
 
     address = {
         'street': record['home_street'],
-        'secondary': None,
+        'secondary': record['apartment_number'],
         'city': record['homecity_other'],
         'state': record['home_state'],
         'zipcode': record['home_zipcode_2'],


### PR DESCRIPTION
This was a new field added to make the shipping process easier.
We need to ingest it to create the correct hashed address identifier.

I've tested locally and the canonicalized address returned by SmartyStreets __does__ include
the apartment number. 