### PR TITLE
etl redcap-det scan-en: include Specimen.note for `yes`/`can-test`

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -336,11 +336,9 @@ def create_specimen(record: dict, patient_reference: dict) -> tuple:
 
     if record['able_to_test'] == 'no':
         note = 'never-tested'
-    # This is based on values currently in the SCAN REDCap project,
-    # I'm guessing `can-test` was filled in at some point before the answer
-    # code was changed.
-    #   -Jover, 3 April 2020
-    elif record['able_to_test'] in {'yes', 'can-test'}:
+    # Assumes that all samples can be tested unless explicitly marked "no".
+    #   - Jover 09 April 2020
+    else:
         note = 'can-test'
 
     specimen_type = 'NSECR'  # Nasal swab.  TODO we may want shared mapping function

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -24,7 +24,7 @@ from . import race
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 4
+REVISION = 5
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -332,7 +332,16 @@ def create_specimen(record: dict, patient_reference: dict) -> tuple:
     # YYYY-MM-DD HH:MM:SS in REDCap
     received_time = record['samp_process_date'].split()[0] if record['samp_process_date'] else None
 
-    note = 'never-tested' if record['able_to_test'] == 'no' else None
+    note = None
+
+    if record['able_to_test'] == 'no':
+        note = 'never-tested'
+    # This is based on values currently in the SCAN REDCap project,
+    # I'm guessing `can-test` was filled in at some point before the answer
+    # code was changed.
+    #   -Jover, 3 April 2020
+    elif record['able_to_test'] in {'yes', 'can-test'}:
+        note = 'can-test'
 
     specimen_type = 'NSECR'  # Nasal swab.  TODO we may want shared mapping function
     specimen_resource = create_specimen_resource(


### PR DESCRIPTION
When we were only including Specimen.note for `no` answers, this prevented updates for when it gets changed from `no` to `yes` (since we concatenate `sample.details`)

Noticed this because currently we have more `never-tested` samples within `warehouse.sample` than records marked `able_to_test: no` in REDCap. 