### PR TITLE
REDCap DET: Support multiple SCAN projects, one per language

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -494,7 +494,7 @@ def canonicalize_name(*parts: Iterable[str]) -> str:
 
     >>> canonicalize_name("`1234567890-=~!@#$%^&*()_+")
     '1234567890'
-    >>> canonicalize_name("qwertyuiop[]\\QWERTYUIOP{}|")
+    >>> canonicalize_name("qwertyuiop[]\\\\QWERTYUIOP{}|")
     'QWERTYUIOPQWERTYUIOP'
     >>> canonicalize_name("asdfghjkl;'ASDFGHJKL:\\"")
     'ASDFGHJKLASDFGHJKL'

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -29,6 +29,9 @@ class ScanProject(NamedTuple):
 
 PROJECTS = [
     ScanProject(20759, "en"),
+    ScanProject(21520, "es"),
+    ScanProject(21512, "vi"),
+    ScanProject(21514, "zh-Hans"),
 ]
 
 REVISION = 7

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -49,10 +49,15 @@ REQUIRED_INSTRUMENTS = [
 ]
 
 
+# A decorator lets us keep command registration up here at the top, instead of
+# moving the loop after the definition of redcap_det_scan().
+#
 def command_for_each_project(function):
     """
     A decorator to register one redcap-det subcommand per SCAN project, each
     calling the same base *function*.
+
+    Used for side-effects only; the original *function* is unmodified.
     """
     for project in PROJECTS:
         redcap_det.command_for_project(

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     python_requires = ">=3.6",
 
     install_requires = [
-        "id3c >=2020.1",
+        "id3c >=2020.2",
         "click >=7.0",
         "regex",
         "requests",


### PR DESCRIPTION
Adds the following commands:

```
id3c etl redcap-det scan-es
id3c etl redcap-det scan-vi
id3c etl redcap-det scan-zh-Hans
```

Details in the commit messages. Requires https://github.com/seattleflu/id3c/pull/147.

~I've not yet fully tested this locally on a fresh copy of the database, but that's in progress. However, type checks and our (minimal) tests pass and it works as expected on an older database copy.~ Tested locally and seems good to me. Travis checks are failing because I haven't yet released the core ID3C change.