### PR TITLE
etl redcap-det scan: Add zh-Hant to project list

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -32,6 +32,7 @@ PROJECTS = [
     ScanProject(21520, "es"),
     ScanProject(21512, "vi"),
     ScanProject(21514, "zh-Hans"),
+    ScanProject(21521, "zh-Hant"),
 ]
 
 REVISION = 8


### PR DESCRIPTION
Add traditional Chinese (zh-Hant) to the list of REDCap SCAN projects to
ingest.