### PR TITLE
etl redcap-det scan: Add so, ko, ru projects

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -33,6 +33,9 @@ PROJECTS = [
     ScanProject(21512, "vi"),
     ScanProject(21514, "zh-Hans"),
     ScanProject(21521, "zh-Hant"),
+    ScanProject(21809, "so"),
+    ScanProject(21810, "ko"),
+    ScanProject(21808, "ru"),
 ]
 
 REVISION = 9


### PR DESCRIPTION
Add Somali (so), Korean, (ko), and Russian (ru) REDCap SCAN projects to
the list of projects we're ingesting into ID3C.