### PR TITLE
etl redcap-det scan: Add tl, am, ti to projects

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -36,6 +36,10 @@ PROJECTS = [
     ScanProject(21809, "so"),
     ScanProject(21810, "ko"),
     ScanProject(21808, "ru"),
+    ScanProject(21953, "tl"),
+    ScanProject(21950, "am"),
+    ScanProject(21951, "ti"),
+
 ]
 
 REVISION = 9


### PR DESCRIPTION
Add Tagalog, Amharic, and Tigrinya to the list of REDCap SCAN projects
to ingest.