### PR TITLE
etl redcap-det scan: skip "false" enrollments

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -102,7 +102,7 @@ def redcap_det_scan(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_r
     # By verifying illness_questionnaire is complete first, we minimize the
     # delay in data ingestion since the back_end_mail_scans is completed the day after enrollment.
     #   -Jover, 29 June 2020
-    if not redcap_record['illness_q_date'] and redcap_record['back_end_mail_scans_complete'] != '2':
+    if not redcap_record['illness_q_date'] and not is_complete('back_end_mail_scans', redcap_record):
         LOG.debug("Skipping incomplete enrollment")
         return None
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -46,7 +46,7 @@ PROJECTS = [
 
 ]
 
-REVISION = 12
+REVISION = 13
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -93,6 +93,19 @@ def command_for_each_project(function):
 
 @command_for_each_project
 def redcap_det_scan(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
+    # Skip record if the illness_questionnaire is not complete, because this is
+    # a "false" enrollment where the participant was not mailed a swab kit.
+    # We must verify illness_questionnaire with the `illness_q_date` field
+    # since there is a bug in REDCap that sometimes leaves the questionnaire marked incomplete/unverified.
+    # We must have another check of the back_end_mail_scans because sometimes
+    # the `illness_q_date` field is not filled in due to a bug in REDCap.
+    # By verifying illness_questionnaire is complete first, we minimize the
+    # delay in data ingestion since the back_end_mail_scans is completed the day after enrollment.
+    #   -Jover, 29 June 2020
+    if not redcap_record['illness_q_date'] and redcap_record['back_end_mail_scans_complete'] != '2':
+        LOG.debug("Skipping incomplete enrollment")
+        return None
+
     site_reference = create_site_reference()
     location_resource_entries = locations(db, cache, redcap_record)
     patient_entry, patient_reference = create_patient(redcap_record)


### PR DESCRIPTION
The study only wants us to ingest "true" enrollments where a participant
was mailed a swab kit. "True" enrollments can be identified by the
participant completing the illness_questionnaire. However, there is
a bug in REDCap that sometimes leaves the instrument marked as
incomplete/unverified. To get around this, we are checking that the
`illness_q_date` is filled in to verify that the instrument is complete.
However, there is yet another bug in REDCap that sometimes leaves the
`illness_q_date` blank. To catch these records, we are also checking
that the back_end_mail_scans instrument is complete.

This leaves us with a majority of records being ingested the day of
enrollment due to the completion of the `illness_q_date` and some
straggling records ingested the day after enrollment where the
back_end_mail_scans instrument is complete.

---
TODO:
- [x] test locally after latest database dump
- [ ] delete "false" encounters currently in ID3C before deployment