### PR TITLE
Views for Power BI Dashboard

### DIFF
--- a/lib/seattleflu/id3c/api/routes.py
+++ b/lib/seattleflu/id3c/api/routes.py
@@ -90,3 +90,42 @@ def get_genomic_data(lineage, segment, session):
     sequences = datastore.fetch_genomic_sequences(session, lineage, segment)
 
     return Response((row[0] + '\n' for row in sequences), mimetype="application/x-ndjson")
+
+
+@api_v1.route("/shipping/scan-demographics", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_scan_demographics(session):
+    """
+    Export basic demographics for SCAN
+    """
+    LOG.debug("Exporting demographics for SCAN")
+
+    demographics = datastore.fetch_rows_from_table(session, ("shipping", "scan_demographics_v1"))
+
+    return Response((row[0] + '\n' for row in demographics), mimetype="application/x-ndjson")
+
+
+@api_v1.route("/shipping/scan-hcov19-positives", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_scan_positives(session):
+    """
+    Export aggregate numbers of hCoV-19 positives for SCAN
+    """
+    LOG.debug("Exporting hCoV-19 positives for SCAN")
+
+    positives = datastore.fetch_rows_from_table(session, ("shipping", "scan_hcov19_positives_v1"))
+
+    return Response((row[0] + '\n' for row in positives), mimetype="application/x-ndjson")
+
+
+@api_v1.route("/shipping/scan-enrollments", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_scan_positives(session):
+    """
+    Export basic enrollment metadata for SCAN
+    """
+    LOG.debug("Exporting enrollment metadata for SCAN")
+
+    enrollments = datastore.fetch_rows_from_table(session, ("shipping", "scan_enrollments_v1"))
+
+    return Response((row[0] + '\n' for row in enrollments), mimetype="application/x-ndjson")

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -50,7 +50,7 @@ PROJECTS = [
 
 ]
 
-REVISION = 13
+REVISION = 14
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -639,6 +639,7 @@ def create_initial_questionnaire_response(record: dict, patient_reference: dict,
     ]
 
     date_questions = [
+        'illness_q_date',
         'hospital_arrive',
         'hospital_leave',
         'prior_test_positive_date',

--- a/schema/deploy/roles/scan-dashboard-exporter/create.sql
+++ b/schema/deploy/roles/scan-dashboard-exporter/create.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/id3c-customizations:roles/scan-dashboard-exporter/create to pg
+
+begin;
+
+create role "scan-dashboard-exporter";
+
+comment on role "scan-dashboard-exporter" is
+    'For exporting data for SCAN dashboards';
+
+commit;

--- a/schema/deploy/roles/scan-dashboard-exporter/grants.sql
+++ b/schema/deploy/roles/scan-dashboard-exporter/grants.sql
@@ -1,0 +1,17 @@
+-- Deploy seattleflu/id3c-customizations:roles/scan-dashboard-exporter/grants to pg
+-- requires: roles/scan-dashboard-exporter/create
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+revoke all on database :"DBNAME" from "scan-dashboard-exporter";
+revoke all on schema receiving, warehouse, shipping from "scan-dashboard-exporter";
+revoke all on all tables in schema receiving, warehouse, shipping from "scan-dashboard-exporter";
+
+grant connect on database :"DBNAME" to "scan-dashboard-exporter";
+
+grant usage
+    on schema shipping
+    to "scan-dashboard-exporter";
+
+commit;

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -1153,6 +1153,7 @@ create or replace view shipping.scan_encounters_v1 as
 
         encountered,
         to_char(encountered, 'IYYY-"W"IW') as encountered_week,
+        illness_questionnaire_date,
 
         site.identifier as site,
         site.details ->> 'type' as site_type,
@@ -1172,6 +1173,7 @@ create or replace view shipping.scan_encounters_v1 as
 
         location.hierarchy -> 'puma' as puma,
         location.hierarchy -> 'tract' as census_tract,
+        location.hierarchy -> 'neighborhood_district' as neighborhood_district,
 
         symptoms,
         symptom_onset,

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -565,6 +565,13 @@ create or replace view shipping.fhir_encounter_details_v2 as
                  string_response as industry
             from shipping.fhir_questionnaire_responses_v1
           where link_id = 'industry'
+        ),
+
+        illness_questionnaire_date as (
+          select encounter_id,
+                 date_response[1] as illness_questionnaire_date
+            from shipping.fhir_questionnaire_responses_v1
+          where link_id = 'illness_q_date'
         )
 
     select
@@ -614,7 +621,8 @@ create or replace view shipping.fhir_encounter_details_v2 as
         distance,
         attend_event,
         wfh,
-        industry
+        industry,
+        illness_questionnaire_date
 
       from warehouse.encounter
       left join scan_study_arm using (encounter_id)
@@ -660,6 +668,7 @@ create or replace view shipping.fhir_encounter_details_v2 as
       left join attend_event using (encounter_id)
       left join wfh using (encounter_id)
       left join industry using (encounter_id)
+      left join illness_questionnaire_date using (encounter_id)
   ;
 comment on view shipping.fhir_encounter_details_v2 is
   'A v2 view of encounter details that are in FHIR format that includes all SCAN questionnaire answers';

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -15,6 +15,8 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_demographics_v1;
+
 drop view if exists shipping.scan_return_results_v1;
 drop view if exists shipping.return_results_v2;
 drop view if exists shipping.return_results_v1;
@@ -2130,5 +2132,34 @@ grant select
 
 comment on view shipping.scan_return_results_v1 is
   'View of barcodes and presence/absence results for SCAN return of results on the UW Lab Med site';
+
+
+/******************** VIEWS FOR POWER BI DASHBOARDS ********************/
+create or replace view shipping.scan_demographics_v1 as
+
+    select
+        encountered_week,
+        sex,
+        age_range_fine,
+        age_range_fine_lower,
+        age_range_fine_upper,
+        race,
+        hispanic_or_latino,
+        income,
+        puma
+    from shipping.scan_encounters_v1
+;
+
+comment on view shipping.scan_demographics_v1 is
+  'A view of basic demographic data from the SCAN project for Power BI dashboards.';
+
+revoke all
+    on shipping.scan_demographics_v1
+  from "scan-dashboard-exporter";
+
+grant select
+    on shipping.scan_demographics_v1
+    to "scan-dashboard-exporter";
+
 
 commit;

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_hcov19_positives_v1;
 drop view if exists shipping.scan_demographics_v1;
 
 drop view if exists shipping.scan_return_results_v1;
@@ -2159,6 +2160,96 @@ revoke all
 
 grant select
     on shipping.scan_demographics_v1
+    to "scan-dashboard-exporter";
+
+
+create or replace view shipping.scan_hcov19_positives_v1 as
+
+    with hcov19_presence_absence as (
+        -- Collapse potentially multiple hCoV-19 results
+        select distinct on (sample_id)
+            sample.identifier as sample,
+            presence_absence_id,
+            pa.present as hcov19_present,
+            pa.created::date as hcov19_result_release_date
+        from
+            warehouse.presence_absence as pa
+            join warehouse.target using (target_id)
+            join warehouse.organism using (organism_id)
+            join warehouse.sample using (sample_id)
+        where
+            organism.lineage <@ 'Human_coronavirus.2019'
+            and pa.details @> '{"assay_type": "Clia"}'
+            and not control
+            -- We shouldn't be receiving these results from Samplify, but they
+            -- sometimes sneak in. Be sure to block them from this view so as
+            -- to not return inaccurate results to participants.
+            and target.identifier not in ('COVID-19_Orf1b', 'COVID-19-S_gene')
+        /*
+          Keep only the most recent push. According to Lea, samples are only
+          retested if there is a failed result. A positive, negative, or
+          indeterminate result would not be retested.
+
+          https://seattle-flu-study.slack.com/archives/CV1E2BC8N/p1584570226450500?thread_ts=1584569401.449800&cid=CV1E2BC8N
+        */
+        order by
+            sample_id, presence_absence_id desc
+    ),
+
+    scan_hcov19_results as (
+      select
+          case
+              when hcov19_present is true then 'positive'
+              when hcov19_present is false then 'negative'
+              when hcov19_present is null then 'inconclusive'
+          end as hcov19_result,
+          hcov19_result_release_date,
+          case
+              when puma in ('5310901', '5310902') then 'yakima'
+              when puma in ('5311701', '5311702', '5311703',
+                            '5311704', '5311705', '5311706') then 'snohomish'
+              when puma in ('5311601', '5311602', '5311603', '5311604',
+                            '5311605', '5311606', '5311607', '5311608',
+                            '5311609', '5311610', '5311611', '5311612',
+                            '5311613', '5311614', '5311615', '5311616') then 'king'
+              else null
+          end as county
+
+      from shipping.scan_encounters_v1
+      join hcov19_presence_absence using (sample)
+
+    )
+
+    select
+        hcov19_result_release_date,
+        count(*) filter (where hcov19_result in ('positive', 'inconclusive')) as total_hcov19_positives,
+        count(*) filter (where hcov19_result in ('positive', 'inconclusive') and county = 'king') as king_county_positives,
+        count(*) filter (where hcov19_result in ('positive', 'inconclusive') and county = 'snohomish') as snohomish_county_positives,
+        count(*) filter (where hcov19_result in ('positive', 'inconclusive') and county = 'yakima') as yakima_county_positives,
+        count(*) filter (where hcov19_result in ('positive', 'inconclusive') and county is null) as other_positives
+    from scan_hcov19_results
+    group by hcov19_result_release_date
+;
+
+comment on view shipping.scan_hcov19_positives_v1 is
+  'A view of counts of hcov19 positives from the SCAN project grouped by date results were released.';
+
+-- Even if it's just aggregate counts of hcov19 positives,
+-- we should probably restrict access to this view to only hcov19-visibility
+-- and scan-dashboard-exporter.
+--  -Jover, 9 July 2020
+revoke all on shipping.scan_return_results_v1 from reporter;
+
+grant select
+    on shipping.scan_return_results_v1
+    to "hcov19-visibility";
+
+revoke all
+    on shipping.scan_hcov19_positives_v1
+  from "scan-dashboard-exporter";
+
+grant select
+    on shipping.scan_hcov19_positives_v1
     to "scan-dashboard-exporter";
 
 

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_enrollments_v1;
 drop view if exists shipping.seattle_neighborhood_districts_v1;
 drop view if exists shipping.scan_hcov19_positives_v1;
 drop view if exists shipping.scan_demographics_v1;
@@ -2285,6 +2286,30 @@ revoke all
 
 grant select
     on shipping.seattle_neighborhood_districts_v1
+    to "scan-dashboard-exporter";
+
+
+create or replace view shipping.scan_enrollments_v1 as
+
+    select
+        illness_questionnaire_date,
+        scan_study_arm,
+        priority_code,
+        puma,
+        neighborhood_district
+
+    from shipping.scan_encounters_v1
+;
+
+comment on view shipping.scan_enrollments_v1 is
+  'A view of enrollment data from the SCAN project for Power BI dashboards';
+
+revoke all
+    on shipping.scan_enrollments_v1
+  from "scan-dashboard-exporter";
+
+grant select
+    on shipping.scan_enrollments_v1
     to "scan-dashboard-exporter";
 
 commit;

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.seattle_neighborhood_districts_v1;
 drop view if exists shipping.scan_hcov19_positives_v1;
 drop view if exists shipping.scan_demographics_v1;
 
@@ -2263,5 +2264,27 @@ grant select
     on shipping.scan_hcov19_positives_v1
     to "scan-dashboard-exporter";
 
+
+create or replace view shipping.seattle_neighborhood_districts_v1 as
+
+    select
+        identifier,
+        st_assvg(point, rel=>1, maxdecimaldigits=>5) as centroid,
+        st_assvg(polygon, rel=>1, maxdecimaldigits=>5) as svg_path
+    from warehouse.location
+    where scale = 'neighborhood_district'
+    and hierarchy -> 'city' = 'seattle'
+;
+
+comment on view shipping.seattle_neighborhood_districts_v1 is
+  'A view of Seattle neighborhood district polygons as SVG paths';
+
+revoke all
+    on shipping.seattle_neighborhood_districts_v1
+  from "scan-dashboard-exporter";
+
+grant select
+    on shipping.seattle_neighborhood_districts_v1
+    to "scan-dashboard-exporter";
 
 commit;

--- a/schema/deploy/shipping/views@2020-06-15.sql
+++ b/schema/deploy/shipping/views@2020-06-15.sql
@@ -15,32 +15,32 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
-drop view if exists shipping.scan_return_results_v1;
-drop view if exists shipping.return_results_v2;
-drop view if exists shipping.return_results_v1;
-drop view if exists shipping.reportable_condition_v1;
+drop view shipping.scan_return_results_v1;
+drop view shipping.return_results_v2;
+drop view shipping.return_results_v1;
+drop view shipping.reportable_condition_v1;
 
-drop view if exists shipping.metadata_for_augur_build_v3;
-drop view if exists shipping.metadata_for_augur_build_v2;
-drop view if exists shipping.genomic_sequences_for_augur_build_v1;
-drop view if exists shipping.flu_assembly_jobs_v1;
+drop view shipping.metadata_for_augur_build_v3;
+drop view shipping.metadata_for_augur_build_v2;
+drop view shipping.genomic_sequences_for_augur_build_v1;
+drop view shipping.flu_assembly_jobs_v1;
 
-drop view if exists shipping.scan_follow_up_encounters_v1;
-drop view if exists shipping.scan_encounters_v1;
-drop view if exists shipping.hcov19_observation_v1;
+drop view shipping.scan_follow_up_encounters_v1;
+drop view shipping.scan_encounters_v1;
+drop view shipping.hcov19_observation_v1;
 
-drop view if exists shipping.observation_with_presence_absence_result_v2;
-drop view if exists shipping.observation_with_presence_absence_result_v1;
+drop view shipping.observation_with_presence_absence_result_v2;
+drop view shipping.observation_with_presence_absence_result_v1;
 
-drop view if exists shipping.incidence_model_observation_v3;
-drop view if exists shipping.incidence_model_observation_v2;
-drop view if exists shipping.incidence_model_observation_v1;
+drop view shipping.incidence_model_observation_v3;
+drop view shipping.incidence_model_observation_v2;
+drop view shipping.incidence_model_observation_v1;
 
-drop view if exists shipping.fhir_encounter_details_v2;
-drop view if exists shipping.fhir_encounter_details_v1;
-drop materialized view if exists shipping.fhir_questionnaire_responses_v1;
+drop view shipping.fhir_encounter_details_v2;
+drop view shipping.fhir_encounter_details_v1;
+drop materialized view shipping.fhir_questionnaire_responses_v1;
 
-drop view if exists shipping.sample_with_best_available_encounter_data_v1;
+drop view shipping.sample_with_best_available_encounter_data_v1;
 
 /******************** VIEWS FOR INTERNAL USE ********************/
 create or replace view shipping.sample_with_best_available_encounter_data_v1 as

--- a/schema/revert/roles/scan-dashboard-exporter/create.sql
+++ b/schema/revert/roles/scan-dashboard-exporter/create.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/id3c-customizations:roles/scan-dashboard-exporter/create from pg
+
+begin;
+
+drop role "scan-dashboard-exporter";
+
+commit;

--- a/schema/revert/roles/scan-dashboard-exporter/grants.sql
+++ b/schema/revert/roles/scan-dashboard-exporter/grants.sql
@@ -1,0 +1,11 @@
+-- Revert seattleflu/id3c-customizations:roles/scan-dashboard-exporter/grants from pg
+-- requires: roles/scan-dashboard-exporter/create
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+revoke all on database :"DBNAME" from "scan-dashboard-exporter";
+revoke all on schema receiving, warehouse, shipping from "scan-dashboard-exporter";
+revoke all on all tables in schema receiving, warehouse, shipping from "scan-dashboard-exporter";
+
+commit;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -15,6 +15,8 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_demographics_v1;
+
 drop view if exists shipping.scan_return_results_v1;
 drop view if exists shipping.return_results_v2;
 drop view if exists shipping.return_results_v1;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_enrollments_v1;
 drop view if exists shipping.seattle_neighborhood_districts_v1;
 drop view if exists shipping.scan_hcov19_positives_v1;
 drop view if exists shipping.scan_demographics_v1;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -15,32 +15,32 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
-drop view shipping.scan_return_results_v1;
-drop view shipping.return_results_v2;
-drop view shipping.return_results_v1;
-drop view shipping.reportable_condition_v1;
+drop view if exists shipping.scan_return_results_v1;
+drop view if exists shipping.return_results_v2;
+drop view if exists shipping.return_results_v1;
+drop view if exists shipping.reportable_condition_v1;
 
-drop view shipping.metadata_for_augur_build_v3;
-drop view shipping.metadata_for_augur_build_v2;
-drop view shipping.genomic_sequences_for_augur_build_v1;
-drop view shipping.flu_assembly_jobs_v1;
+drop view if exists shipping.metadata_for_augur_build_v3;
+drop view if exists shipping.metadata_for_augur_build_v2;
+drop view if exists shipping.genomic_sequences_for_augur_build_v1;
+drop view if exists shipping.flu_assembly_jobs_v1;
 
-drop view shipping.scan_follow_up_encounters_v1;
-drop view shipping.scan_encounters_v1;
-drop view shipping.hcov19_observation_v1;
+drop view if exists shipping.scan_follow_up_encounters_v1;
+drop view if exists shipping.scan_encounters_v1;
+drop view if exists shipping.hcov19_observation_v1;
 
-drop view shipping.observation_with_presence_absence_result_v2;
-drop view shipping.observation_with_presence_absence_result_v1;
+drop view if exists shipping.observation_with_presence_absence_result_v2;
+drop view if exists shipping.observation_with_presence_absence_result_v1;
 
-drop view shipping.incidence_model_observation_v3;
-drop view shipping.incidence_model_observation_v2;
-drop view shipping.incidence_model_observation_v1;
+drop view if exists shipping.incidence_model_observation_v3;
+drop view if exists shipping.incidence_model_observation_v2;
+drop view if exists shipping.incidence_model_observation_v1;
 
-drop view shipping.fhir_encounter_details_v2;
-drop view shipping.fhir_encounter_details_v1;
-drop materialized view shipping.fhir_questionnaire_responses_v1;
+drop view if exists shipping.fhir_encounter_details_v2;
+drop view if exists shipping.fhir_encounter_details_v1;
+drop materialized view if exists shipping.fhir_questionnaire_responses_v1;
 
-drop view shipping.sample_with_best_available_encounter_data_v1;
+drop view if exists shipping.sample_with_best_available_encounter_data_v1;
 
 /******************** VIEWS FOR INTERNAL USE ********************/
 create or replace view shipping.sample_with_best_available_encounter_data_v1 as
@@ -1042,6 +1042,7 @@ create or replace view shipping.hcov19_observation_v1 as
         best_available_site as site,
         best_available_site_type as site_type,
 
+        location.hierarchy->'tract' as census_tract,
         location.hierarchy->'puma' as puma,
         case location.scale
           -- Only include address identifiers as those are used to identify
@@ -1158,6 +1159,7 @@ create or replace view shipping.scan_encounters_v1 as
         age_in_years(upper(age_bin_coarse_v2.range)) as age_range_coarse_upper,
 
         location.hierarchy -> 'puma' as puma,
+        location.hierarchy -> 'tract' as census_tract,
 
         symptoms,
         symptom_onset,

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_hcov19_positives_v1;
 drop view if exists shipping.scan_demographics_v1;
 
 drop view if exists shipping.scan_return_results_v1;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.seattle_neighborhood_districts_v1;
 drop view if exists shipping.scan_hcov19_positives_v1;
 drop view if exists shipping.scan_demographics_v1;
 

--- a/schema/revert/shipping/views@2020-06-15.sql
+++ b/schema/revert/shipping/views@2020-06-15.sql
@@ -15,32 +15,32 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
-drop view if exists shipping.scan_return_results_v1;
-drop view if exists shipping.return_results_v2;
-drop view if exists shipping.return_results_v1;
-drop view if exists shipping.reportable_condition_v1;
+drop view shipping.scan_return_results_v1;
+drop view shipping.return_results_v2;
+drop view shipping.return_results_v1;
+drop view shipping.reportable_condition_v1;
 
-drop view if exists shipping.metadata_for_augur_build_v3;
-drop view if exists shipping.metadata_for_augur_build_v2;
-drop view if exists shipping.genomic_sequences_for_augur_build_v1;
-drop view if exists shipping.flu_assembly_jobs_v1;
+drop view shipping.metadata_for_augur_build_v3;
+drop view shipping.metadata_for_augur_build_v2;
+drop view shipping.genomic_sequences_for_augur_build_v1;
+drop view shipping.flu_assembly_jobs_v1;
 
-drop view if exists shipping.scan_follow_up_encounters_v1;
-drop view if exists shipping.scan_encounters_v1;
-drop view if exists shipping.hcov19_observation_v1;
+drop view shipping.scan_follow_up_encounters_v1;
+drop view shipping.scan_encounters_v1;
+drop view shipping.hcov19_observation_v1;
 
-drop view if exists shipping.observation_with_presence_absence_result_v2;
-drop view if exists shipping.observation_with_presence_absence_result_v1;
+drop view shipping.observation_with_presence_absence_result_v2;
+drop view shipping.observation_with_presence_absence_result_v1;
 
-drop view if exists shipping.incidence_model_observation_v3;
-drop view if exists shipping.incidence_model_observation_v2;
-drop view if exists shipping.incidence_model_observation_v1;
+drop view shipping.incidence_model_observation_v3;
+drop view shipping.incidence_model_observation_v2;
+drop view shipping.incidence_model_observation_v1;
 
-drop view if exists shipping.fhir_encounter_details_v2;
-drop view if exists shipping.fhir_encounter_details_v1;
-drop materialized view if exists shipping.fhir_questionnaire_responses_v1;
+drop view shipping.fhir_encounter_details_v2;
+drop view shipping.fhir_encounter_details_v1;
+drop materialized view shipping.fhir_questionnaire_responses_v1;
 
-drop view if exists shipping.sample_with_best_available_encounter_data_v1;
+drop view shipping.sample_with_best_available_encounter_data_v1;
 
 /******************** VIEWS FOR INTERNAL USE ********************/
 create or replace view shipping.sample_with_best_available_encounter_data_v1 as
@@ -1042,7 +1042,6 @@ create or replace view shipping.hcov19_observation_v1 as
         best_available_site as site,
         best_available_site_type as site_type,
 
-        location.hierarchy->'tract' as census_tract,
         location.hierarchy->'puma' as puma,
         case location.scale
           -- Only include address identifiers as those are used to identify
@@ -1159,7 +1158,6 @@ create or replace view shipping.scan_encounters_v1 as
         age_in_years(upper(age_bin_coarse_v2.range)) as age_range_coarse_upper,
 
         location.hierarchy -> 'puma' as puma,
-        location.hierarchy -> 'tract' as census_tract,
 
         symptoms,
         symptom_onset,

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -194,3 +194,4 @@ shipping/views [shipping/views@2020-06-10] 2020-06-15T20:52:16Z Kairsten Fay <kf
 @2020-06-15 2020-06-15T20:54:12Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 15 Jun 2020
 
 roles/scan-dashboard-exporter/create 2020-07-09T19:58:57Z Jover Lee <joverlee@fredhutch.org> # Role for exporting data for SCAN dashboards
+roles/scan-dashboard-exporter/grants [roles/scan-dashboard-exporter/create seattleflu/schema:shipping/schema] 2020-07-09T21:44:11Z Jover Lee <joverlee@fredhutch.org> # Add basic grants to scan-dashboard-exporter role

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -195,3 +195,4 @@ shipping/views [shipping/views@2020-06-10] 2020-06-15T20:52:16Z Kairsten Fay <kf
 
 roles/scan-dashboard-exporter/create 2020-07-09T19:58:57Z Jover Lee <joverlee@fredhutch.org> # Role for exporting data for SCAN dashboards
 roles/scan-dashboard-exporter/grants [roles/scan-dashboard-exporter/create seattleflu/schema:shipping/schema] 2020-07-09T21:44:11Z Jover Lee <joverlee@fredhutch.org> # Add basic grants to scan-dashboard-exporter role
+shipping/views [shipping/views@2020-06-15] 2020-07-09T20:06:18Z Jover Lee <joverlee@fredhutch.org> # Add new views for Power BI

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -196,3 +196,4 @@ shipping/views [shipping/views@2020-06-10] 2020-06-15T20:52:16Z Kairsten Fay <kf
 roles/scan-dashboard-exporter/create 2020-07-09T19:58:57Z Jover Lee <joverlee@fredhutch.org> # Role for exporting data for SCAN dashboards
 roles/scan-dashboard-exporter/grants [roles/scan-dashboard-exporter/create seattleflu/schema:shipping/schema] 2020-07-09T21:44:11Z Jover Lee <joverlee@fredhutch.org> # Add basic grants to scan-dashboard-exporter role
 shipping/views [shipping/views@2020-06-15] 2020-07-09T20:06:18Z Jover Lee <joverlee@fredhutch.org> # Add new views for Power BI
+@2020-07-13 2020-07-13T23:42:15Z Jover Lee <joverlee@fredhutch.org> # Schema as of 13 July 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -192,3 +192,5 @@ shipping/views [shipping/views@2020-06-09] 2020-06-10T17:07:09Z Jover Lee <jover
 
 shipping/views [shipping/views@2020-06-10] 2020-06-15T20:52:16Z Kairsten Fay <kfay@fredhutch.org> # Add census tract to SCAN encounters
 @2020-06-15 2020-06-15T20:54:12Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 15 Jun 2020
+
+roles/scan-dashboard-exporter/create 2020-07-09T19:58:57Z Jover Lee <joverlee@fredhutch.org> # Role for exporting data for SCAN dashboards

--- a/schema/verify/roles/scan-dashboard-exporter/create.sql
+++ b/schema/verify/roles/scan-dashboard-exporter/create.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/id3c-customizations:roles/scan-dashboard-exporter/create on pg
+
+begin;
+
+-- No real need to test that the user was created; the database would have
+-- thrown an error if it wasn't.
+
+rollback;

--- a/schema/verify/roles/scan-dashboard-exporter/grants.sql
+++ b/schema/verify/roles/scan-dashboard-exporter/grants.sql
@@ -1,0 +1,10 @@
+-- Verify seattleflu/id3c-customizations:roles/scan-dashboard-exporter/grants on pg
+-- requires: roles/scan-dashboard-exporter/create
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+select 1/pg_catalog.has_database_privilege('scan-dashboard-exporter', :'DBNAME', 'connect')::int;
+select 1/pg_catalog.has_schema_privilege('scan-dashboard-exporter', 'shipping', 'usage')::int;
+
+rollback;

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -114,4 +114,9 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.scan_demographics_v1');
 
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_hcov19_positives_v1');
+
 rollback;

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -109,4 +109,9 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.scan_follow_up_encounters_v1');
 
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_demographics_v1');
+
 rollback;

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -119,4 +119,9 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.scan_hcov19_positives_v1');
 
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.seattle_neighborhood_districts_v1');
+
 rollback;

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -124,4 +124,9 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.seattle_neighborhood_districts_v1');
 
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_enrollments_v1');
+
 rollback;

--- a/schema/verify/shipping/views@2020-06-15.sql
+++ b/schema/verify/shipping/views@2020-06-15.sql
@@ -1,0 +1,112 @@
+-- Verify seattleflu/id3c-customizations:shipping/views on pg
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.reportable_condition_v1');
+
+-- Verify that the view has been dropped
+select 1/(count(*) = 0)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.genomic_sequences_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.flu_assembly_jobs_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v1');
+
+select 1/(count(*) = 1)::int
+  from pg_matviews
+ where array[schemaname, matviewname]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_questionnaire_responses_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_encounter_details_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.sample_with_best_available_encounter_data_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_encounter_details_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.hcov19_observation_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_return_results_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_encounters_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_follow_up_encounters_v1');
+
+rollback;


### PR DESCRIPTION
Changes to set up the views for the public Power BI dashboard:
1. Ingest `illness_q_date` field from REDCap - this represents the "completed enrollment" date
2. Add a `power-bi-exporter` role to the database.
3. Add new views for the dashboard:
      - shipping.scan_demographics_v1
      - shipping.scan_hcov19_positives_v1
      - shipping.seattle_neighborhood_districts_v1
      - shipping.scan_enrollments_v1