### PR TITLE
etl redcap-det scan: Add SCAN kiosk project

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -595,7 +595,10 @@ def create_specimen(record: dict, patient_reference: dict) -> tuple:
     )
 
     # YYYY-MM-DD in REDCap
-    collected_time = record['collection_date'] or None
+    # The `collection_date` field is being removed from the SCAN REDCap projects
+    # on 22 July 2020.
+    #   -Jover, 16 July 2020.
+    collected_time = record.get('collection_date')
 
     # YYYY-MM-DD HH:MM:SS in REDCap
     # `samp_process_date`field does not exist in new SCAN In-Person Enrollments

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -62,7 +62,6 @@ LANGUAGE_CODE = {
 
 REQUIRED_INSTRUMENTS = [
     'consent_form',
-    'enrollment_questionnaire',
 ]
 
 
@@ -98,6 +97,15 @@ def command_for_each_project(function):
 
 @command_for_each_project
 def redcap_det_scan(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
+    # Add check for `enrollment_questionnaire` is complete because we cannot
+    # include it in the top list of REQUIRED_INSTRUMENTS since the new
+    # SCAN In-Person Enrollment project does not have this instrument.
+    #   -Jover, 17 July 2020
+    if ('enrollment_questionnaire_complete' in redcap_record and
+        not is_complete('enrollment_questionnaire', redcap_record)):
+        LOG.debug("Skipping enrollment with incomplete `enrollment_questionnaire` instrument")
+        return None
+
     # Skip record if the illness_questionnaire is not complete, because this is
     # a "false" enrollment where the participant was not mailed a swab kit.
     # We must verify illness_questionnaire with the `illness_q_date` field

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -732,8 +732,11 @@ def create_initial_questionnaire_response(record: dict, patient_reference: dict,
     record['state'] = combine_multiple_fields('state')
 
     # Age Ceiling
-    record['age'] = age_ceiling(int(record['age']))
-    record['age_months'] = age_ceiling(int(record['age_months']) / 12) * 12
+    try:
+        record['age'] = age_ceiling(int(record['age']))
+        record['age_months'] = age_ceiling(int(record['age_months']) / 12) * 12
+    except ValueError:
+        record['age'] = record['age_months'] = None
 
     return questionnaire_response(record, question_categories, patient_reference, encounter_reference)
 

--- a/schema/deploy/warehouse/site/data.sql
+++ b/schema/deploy/warehouse/site/data.sql
@@ -53,6 +53,8 @@ insert into warehouse.site(identifier, details)
         ('swabNSend',                               '{"category": "community",  "type": "swab-n-send",
             "swab_site": "swab_and_send"}'),
         ('UWDaycare',                               '{"category": "community",  "type": "childcare"}'),
+        ('UWGreek',                                 '{"category": "community",  "type": "collegeCampus",
+            "swab_site": "uw_greek"}'),
         ('UWHallHealth',                            '{"category": "clinic",     "type": "clinic",
             "swab_site": "hall_health"}'),
         ('UWSeaMar',                                '{"category": "clinic",     "type": "clinic",

--- a/schema/deploy/warehouse/site/data@2020-07-13.sql
+++ b/schema/deploy/warehouse/site/data@2020-07-13.sql
@@ -67,8 +67,4 @@ insert into warehouse.site(identifier, details)
         set details = EXCLUDED.details
 ;
 
-delete from warehouse.site
-    where identifier = 'UWGreek'
-;
-
 commit;

--- a/schema/revert/warehouse/site/data@2020-07-13.sql
+++ b/schema/revert/warehouse/site/data@2020-07-13.sql
@@ -28,8 +28,7 @@ insert into warehouse.site(identifier, details)
         ('HUB',                                     '{"category": "community",  "type": "collegeCampus",
             "swab_site": "hub"}'),
         ('HutchKids',                               '{"category": "community",  "type": "childcare"}'),
-        ('KaiserPermanente',                        '{"category": "clinic",     "type": "clinic",
-            "sample_origin": "kp"}'),
+        ('KaiserPermanente',                        '{"category": "clinic",     "type": "clinic"}'),
         ('KingStreetStation',                       '{"category": "community",  "type": "publicSpace",
             "swab_site": "king_street%"}'),
         ('PioneerSquare',                           '{"category": "clinic",     "type": "clinic"}'),
@@ -41,8 +40,7 @@ insert into warehouse.site(identifier, details)
             "sample_origin": "nwh_retro"}'),
         ('RetrospectiveUWMedicalCenter',            '{"category": "hospital",   "type": "retrospective",
             "sample_origin": "uwmc_retro"}'),
-        ('SCAN',                                    '{"category": "community", "type": "SCAN",
-            "sample_origin": "scan"}'),
+        ('SCAN',                                    '{"category": "community", "type": "SCAN"}'),
         ('SeaTacDomestic',                          '{"category": "community",  "type": "publicSpace",
             "swab_site": "seatac_airport"}'),
         ('SeaTacInternational',                     '{"category": "community",  "type": "publicSpace"}'),
@@ -65,10 +63,6 @@ insert into warehouse.site(identifier, details)
 
     on conflict (identifier) do update
         set details = EXCLUDED.details
-;
-
-delete from warehouse.site
-    where identifier = 'UWGreek'
 ;
 
 commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -199,3 +199,4 @@ shipping/views [shipping/views@2020-06-15] 2020-07-09T20:06:18Z Jover Lee <jover
 @2020-07-13 2020-07-13T23:42:15Z Jover Lee <joverlee@fredhutch.org> # Schema as of 13 July 2020
 
 warehouse/site/data [warehouse/site/data@2020-07-13] 2020-07-17T22:48:31Z Jover Lee <joverlee@fredhutch.org> # Add new UWGreek site
+@2020-07-17 2020-07-17T23:11:02Z Jover Lee <joverlee@fredhutch.org> # Schema as of 17 July 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -197,3 +197,5 @@ roles/scan-dashboard-exporter/create 2020-07-09T19:58:57Z Jover Lee <joverlee@fr
 roles/scan-dashboard-exporter/grants [roles/scan-dashboard-exporter/create seattleflu/schema:shipping/schema] 2020-07-09T21:44:11Z Jover Lee <joverlee@fredhutch.org> # Add basic grants to scan-dashboard-exporter role
 shipping/views [shipping/views@2020-06-15] 2020-07-09T20:06:18Z Jover Lee <joverlee@fredhutch.org> # Add new views for Power BI
 @2020-07-13 2020-07-13T23:42:15Z Jover Lee <joverlee@fredhutch.org> # Schema as of 13 July 2020
+
+warehouse/site/data [warehouse/site/data@2020-07-13] 2020-07-17T22:48:31Z Jover Lee <joverlee@fredhutch.org> # Add new UWGreek site

--- a/schema/verify/warehouse/site/data@2020-07-13.sql
+++ b/schema/verify/warehouse/site/data@2020-07-13.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/id3c-customizations:warehouse/site/data on pg
+-- requires: seattleflu/schema:warehouse/site
+
+begin;
+
+-- No need to verify data.
+
+rollback;


### PR DESCRIPTION
Includes updates to the ingest to use the get() method for fields that
do not exist in the new project.