### PR TITLE
etl redcap-det uw-retros: add discharge mapping for 'still a patient'

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -286,6 +286,7 @@ def discharge_disposition(redcap_record: dict) -> Optional[str]:
     Encounter.hospitalization.dischargeDisposition code
     (https://www.hl7.org/fhir/valueset-encounter-discharge-disposition.html)
     """
+
     disposition = redcap_record['discharge_disposition']
     if not disposition:
         return None
@@ -328,6 +329,7 @@ def discharge_disposition(redcap_record: dict) -> Optional[str]:
         'dis/trans: disch/trans to a distinct rehab unit/hospital': 'rehab',
         'snf-skilled nursing facility'                          : 'snf',
         'snf: snf-skilled nursing facility'                     : 'snf',
+        'still a patient'                                       : None,
     }
 
     standardized_disposition = standardize_whitespace(disposition.lower())


### PR DESCRIPTION
Add a new discharge disposition mapping to the REDCap DET ETL for UW
retrospective data. We received a value of "still a patient", for a
patient that was not actually discharged. We will map this value to
None as there is no matching FHIR code.