### PR TITLE
etl redcap-det uw-retros: add discharge mapping for organ donor

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -300,6 +300,7 @@ def discharge_disposition(redcap_record: dict) -> Optional[str]:
         'ama: against medical advice'                           : 'aadvice',
         'expired'                                               : 'exp',
         'expired: expired'                                      : 'exp',
+        'deceased - o: deceased - organ donor'                  : 'exp',
         'home health care'                                      : 'home',
         'home hlth: home health care'                           : 'home',
         'home/self care'                                        : 'home',


### PR DESCRIPTION
Add a new discharge disposition mapping to the REDCap DET ETL for UW
retrospective data. We received a value of "deceased - o: deceased -
organ donor", and will map this to an appropriate FHIR code.