### PR TITLE
Formative v2 API + internal dashboard API

### DIFF
--- a/lib/seattleflu/id3c/api/routes.py
+++ b/lib/seattleflu/id3c/api/routes.py
@@ -105,6 +105,19 @@ def get_scan_demographics(session):
     return Response((row[0] + '\n' for row in demographics), mimetype="application/x-ndjson")
 
 
+@api_v2.route("/shipping/scan-demographics", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_scan_demographics__v2(session):
+    """
+    Export basic demographics for SCAN
+    """
+    LOG.debug("Exporting demographics with COVID status for SCAN")
+
+    demographics = datastore.fetch_rows_from_table(session, ("shipping", "scan_demographics_v2"))
+
+    return Response((row[0] + '\n' for row in demographics), mimetype="application/x-ndjson")
+
+
 @api_v1.route("/shipping/scan-hcov19-positives", methods = ['GET'])
 @authenticated_datastore_session_required
 def get_scan_positives(session):
@@ -127,5 +140,18 @@ def get_scan_enrollments(session):
     LOG.debug("Exporting enrollment metadata for SCAN")
 
     enrollments = datastore.fetch_rows_from_table(session, ("shipping", "scan_enrollments_v1"))
+
+    return Response((row[0] + '\n' for row in enrollments), mimetype="application/x-ndjson")
+
+
+@api_v1.route("/shipping/scan-enrollments-internal", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_scan_enrollments_internal(session):
+    """
+    Export basic enrollment metadata for SCAN
+    """
+    LOG.debug("Exporting enrollment metadata for SCAN internal dashboard")
+
+    enrollments = datastore.fetch_rows_from_table(session, ("shipping", "scan_redcap_enrollments_v1"))
 
     return Response((row[0] + '\n' for row in enrollments), mimetype="application/x-ndjson")

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_redcap_enrollments_v1;
 drop view if exists shipping.scan_enrollments_v1;
 drop view if exists shipping.scan_hcov19_result_counts_v1;
 drop view if exists shipping.scan_demographics_v2;
@@ -2422,6 +2423,30 @@ revoke all
 
 grant select
     on shipping.scan_enrollments_v1
+    to "scan-dashboard-exporter";
+
+
+create or replace view shipping.scan_redcap_enrollments_v1 as
+
+    select
+        illness_questionnaire_date,
+        scan_study_arm,
+        puma,
+        age_range_fine,
+        age_range_fine_lower,
+        age_range_fine_upper
+    from shipping.scan_encounters_v1
+;
+
+comment on view shipping.scan_redcap_enrollments_v1 is
+  'A view of SCAN REDCap enrollments for internal Power BI dashboards';
+
+revoke all
+    on shipping.scan_redcap_enrollments_v1
+    from "scan-dashboard-exporter";
+
+grant select
+    on shipping.scan_redcap_enrollments_v1
     to "scan-dashboard-exporter";
 
 commit;

--- a/schema/deploy/shipping/views@2020-08-19.sql
+++ b/schema/deploy/shipping/views@2020-08-19.sql
@@ -30,8 +30,7 @@ drop view if exists shipping.genomic_sequences_for_augur_build_v1;
 drop view if exists shipping.flu_assembly_jobs_v1;
 
 drop view if exists shipping.scan_follow_up_encounters_v1;
-drop view if exists shipping.scan_encounters_v1; -- Delete in next rework -Jover, 19 August 2020
-drop materialized view if exists shipping.scan_encounters_v1;
+drop view if exists shipping.scan_encounters_v1;
 drop view if exists shipping.hcov19_observation_v1;
 
 drop view if exists shipping.observation_with_presence_absence_result_v2;
@@ -1146,7 +1145,7 @@ comment on view shipping.hcov19_observation_v1 is
   'Custom view of hCoV-19 samples with presence-absence results and best available encounter data';
 
 
-create materialized view shipping.scan_encounters_v1 as
+create or replace view shipping.scan_encounters_v1 as
 
     select
         encounter_id,
@@ -1172,10 +1171,6 @@ create materialized view shipping.scan_encounters_v1 as
         age_bin_coarse_v2.range as age_range_coarse,
         age_in_years(lower(age_bin_coarse_v2.range)) as age_range_coarse_lower,
         age_in_years(upper(age_bin_coarse_v2.range)) as age_range_coarse_upper,
-
-        age_bin_decade_v1.range as age_range_decade,
-        age_in_years(lower(age_bin_decade_v1.range)) as age_range_decade_lower,
-        age_in_years(upper(age_bin_decade_v1.range)) as age_range_decade_upper,
 
         location.hierarchy -> 'puma' as puma,
         location.hierarchy -> 'tract' as census_tract,
@@ -1233,7 +1228,6 @@ create materialized view shipping.scan_encounters_v1 as
     left join warehouse.location using (location_id)
     left join shipping.age_bin_fine_v2 on age_bin_fine_v2.range @> age
     left join shipping.age_bin_coarse_v2 on age_bin_coarse_v2.range @> age
-    left join shipping.age_bin_decade_v1 on age_bin_decade_v1.range @> age
     left join shipping.fhir_encounter_details_v2 using (encounter_id)
     left join warehouse.sample using (encounter_id)
     where site.identifier = 'SCAN'
@@ -1241,7 +1235,7 @@ create materialized view shipping.scan_encounters_v1 as
     and not encounter.details @> '{"reason": [{"system": "http://snomed.info/sct", "code": "390906007"}]}'
 ;
 
-comment on materialized view shipping.scan_encounters_v1 is
+comment on view shipping.scan_encounters_v1 is
   'A view of encounter data that are from the SCAN project';
 
 revoke all

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -30,7 +30,7 @@ drop view if exists shipping.genomic_sequences_for_augur_build_v1;
 drop view if exists shipping.flu_assembly_jobs_v1;
 
 drop view if exists shipping.scan_follow_up_encounters_v1;
-drop view if exists shipping.scan_encounters_v1;
+drop materialized view if exists shipping.scan_encounters_v1;
 drop view if exists shipping.hcov19_observation_v1;
 
 drop view if exists shipping.observation_with_presence_absence_result_v2;
@@ -2087,7 +2087,10 @@ create or replace view shipping.scan_return_results_v1 as
       select
         sample_id,
         barcode as qrcode,
-        encountered::date as collect_ts,
+        case when encountered::date >= '2020-08-19'
+            then collected
+            else encountered::date
+        end as collect_ts,
         sample.details @> '{"note": "never-tested"}' as never_tested,
         sample.details ->> 'swab_type' as swab_type,
         -- The identifier set of the sample's collection identifier determines

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -15,6 +15,7 @@ begin;
 
 -- Drop all views at the top in order of dependency so we don't have to
 -- worry about view dependencies when reworking view definitions.
+drop view if exists shipping.scan_redcap_enrollments_v1;
 drop view if exists shipping.scan_enrollments_v1;
 drop view if exists shipping.scan_hcov19_result_counts_v1;
 drop view if exists shipping.scan_demographics_v2;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -17,6 +17,7 @@ begin;
 -- worry about view dependencies when reworking view definitions.
 drop view if exists shipping.scan_enrollments_v1;
 drop view if exists shipping.scan_hcov19_result_counts_v1;
+drop view if exists shipping.scan_demographics_v2;
 drop view if exists shipping.scan_demographics_v1;
 
 drop view if exists shipping.scan_return_results_v1;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -214,3 +214,5 @@ shipping/views [shipping/views@2020-08-05] 2020-08-11T23:40:20Z Jover Lee <jover
 @2020-08-11 2020-08-12T00:41:32Z Jover Lee <joverlee@fredhutch.org> # Schema as of 11 August 2020
 shipping/views [shipping/views@2020-08-11] 2020-08-17T21:57:43Z Thomas Sibley <tsibley@fredhutch.org> # Use collected instead of encountered in SCAN return of results view
 @2020-08-19 2020-08-19T17:01:56Z Thomas Sibley <tsibley@fredhutch.org> # Schema as of 19 Aug 2020
+
+shipping/views [shipping/views@2020-08-19 seattleflu/schema:shipping/age-bin-decade] 2020-08-19T20:23:05Z Jover Lee <joverlee@fredhutch.org> # Update shipping views for Formative to include hcov19 result with demographics

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -216,3 +216,4 @@ shipping/views [shipping/views@2020-08-11] 2020-08-17T21:57:43Z Thomas Sibley <t
 @2020-08-19 2020-08-19T17:01:56Z Thomas Sibley <tsibley@fredhutch.org> # Schema as of 19 Aug 2020
 
 shipping/views [shipping/views@2020-08-19 seattleflu/schema:shipping/age-bin-decade] 2020-08-19T20:23:05Z Jover Lee <joverlee@fredhutch.org> # Update shipping views for Formative to include hcov19 result with demographics
+@2020-08-19b 2020-08-19T20:38:14Z Jover Lee <joverlee@fredhutch.org> # Schema as of later on 19 August 2020

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -117,6 +117,11 @@ select 1/(count(*) = 1)::int
 select 1/(count(*) = 1)::int
   from information_schema.views
  where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_demographics_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.scan_hcov19_result_counts_v1');
 
 select 1/(count(*) = 1)::int

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -129,4 +129,9 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.scan_enrollments_v1');
 
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_redcap_enrollments_v1');
+
 rollback;

--- a/schema/verify/shipping/views@2020-08-19.sql
+++ b/schema/verify/shipping/views@2020-08-19.sql
@@ -100,8 +100,8 @@ select 1/(count(*) = 1)::int
      = pg_catalog.parse_ident('shipping.scan_return_results_v1');
 
 select 1/(count(*) = 1)::int
-  from pg_matviews
- where array[schemaname, matviewname]::text[]
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.scan_encounters_v1');
 
 select 1/(count(*) = 1)::int


### PR DESCRIPTION
- Change `shipping.scan_encounters_v1` to a materialized view in order to speed up downstream queries
- Add `shipping.scan_demographics_v2`
- Add `shipping.scan_redcap_enrollments_v1`

Will add a new cronjob to backoffice to refresh the `shipping.scan_encounters_v1` view every 5 minutes. See https://github.com/seattleflu/backoffice/pull/73