### PR TITLE
etl: Create distinct code for having no symptoms

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
@@ -23,7 +23,7 @@ from . import race
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 1
+REVISION = 2
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -37,7 +37,7 @@ REQUIRED_INSTRUMENTS = [
 # REDCap DET records lacking this revision number in their log.  If a
 # change to the ETL routine necessitates re-processing all REDCap DET records,
 # this revision number should be incremented.
-REVISION = 4
+REVISION = 5
 
 
 @redcap_det.command_for_project(

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -51,7 +51,7 @@ PROJECTS = [
 
 ]
 
-REVISION = 15
+REVISION = 16
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -23,7 +23,7 @@ from . import race
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 1
+REVISION = 2
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -25,7 +25,7 @@ from . import race
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 3
+REVISION = 4
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
@@ -81,8 +81,8 @@ def map_symptom(symptom_name: str) -> Optional[str]:
         'eye':                                  'eyePain',
         'smell_taste':                          'lossOfSmellOrTaste',
         'other':                                'other',
-        'none':                                 None,
-        'none of the above':                    None
+        'none':                                 'none',
+        'none of the above':                    'none',
     }
 
     if symptom_name.lower() not in symptom_map:


### PR DESCRIPTION
Currently in ID3C, a `null` symptoms response captures both encounters
with asymptomatic participants as well as participants who did not fill
out the Illness Questionnaire. Instead of relying on a proxy field
like `illness_questionnaire_complete` or `illness_q_date` to determine
if a `null` symptoms response is indicative of an asymptomatic
participant or simply indicates missing data, create a new code to
distinguish the condition where a participant reports having no
symptoms.