### PR TITLE
Skip record with unmapped discharge value

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -182,7 +182,11 @@ def create_encounter(db: DatabaseSession,
     if not encounter_location_references:
         return None, None
 
-    hospitalization = create_encounter_hospitalization(record)
+    try:
+        hospitalization = create_encounter_hospitalization(record)
+    except UnknownHospitalDischargeDisposition as e:
+        LOG.warning(e)
+        return None, None
 
     encounter_date = record["collection_date"]
     if not encounter_date:
@@ -340,7 +344,8 @@ def discharge_disposition(redcap_record: dict) -> Optional[str]:
     standardized_disposition = standardize_whitespace(disposition.lower())
 
     if standardized_disposition not in mapper:
-        raise Exception(f"Unknown discharge disposition value «{standardized_disposition}».")
+        raise UnknownHospitalDischargeDisposition("Unknown discharge disposition value "
+            f"«{standardized_disposition}» for barcode «{redcap_record['barcode']}».")
 
     return mapper[standardized_disposition]
 
@@ -583,5 +588,12 @@ class UnknownSampleOrigin(ValueError):
     """
     Raised by :function: `create_encounter_location_references` if it finds
     a sample_origin that is not among a set of expected values
+    """
+    pass
+
+class UnknownHospitalDischargeDisposition(ValueError):
+    """
+    Raised by :function: `discharge_disposition` if it finds
+    a discharge disposition value that is not among a set of mapped values
     """
     pass


### PR DESCRIPTION
Before this change, an unmapped discharge disposition value would stop
the ETL process. With this change, we skip the problematic record and
continue processing.