### PR TITLE
etl redcap-det scan: normalize SCAN husky netids

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -1,0 +1,46 @@
+"""
+Functions shared by REDCap DET ETL
+"""
+from typing import Optional
+
+
+def normalize_net_id(net_id: str=None) -> Optional[str]:
+    """
+    If netid or UW email provided, return netid@washington.edu
+
+    >>> normalize_net_id('abcd')
+    'abcd@washington.edu'
+
+    >>> normalize_net_id('aBcD ')
+    'abcd@washington.edu'
+
+    >>> normalize_net_id('abcd@uw.edu')
+    'abcd@washington.edu'
+
+    >>> normalize_net_id('aBcD@u.washington.edu')
+    'abcd@washington.edu'
+
+    If missing netid or non-uw email provided, it cannot be normalized so return nothing
+    >>> normalize_net_id('notuw@gmail.com')
+    >>> normalize_net_id('nodomain@')
+    >>> normalize_net_id('multiple@at@signs')
+    >>> normalize_net_id()
+    >>> normalize_net_id('')
+    >>> normalize_net_id(' ')
+    """
+
+    if not net_id or net_id.isspace():
+        return None
+
+    net_id = net_id.strip().lower()
+
+    # if a uw email was entered, drop the domain before normalizing
+    if net_id.count('@') == 1:
+        net_id, domain = net_id.split('@')
+        if domain not in ['u.washington.edu', 'uw.edu']:
+            return None
+    elif net_id.count('@') > 1:
+        return None
+
+    username = f'{net_id}@washington.edu'
+    return username

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -17,6 +17,7 @@ from id3c.cli.command.de_identify import generate_hash
 from id3c.cli.redcap import is_complete, Record as REDCapRecord
 from seattleflu.id3c.cli.command import age_ceiling
 from .redcap_map import *
+from .redcap import *
 from .fhir import *
 from . import race, first_record_instance, required_instruments
 
@@ -470,14 +471,13 @@ def create_patient(record: REDCapRecord) -> tuple:
         'preferred': True # Assumes that the project language is the patient's preferred language
     }]
 
-    # Use the UW NetID to generate patient id if it's available.
+    # Use the UW NetID and domain to generate patient id, if it's available.
     # This is the stable identifier that can allow us to match UW reopening
     # participants.
     #   -Jover, 04 September 2020
-    net_id = record.get('netid')
-    net_id = net_id.strip().lower() if net_id else None
-    if net_id:
-        patient_id = generate_hash(net_id)
+    uw_username = normalize_net_id(record.get('netid'))
+    if uw_username:
+        patient_id = generate_hash(uw_username)
     else:
         patient_id = generate_patient_hash(
             names       = (record['participant_first_name'], record['participant_last_name']),


### PR DESCRIPTION
Normalize netids and add @washington.edu domain before hashing for patient_id.
The netids coming from redcap sometimes have @uw.edu, and sometimes no suffix.
Normalizing helps standardize and also reduces potential future conflicts if we
hash other usernames.