### PR TITLE
etl redcap-det scan: Add PICAWA site

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -248,6 +248,7 @@ def site_map(record_location: str) -> str:
     """
     location_site_map = {
         'greek': 'UWGreek',
+        'PICAWA': 'PICAWA',
         'uw_study': 'UWClub',
     }
 


### PR DESCRIPTION
Add a new site for PICA-WA to the SCAN In-Person Enrollments project.