### PR TITLE
Encounter Provenance

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Union, T
 from datetime import datetime
 from cachetools import TTLCache
 from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
 from id3c.cli.command.etl import redcap_det
 from id3c.cli.command.geocode import get_response_from_cache_or_geocoding
 from id3c.cli.command.location import location_lookup
@@ -23,7 +24,7 @@ from . import race, first_record_instance, required_instruments
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 2
+REVISION = 3
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -48,7 +49,7 @@ REQUIRED_INSTRUMENTS = [
 
 @first_record_instance
 @required_instruments(REQUIRED_INSTRUMENTS)
-def redcap_det_asymptomatic_swab_n_send(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: dict) -> Optional[dict]:
+def redcap_det_asymptomatic_swab_n_send(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
     location_resource_entries = locations(db, cache, redcap_record)
     patient_entry, patient_reference = create_patient(redcap_record)
 
@@ -166,7 +167,7 @@ def create_patient(record: dict) -> tuple:
     return create_entry_and_reference(patient_resource, "Patient")
 
 
-def create_encounter(record: dict, patient_reference: dict, locations: list) -> tuple:
+def create_encounter(record: REDCapRecord, patient_reference: dict, locations: list) -> tuple:
     """ Returns a FHIR Encounter resource entry and reference """
 
     def grab_symptom_keys(key: str) -> Optional[Match[str]]:
@@ -225,6 +226,7 @@ def create_encounter(record: dict, patient_reference: dict, locations: list) -> 
     non_tract_references.append(site_reference)
 
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
@@ -24,7 +24,7 @@ from . import race, first_record_instance, required_instruments
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 3
+REVISION = 2
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any, List, Optional, Tuple, Dict
 from cachetools import TTLCache
 from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
 from id3c.cli.command.de_identify import generate_hash
 from id3c.cli.command.geocode import get_response_from_cache_or_geocoding
 from id3c.cli.command.location import location_lookup
@@ -37,7 +38,7 @@ REQUIRED_INSTRUMENTS = [
 # REDCap DET records lacking this revision number in their log.  If a
 # change to the ETL routine necessitates re-processing all REDCap DET records,
 # this revision number should be incremented.
-REVISION = 5
+REVISION = 6
 
 
 @redcap_det.command_for_project(
@@ -49,7 +50,7 @@ REVISION = 5
 
 @first_record_instance
 @required_instruments(REQUIRED_INSTRUMENTS)
-def redcap_det_kisok(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: dict) -> Optional[dict]:
+def redcap_det_kisok(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
     # XXX TODO: INCLUDE SPANISH RESPONSES
     if redcap_record['language_questions'] == 'Spanish':
         LOG.warning("Skipping enrollment because the Spanish questionnaire is not yet supported")
@@ -689,7 +690,7 @@ def determine_symptoms_codes(redcap_record: dict) -> Optional[dict]:
     return symptom_codes
 
 
-def create_encounter(redcap_record: dict,
+def create_encounter(redcap_record: REDCapRecord,
                      patient_reference: dict,
                      location_references: List[dict],
                      symptom_resources: Optional[List[dict]],
@@ -718,6 +719,7 @@ def create_encounter(redcap_record: dict,
     )
 
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(redcap_record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class,
         encounter_date = encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -94,9 +94,7 @@ def redcap_det_kisok(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_
         patient_reference
     )
 
-    encounter_id = '/'.join([REDCAP_URL.rstrip('/'), str(PROJECT_ID), redcap_record['record_id']])
     encounter_resource_entry, encounter_reference = create_encounter(
-        encounter_id,
         redcap_record,
         patient_reference,
         location_references,
@@ -691,8 +689,7 @@ def determine_symptoms_codes(redcap_record: dict) -> Optional[dict]:
     return symptom_codes
 
 
-def create_encounter(encounter_id: str,
-                     redcap_record: dict,
+def create_encounter(redcap_record: dict,
                      patient_reference: dict,
                      location_references: List[dict],
                      symptom_resources: Optional[List[dict]],
@@ -701,6 +698,7 @@ def create_encounter(encounter_id: str,
     Create FHIR encounter resource and encounter reference from given
     *redcap_record*.
     """
+    encounter_id = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}"
     enrollment_date = redcap_record.get('enrollment_date')
 
     if not enrollment_date:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -38,7 +38,7 @@ REQUIRED_INSTRUMENTS = [
 # REDCap DET records lacking this revision number in their log.  If a
 # change to the ETL routine necessitates re-processing all REDCap DET records,
 # this revision number should be incremented.
-REVISION = 6
+REVISION = 5
 
 
 @redcap_det.command_for_project(

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -54,7 +54,7 @@ PROJECTS = [
 
 ]
 
-REVISION = 17
+REVISION = 18
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -571,6 +571,7 @@ def create_initial_encounter(record: REDCapRecord, patient_reference: dict, site
     non_tract_references.append(site_reference)
 
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,
@@ -992,6 +993,7 @@ def create_follow_up_encounter(record: REDCapRecord,
     # YYYY-MM-DD HH:MM in REDCap
     encounter_date = record['fu_timestamp'].split()[0]
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -54,7 +54,7 @@ PROJECTS = [
 
 ]
 
-REVISION = 18
+REVISION = 17
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Union, T
 from datetime import datetime
 from cachetools import TTLCache
 from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
 from id3c.cli.command.etl import redcap_det
 from id3c.cli.command.geocode import get_response_from_cache_or_geocoding
 from id3c.cli.command.location import location_lookup
@@ -23,7 +24,7 @@ from . import race, first_record_instance, required_instruments
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 2
+REVISION = 3
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -48,7 +49,7 @@ REQUIRED_INSTRUMENTS = [
 
 @first_record_instance
 @required_instruments(REQUIRED_INSTRUMENTS)
-def redcap_det_swab_and_home_flu(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: dict) -> Optional[dict]:
+def redcap_det_swab_and_home_flu(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
     location_resource_entries = locations(db, cache, redcap_record)
     patient_entry, patient_reference = create_patient(redcap_record)
 
@@ -218,7 +219,7 @@ def create_patient(record: dict) -> tuple:
     return create_entry_and_reference(patient_resource, "Patient")
 
 
-def create_encounter(record: dict, patient_reference: dict, locations: list) -> tuple:
+def create_encounter(record: REDCapRecord, patient_reference: dict, locations: list) -> tuple:
     """ Returns a FHIR Encounter resource entry and reference """
 
     def grab_symptom_keys(key: str) -> Optional[Match[str]]:
@@ -286,6 +287,7 @@ def create_encounter(record: dict, patient_reference: dict, locations: list) -> 
     non_tract_references.append(site_reference)
 
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -24,7 +24,7 @@ from . import race, first_record_instance, required_instruments
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 3
+REVISION = 2
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -26,7 +26,7 @@ from . import race, first_record_instance, required_instruments
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 5
+REVISION = 4
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Union, T
 from datetime import datetime
 from cachetools import TTLCache
 from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
 from id3c.cli.command.etl import redcap_det
 from id3c.cli.command.geocode import get_response_from_cache_or_geocoding
 from id3c.cli.command.location import location_lookup
@@ -25,7 +26,7 @@ from . import race, first_record_instance, required_instruments
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 4
+REVISION = 5
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -50,7 +51,7 @@ REQUIRED_INSTRUMENTS = [
 
 @first_record_instance
 @required_instruments(REQUIRED_INSTRUMENTS)
-def redcap_det_swab_n_send(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: dict) -> Optional[dict]:
+def redcap_det_swab_n_send(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
     location_resource_entries = locations(db, cache, redcap_record)
     patient_entry, patient_reference = create_patient(redcap_record)
 
@@ -220,7 +221,7 @@ def create_patient(record: dict) -> tuple:
     return create_entry_and_reference(patient_resource, "Patient")
 
 
-def create_encounter(record: dict, patient_reference: dict, locations: list) -> tuple:
+def create_encounter(record: REDCapRecord, patient_reference: dict, locations: list) -> tuple:
     """ Returns a FHIR Encounter resource entry and reference """
 
     def grab_symptom_keys(key: str) -> Optional[Match[str]]:
@@ -281,6 +282,7 @@ def create_encounter(record: dict, patient_reference: dict, locations: list) -> 
     non_tract_references.append(site_reference)
 
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -56,7 +56,7 @@ class EventType(Enum):
     ENROLLMENT = 'enrollment'
     ENCOUNTER = 'encounter'
 
-REVISION = 0
+REVISION = 1
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -539,6 +539,7 @@ def create_encounter(record: REDCapRecord, patient_reference: dict,
         non_tract_references.append(site_reference)
 
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,
@@ -1014,6 +1015,7 @@ def create_follow_up_encounter(record: REDCapRecord,
     # YYYY-MM-DD HH:MM in REDCap
     encounter_date = record['fu_timestamp'].split()[0]
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Optional, List, Dict, Any
 from cachetools import TTLCache
 from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
 from id3c.cli.command.etl import redcap_det
 from id3c.cli.command.location import location_lookup
 from id3c.cli.command.geocode import get_response_from_cache_or_geocoding
@@ -23,7 +24,7 @@ SFS = "https://seattleflu.org"
 REDCAP_URL = "https://redcap.iths.org/"
 PROJECT_ID = 19915
 
-REVISION = 2
+REVISION = 3
 
 @redcap_det.command_for_project(
     "uw-retrospectives",
@@ -38,7 +39,7 @@ def redcap_det_uw_retrospectives(*,
                                    db: DatabaseSession,
                                    cache: TTLCache,
                                    det: dict,
-                                   redcap_record: dict) -> Optional[dict]:
+                                   redcap_record: REDCapRecord) -> Optional[dict]:
 
     patient_entry, patient_reference = create_patient(redcap_record)
 
@@ -174,7 +175,7 @@ def create_resident_locations(db: DatabaseSession, cache: TTLCache, record: dict
 
 
 def create_encounter(db: DatabaseSession,
-                     record: dict,
+                     record: REDCapRecord,
                      patient_reference: dict,
                      location_references: list) -> Optional[tuple]:
     """ Returns a FHIR Encounter resource entry and reference """
@@ -201,6 +202,7 @@ def create_encounter(db: DatabaseSession,
     encounter_status = create_encounter_status(record)
 
     encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class,
         encounter_date = encounter_date,


### PR DESCRIPTION
~Add Encounter.meta.source to track the provenance information of the
encounter. For the REDCap DET ETLs, this is a URL with the format:~
```
https://redcap.iths.org/<project_id>/<record_id>/<event_name>/<repeat_instance>
```
~Event name and repeat instance number are only included if the
project has repeating events.~

See latest commits for details

Should be deployed along with https://github.com/seattleflu/id3c/pull/170