### PR TITLE
Move common REDCap ETL code to redcap.py

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -1,7 +1,32 @@
 """
 Functions shared by REDCap DET ETL
 """
-from typing import Optional
+from datetime import datetime
+from enum import Enum
+import re
+from typing import Dict, List, Mapping, Match, Optional, Tuple, Union
+
+from cachetools import TTLCache
+
+from . import race
+from .fhir import *
+from .redcap_map import map_sex, map_symptom, UnknownVaccineResponseError
+from id3c.cli.command.geocode import get_response_from_cache_or_geocoding
+from id3c.cli.command.location import location_lookup
+from id3c.cli.redcap import Record as REDCapRecord
+from id3c.db.session import DatabaseSession
+import logging
+
+
+LOG = logging.getLogger(__name__)
+
+# See https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html for
+    # possible collection codes.
+    # HH = 'home health'
+    # FLD = 'field'
+class CollectionCode(Enum):
+    HOME_HEALTH = "HH"
+    FIELD = "FLD"
 
 
 def normalize_net_id(net_id: str=None) -> Optional[str]:
@@ -44,3 +69,630 @@ def normalize_net_id(net_id: str=None) -> Optional[str]:
 
     username = f'{net_id}@washington.edu'
     return username
+
+
+def parse_date_from_string(input_string: str)-> Optional[datetime]:
+    """ Returns a date from a given *input_string* as a datetime
+    object if the value can be parsed.
+    Otherwise, emits a debug log entry and returns None.
+
+    >>> parse_date_from_string('2000-2-12')
+    datetime.datetime(2000, 2, 12, 0, 0)
+
+    >>> parse_date_from_string('abc')
+
+    >>> parse_date_from_string(None)
+    """
+    date = None
+
+    if input_string:
+        try:
+            date = datetime.strptime(input_string, '%Y-%m-%d')
+        except ValueError:
+            LOG.debug(f"Invalid date value.")
+
+    return date
+
+
+def build_location_resources(db: DatabaseSession, cache: TTLCache, housing_type: str,
+        primary_street_address: str, secondary_street_address: str, city: str, state: str,
+        zipcode: str, system_identifier: str) -> list:
+    """ Creates a list of Location resource entries. """
+
+    def residence_census_tract(db: DatabaseSession, lat_lng: Tuple[float, float],
+            housing_type: str, system_identifier: str) -> Optional[dict]:
+        """
+        Creates a new Location Resource for the census tract containing the given
+        *lat_lng* coordintes and associates it with the given *housing_type*.
+        """
+        location = location_lookup(db, lat_lng, 'tract')
+
+        if location and location.identifier:
+            return create_location(
+                f"{system_identifier}/location/tract", location.identifier, housing_type
+            )
+        else:
+            LOG.debug("No census tract found for given location.")
+            return None
+
+    def create_location(system: str, value: str, location_type: str, parent: str=None) -> dict:
+        """ Returns a FHIR Location resource. """
+        location_type_system = "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+        location_type_map = {
+            "residence": "PTRES",
+            "school": "SCHOOL",
+            "work": "WORK",
+            "site": "HUSCS",
+            "lodging": "PTLDG",
+        }
+
+        location_type_cc = create_codeable_concept(location_type_system,
+            location_type_map[location_type])
+        location_identifier = create_identifier(system, value)
+        part_of = None
+        if parent:
+            part_of = create_reference(reference_type="Location", reference=parent)
+
+        return create_location_resource([location_type_cc], [location_identifier], part_of)
+
+    lodging_options = [
+        'shelter',
+        'afl',
+        'snf',
+        'ltc',
+        'be',
+        'pst',
+        'cf',
+        'none',
+    ]
+
+    if housing_type in lodging_options:
+        housing_type = 'lodging'
+    else:
+        housing_type = 'residence'
+
+    address = {
+        'street': primary_street_address,
+        'secondary': secondary_street_address,
+        'city': city,
+        'state': state,
+        'zipcode': zipcode
+    }
+
+    lat, lng, canonicalized_address = get_response_from_cache_or_geocoding(address, cache)
+    if not canonicalized_address:
+        return []  # TODO
+
+    tract_location = residence_census_tract(db, (lat, lng), housing_type, system_identifier)
+    # TODO what if tract_location is null?
+    tract_full_url = generate_full_url_uuid()
+    tract_entry = create_resource_entry(tract_location, tract_full_url)
+
+    address_hash = generate_hash(canonicalized_address)
+    address_location = create_location(
+        f"{system_identifier}/location/address",
+        address_hash,
+        housing_type,
+        tract_full_url
+    )
+    address_entry = create_resource_entry(address_location, generate_full_url_uuid())
+
+    return [tract_entry, address_entry]
+
+
+def create_site_reference(location: str, site_map: dict, default_site: str,
+    system_identifier: str) -> Optional[Dict[str,dict]]:
+    """
+    Create a Location reference for site of the sample collection encounter based
+    on how the sample was collected.
+    """
+    class UnknownRedcapRecordLocation(ValueError):
+        """
+        Raised if a provided *location* is not
+        among a set of expected values.
+        """
+        pass
+
+    if location:
+        if location not in site_map:
+            raise UnknownRedcapRecordLocation(f"Found unknown location type «{location}»")
+        site = site_map[location]
+    else:
+        site = default_site
+
+    return {
+        "location": create_reference(
+            reference_type = "Location",
+            identifier = create_identifier(f"{system_identifier}/site", site)
+        )
+    }
+
+
+def _create_patient(sex: str, preferred_language: str, first_name: str, last_name: str,
+        birth_date: str, zipcode: str, redcap_url: str, redcap_project_id: int, redcap_record_id: str,
+        system_identifier: str, unique_identifier: str = None) -> tuple:
+    """
+    Returns a FHIR Patient resource entry and reference.
+    Uses demographics to create the patient identifier unless
+    a *unique_identifier* is provided.
+    """
+    gender = map_sex(sex)
+
+    language_codeable_concept = create_codeable_concept(
+        system = 'urn:ietf:bcp:47',
+        code = preferred_language
+    )
+
+    communication = [{
+        'language' : language_codeable_concept,
+        'preferred': True
+    }]
+
+    patient_id = None
+    if unique_identifier:
+        patient_id = generate_hash(unique_identifier)
+    else:
+        patient_id = generate_patient_hash(
+                names       = (first_name, last_name),
+                gender      = gender,
+                birth_date  = birth_date,
+                postal_code = zipcode)
+
+    if not patient_id:
+        # Some piece of information was missing, so we couldn't generate a
+        # hash.  Fallback to treating this individual as always unique by using
+        # the REDCap record id.
+        patient_id = generate_hash(f"{redcap_url}{str(redcap_project_id)}/{redcap_record_id}")
+
+    LOG.debug(f"Generated individual identifier {patient_id}")
+
+    patient_identifier = create_identifier(f"{system_identifier}/individual", patient_id)
+    patient_resource = create_patient_resource([patient_identifier], gender, communication)
+
+    return create_entry_and_reference(patient_resource, "Patient")
+
+
+def create_patient_using_demographics(sex: str, preferred_language: str, first_name: str, last_name: str,
+        birth_date: str, zipcode: str, redcap_url: str, redcap_project_id: int, redcap_record_id: str,
+        system_identifier: str) -> tuple:
+    """
+    Returns a FHIR Patient resource entry and reference.
+    Uses demographics to create the patient identifier
+    """
+    return _create_patient(
+        sex = sex,
+        preferred_language = preferred_language,
+        first_name = first_name,
+        last_name = last_name,
+        birth_date = birth_date,
+        zipcode = zipcode,
+        redcap_url = redcap_url,
+        redcap_project_id = redcap_project_id,
+        redcap_record_id = redcap_record_id,
+        system_identifier = system_identifier,
+        unique_identifier = None)
+
+
+def create_patient_using_unique_identifier(sex: str, preferred_language: str, unique_identifier: str,
+    redcap_url: str, redcap_project_id: int, redcap_record_id: str, system_identifier: str) -> tuple:
+    """
+    Returns a FHIR Patient resource entry and reference.
+    Uses a unique identifier to create the patient identifier
+    """
+    return _create_patient(
+        sex = sex,
+        preferred_language = preferred_language,
+        first_name = None,
+        last_name = None,
+        birth_date = None,
+        zipcode = None,
+        redcap_url = redcap_url,
+        redcap_project_id = redcap_project_id,
+        redcap_record_id = redcap_record_id,
+        system_identifier = system_identifier,
+        unique_identifier = unique_identifier)
+
+
+def create_specimen(prioritized_barcodes: List[str], patient_reference: dict, collection_date: str, sample_received_time: str,
+    able_to_test: str, system_identifier: str, specimen_type: Optional[str] = None) -> tuple:
+    """ Returns a FHIR Specimen resource entry and reference
+        Uses the first non-empty barcode from *prioritized_barcodes*
+    """
+
+    for barcode in prioritized_barcodes:
+        prepared_barcode = barcode.strip().lower()
+        if prepared_barcode:
+            break
+
+    if not prepared_barcode:
+        LOG.debug("Could not create Specimen Resource due to lack of barcode.")
+        return None, None
+
+    specimen_identifier = create_identifier(
+        system = f"{system_identifier}/sample",
+        value = prepared_barcode
+    )
+
+    # YYYY-MM-DD HH:MM:SS in REDCap
+    received_time = sample_received_time.split()[0] if sample_received_time else None
+
+    note = None
+
+    if able_to_test == 'no':
+        note = 'never-tested'
+    else:
+        note = 'can-test'
+
+    specimen_type = specimen_type or 'NSECR'  # Nasal swab.
+    specimen_resource = create_specimen_resource(
+        [specimen_identifier], patient_reference, specimen_type, received_time,
+        collection_date, note
+    )
+
+    return create_entry_and_reference(specimen_resource, "Specimen")
+
+
+def build_contained_and_diagnosis(patient_reference: dict, record: REDCapRecord,
+        symptom_onset_map: dict, system_identifier: str) -> Tuple[list, list]:
+
+    def grab_symptom_key(record: REDCapRecord, key: str, variable_name: str) -> Optional[Match[str]]:
+        if record[key] == '1':
+            return re.match(f"{variable_name}___[a-z_]+", key)
+        else:
+            return None
+
+
+    def build_condition(patient_reference: dict, symptom_name: str, onset_date: str,
+        system_identifier: str) -> Optional[dict]:
+        """ Returns a FHIR Condition resource. """
+        mapped_symptom_name = map_symptom(symptom_name)
+        if not mapped_symptom_name:
+            return None
+
+        # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
+        # 3.8.  Until then, there's no reasonable way to type this data structure
+        # better than Any.
+        #   -trs, 24 Oct 2019
+        condition: Any = {
+            "resourceType": "Condition",
+            "id": f'{mapped_symptom_name}',
+            "code": {
+                "coding": [
+                    {
+                        "system": f"{system_identifier}/symptom",
+                        "code": mapped_symptom_name
+                    }
+                ]
+            },
+            "subject": patient_reference
+        }
+
+        if onset_date:
+            condition["onsetDateTime"] = onset_date
+
+        return condition
+
+
+    def build_diagnosis(symptom: str) -> Optional[dict]:
+        mapped_symptom = map_symptom(symptom)
+        if not mapped_symptom:
+            return None
+
+        return { "condition": { "reference": f"#{mapped_symptom}" } }
+
+
+    contained = []
+    diagnosis = []
+
+    for symptom_variable in symptom_onset_map:
+            symptom_keys = []
+
+            for redcap_key in record.keys():
+                symptom_key = grab_symptom_key(record, redcap_key, symptom_variable)
+                if symptom_key:
+                    symptom_keys.append(symptom_key.string)
+
+            symptoms = list(map(lambda x: re.sub('[a-z_]+___', '', x), symptom_keys))
+
+            for symptom in symptoms:
+                contained.append(build_condition(patient_reference, symptom, symptom_onset_map[symptom_variable], system_identifier))
+                diagnosis.append(build_diagnosis(symptom))
+
+    return contained, diagnosis
+
+
+def create_encounter(encounter_date: str, patient_reference: dict, site_reference: dict,
+    locations: list, diagnosis: list, contained: list, collection_code: CollectionCode,
+    parent_encounter_reference: dict, encounter_reason_code: dict, encounter_identifier_suffix: str,
+    system_identifier: str, redcap_uri: str, redcap_url: str, redcap_project_id: int, redcap_record_id: str,
+    redcap_event_name: str, redcap_repeat_instance: str) -> tuple:
+    """
+    Returns a FHIR Encounter resource entry and reference for the encounter in the study.
+    """
+
+    def build_locations_list(location: dict) -> dict:
+        return {
+            "location": create_reference(
+                reference_type = "Location",
+                reference = location["fullUrl"]
+            )
+        }
+
+
+    def non_tract_locations(resource: dict):
+        return bool(resource) \
+            and resource['resource']['identifier'][0]['system'] != f"{system_identifier}/location/tract"
+
+
+    if not encounter_date:
+        LOG.debug("Not creating the encounter because there is no encounter_date.")
+        return None, None
+
+    if not site_reference:
+        LOG.debug("Not creating the encounter because there is no site_reference.")
+        return None, None
+
+    # Keep the encounter_id format the same as what was used in an earlier
+    # version of redcap_det_uw_reopening.py.
+    if not redcap_event_name:
+        redcap_event_name = ""
+    if not redcap_repeat_instance:
+        redcap_repeat_instance = ""
+    if not encounter_identifier_suffix:
+        encounter_identifier_suffix = ""
+    encounter_id = f"{redcap_url}{str(redcap_project_id)}/{str(redcap_record_id)}/{redcap_event_name}/" + \
+        f"{redcap_repeat_instance}{encounter_identifier_suffix}"
+
+    encounter_identifier = create_identifier(
+        system = f"{system_identifier}/encounter",
+        value = encounter_id
+    )
+
+    collection_code_value = None
+    if collection_code:
+        collection_code_value = collection_code.value
+
+    encounter_class_coding = create_coding(
+        system = "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        code = collection_code_value
+    )
+
+    site_reference_list = [site_reference]
+
+    # Add hard-coded site Location reference
+    if locations:
+        non_tracts = list(filter(non_tract_locations, locations))
+        non_tract_references = list(map(build_locations_list, non_tracts))
+        site_reference_list.extend(non_tract_references)
+
+    reason_code_list = None
+    if encounter_reason_code:
+        reason_code_list = [encounter_reason_code]
+
+
+    encounter_resource = create_encounter_resource(
+        encounter_source = redcap_uri,
+        encounter_identifier = [encounter_identifier],
+        encounter_class = encounter_class_coding,
+        encounter_date = encounter_date,
+        patient_reference = patient_reference,
+        location_references = site_reference_list,
+        diagnosis = diagnosis,
+        contained = contained,
+        reason_code = reason_code_list,
+        part_of = parent_encounter_reference
+    )
+
+    return create_entry_and_reference(encounter_resource, "Encounter")
+
+
+def filter_fields(field: str, field_value: str, regex: str, empty_value: str) -> bool:
+    """
+    Function that filters for *field* matching given *regex* and the
+    *field_value* must not equal the expected *empty_value.
+    """
+    if re.match(regex, field) and field_value != empty_value:
+        return True
+
+    return False
+
+
+def combine_multiple_fields(record: Dict[Any, Any], field_prefix: str, field_suffix: str = "") -> Optional[List]:
+        """
+        Handles the combining of multiple fields asking the same question such
+        as country and state traveled.
+        """
+        regex = rf'^{re.escape(field_prefix)}[0-9]+{re.escape(field_suffix)}$'
+        empty_value = ''
+        answered_fields = list(filter(lambda f: filter_fields(f, record[f], regex, empty_value), record))
+
+        if not answered_fields:
+            return None
+
+        return list(map(lambda x: record[x], answered_fields))
+
+
+def combine_checkbox_answers(record: dict, coded_question: str) -> Optional[List]:
+    """
+    Handles the combining "select all that apply"-type checkbox
+    responses into one list.
+
+    Uses our in-house mapping for race and symptoms
+    """
+    regex = rf'{re.escape(coded_question)}___[\w]*$'
+    empty_value = '0'
+    answered_checkboxes = list(filter(lambda f: filter_fields(f, record[f], regex, empty_value), record))
+    # REDCap checkbox fields have format of {question}___{answer}
+    answers = list(map(lambda k: k.replace(f"{coded_question}___", ""), answered_checkboxes))
+
+    if coded_question == 'race':
+        return race(answers)
+
+    if re.match(r'fu_[1-4]_symptoms$', coded_question):
+        return list(map(lambda a: map_symptom(a), answers))
+
+    return answers
+
+
+def map_vaccine(vaccine_response: str) -> Optional[bool]:
+    """
+    Maps a vaccine response to FHIR immunization status codes
+    (https://www.hl7.org/fhir/valueset-immunization-status.html)
+    """
+    vaccine_map = {
+        'yes': True,
+        '1': True,
+        'no': False,
+        '0': False,
+        'dont_know': None,
+        '': None
+    }
+
+    if vaccine_response.lower() not in vaccine_map:
+        raise UnknownVaccineResponseError(f"Unknown vaccine response «{vaccine_response}»")
+
+    return vaccine_map[vaccine_response.lower()]
+
+
+def create_vaccine_item(vaccine_status: str, vaccine_year: str, vaccine_month: str, dont_know_text: str) -> Optional[dict]:
+    """
+    Return a questionnaire response item with the vaccine response(s) encoded.
+    """
+    def vaccine_date(vaccine_year: str, vaccine_month: str, dont_know_text: str) -> Optional[str]:
+        """ Converts a vaccination date to 'YYYY' or 'YYYY-MM' format. """
+        if vaccine_year == '' or vaccine_year == dont_know_text:
+            return None
+
+        if vaccine_month == dont_know_text:
+            return datetime.strptime(vaccine_year, '%Y').strftime('%Y')
+
+        return datetime.strptime(f'{vaccine_month} {vaccine_year}', '%B %Y').strftime('%Y-%m')
+
+
+    vaccine_status_bool = map_vaccine(vaccine_status)
+    if vaccine_status_bool is None:
+        return None
+
+    answers: List[Dict[str, Any]] = [{ 'valueBoolean': vaccine_status_bool }]
+
+    date = vaccine_date(vaccine_year, vaccine_month, dont_know_text)
+    if vaccine_status_bool and date:
+        answers.append({ 'valueDate': date })
+
+    return create_questionnaire_response_item('vaccine', answers)
+
+
+def questionnaire_item(record: REDCapRecord, question_id: str, response_type: str, system_identifier: str) -> Optional[dict]:
+    """ Creates a QuestionnaireResponse internal item from a REDCap record.
+    """
+    response = record.get(question_id)
+    if not response:
+        return None
+
+
+    def cast_to_coding(string: str) -> dict:
+        """ Currently the only QuestionnaireItem we code is race. """
+        return create_coding(
+            system = f"{system_identifier}/race",
+            code = string,
+        )
+
+
+    def cast_to_string(string: str) -> Optional[str]:
+        if string != '':
+            return string.strip()
+        return None
+
+
+    def cast_to_integer(string: str) -> Optional[int]:
+        try:
+            return int(string)
+        except ValueError:
+            return None
+
+
+    def cast_to_float(string: str) -> Optional[float]:
+        try:
+            return float(string)
+        except ValueError:
+            return None
+
+
+    def cast_to_boolean(string: str) -> Optional[bool]:
+        if (string and string.lower() == 'yes') or string == '1':
+            return True
+        elif (string and string.lower() == 'no') or string == '0':
+            return False
+        return None
+
+
+    def build_response_answers(response: Union[str, List]) -> List:
+        answers = []
+        if not isinstance(response, list):
+            response = [response]
+
+        for item in response:
+            type_casted_item = casting_functions[response_type](item)
+
+            # cast_to_boolean can return False, so must be `is not None`
+            if type_casted_item is not None:
+                answers.append({ response_type: type_casted_item })
+
+        return answers
+
+
+    casting_functions: Mapping[str, Callable[[str], Any]] = {
+        'valueCoding': cast_to_coding,
+        'valueInteger': cast_to_integer,
+        'valueBoolean': cast_to_boolean,
+        'valueString': cast_to_string,
+        'valueDate': cast_to_string,
+        'valueDecimal': cast_to_float
+    }
+
+    answers = build_response_answers(response)
+    if answers:
+        return create_questionnaire_response_item(question_id, answers)
+
+    return None
+
+
+def create_questionnaire_response(record: REDCapRecord, question_categories: Dict[str, list],
+    patient_reference: dict, encounter_reference: dict, system_identifier: str,
+    additional_items: Optional[List[dict]] = None) -> Optional[dict]:
+    """
+    Provided a dictionary of *question_categories* with the key being the value
+    type and the value being a list of field names, return a FHIR
+    Questionnaire Response resource entry. To the list of items built by
+    processing the *question_categories*, add *additional_items* if there are any.
+    """
+    def build_questionnaire_items(question: str) -> Optional[dict]:
+        return questionnaire_item(record, question, category, system_identifier)
+
+    items: List[dict] = []
+    for category in question_categories:
+        category_items = list(map(build_questionnaire_items, question_categories[category]))
+        for item in category_items:
+            if item:
+                items.append(item)
+
+    if additional_items:
+        items.extend(additional_items)
+
+    if items:
+        questionnaire_reseponse_resource = create_questionnaire_response_resource(
+            patient_reference, encounter_reference, items
+        )
+        full_url = generate_full_url_uuid()
+        return create_resource_entry(questionnaire_reseponse_resource, full_url)
+
+    return None
+
+
+def follow_up_encounter_reason_code() -> dict:
+    encounter_reason_code = create_codeable_concept(
+        system = "http://snomed.info/sct",
+        code = "390906007",
+        display = "Follow-up encounter"
+    )
+    return encounter_reason_code

--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -28,6 +28,24 @@ class CollectionCode(Enum):
     HOME_HEALTH = "HH"
     FIELD = "FLD"
 
+class REDCapRecordInfo:
+    redcap_url: str
+    project_id: int
+    record_id: str
+    event_name: str
+    repeat_instance: int
+
+    def __init__(self, record: REDCapRecord)-> None:
+        self.redcap_url = record.project.base_url
+        self.project_id = record.project.id
+        self.record_id = record.id
+        self.event_name = record.get('redcap_event_name')
+
+        if record.get('redcap_repeat_instance'):
+            self.repeat_instance = int(record.get('redcap_repeat_instance'))
+        else:
+            self.repeat_instance = None
+
 
 def normalize_net_id(net_id: str=None) -> Optional[str]:
     """
@@ -209,13 +227,15 @@ def create_site_reference(location: str, site_map: dict, default_site: str,
 
 
 def _create_patient(sex: str, preferred_language: str, first_name: str, last_name: str,
-        birth_date: str, zipcode: str, redcap_url: str, redcap_project_id: int, redcap_record_id: str,
+        birth_date: str, zipcode: str, record: REDCapRecord,
         system_identifier: str, unique_identifier: str = None) -> tuple:
     """
     Returns a FHIR Patient resource entry and reference.
     Uses demographics to create the patient identifier unless
     a *unique_identifier* is provided.
     """
+    record_info = REDCapRecordInfo(record)
+
     gender = map_sex(sex)
 
     language_codeable_concept = create_codeable_concept(
@@ -242,7 +262,7 @@ def _create_patient(sex: str, preferred_language: str, first_name: str, last_nam
         # Some piece of information was missing, so we couldn't generate a
         # hash.  Fallback to treating this individual as always unique by using
         # the REDCap record id.
-        patient_id = generate_hash(f"{redcap_url}{str(redcap_project_id)}/{redcap_record_id}")
+        patient_id = generate_hash(f"{record_info.redcap_url}{str(record_info.project_id)}/{str(record_info.record_id)}")
 
     LOG.debug(f"Generated individual identifier {patient_id}")
 
@@ -253,8 +273,7 @@ def _create_patient(sex: str, preferred_language: str, first_name: str, last_nam
 
 
 def create_patient_using_demographics(sex: str, preferred_language: str, first_name: str, last_name: str,
-        birth_date: str, zipcode: str, redcap_url: str, redcap_project_id: int, redcap_record_id: str,
-        system_identifier: str) -> tuple:
+        birth_date: str, zipcode: str, record: REDCapRecord, system_identifier: str) -> tuple:
     """
     Returns a FHIR Patient resource entry and reference.
     Uses demographics to create the patient identifier
@@ -266,15 +285,13 @@ def create_patient_using_demographics(sex: str, preferred_language: str, first_n
         last_name = last_name,
         birth_date = birth_date,
         zipcode = zipcode,
-        redcap_url = redcap_url,
-        redcap_project_id = redcap_project_id,
-        redcap_record_id = redcap_record_id,
+        record = record,
         system_identifier = system_identifier,
         unique_identifier = None)
 
 
 def create_patient_using_unique_identifier(sex: str, preferred_language: str, unique_identifier: str,
-    redcap_url: str, redcap_project_id: int, redcap_record_id: str, system_identifier: str) -> tuple:
+    record: REDCapRecord, system_identifier: str) -> tuple:
     """
     Returns a FHIR Patient resource entry and reference.
     Uses a unique identifier to create the patient identifier
@@ -286,9 +303,7 @@ def create_patient_using_unique_identifier(sex: str, preferred_language: str, un
         last_name = None,
         birth_date = None,
         zipcode = None,
-        redcap_url = redcap_url,
-        redcap_project_id = redcap_project_id,
-        redcap_record_id = redcap_record_id,
+        record = record,
         system_identifier = system_identifier,
         unique_identifier = unique_identifier)
 
@@ -404,8 +419,7 @@ def build_contained_and_diagnosis(patient_reference: dict, record: REDCapRecord,
 def create_encounter(encounter_date: str, patient_reference: dict, site_reference: dict,
     locations: list, diagnosis: list, contained: list, collection_code: CollectionCode,
     parent_encounter_reference: dict, encounter_reason_code: dict, encounter_identifier_suffix: str,
-    system_identifier: str, redcap_uri: str, redcap_url: str, redcap_project_id: int, redcap_record_id: str,
-    redcap_event_name: str, redcap_repeat_instance: str) -> tuple:
+    system_identifier: str, record: REDCapRecord) -> tuple:
     """
     Returns a FHIR Encounter resource entry and reference for the encounter in the study.
     """
@@ -432,15 +446,20 @@ def create_encounter(encounter_date: str, patient_reference: dict, site_referenc
         LOG.debug("Not creating the encounter because there is no site_reference.")
         return None, None
 
+    record_info = REDCapRecordInfo(record)
+
     # Keep the encounter_id format the same as what was used in an earlier
     # version of redcap_det_uw_reopening.py.
+    redcap_event_name = record_info.event_name
+    redcap_repeat_instance = record_info.repeat_instance
+
     if not redcap_event_name:
         redcap_event_name = ""
     if not redcap_repeat_instance:
         redcap_repeat_instance = ""
     if not encounter_identifier_suffix:
         encounter_identifier_suffix = ""
-    encounter_id = f"{redcap_url}{str(redcap_project_id)}/{str(redcap_record_id)}/{redcap_event_name}/" + \
+    encounter_id = f"{record_info.redcap_url}{str(record_info.project_id)}/{record_info.record_id}/{redcap_event_name}/" + \
         f"{redcap_repeat_instance}{encounter_identifier_suffix}"
 
     encounter_identifier = create_identifier(
@@ -471,7 +490,7 @@ def create_encounter(encounter_date: str, patient_reference: dict, site_referenc
 
 
     encounter_resource = create_encounter_resource(
-        encounter_source = redcap_uri,
+        encounter_source = create_redcap_uri(record),
         encounter_identifier = [encounter_identifier],
         encounter_class = encounter_class_coding,
         encounter_date = encounter_date,

--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -242,7 +242,7 @@ def _create_patient(sex: str, preferred_language: str, first_name: str, last_nam
         # Some piece of information was missing, so we couldn't generate a
         # hash.  Fallback to treating this individual as always unique by using
         # the REDCap record id.
-        patient_id = generate_hash(f"{record.project.base_url}{str(record.project.id)}/{record.id}")
+        patient_id = generate_hash(f"{record.project.base_url}{record.project.id}/{record.id}")
 
     LOG.debug(f"Generated individual identifier {patient_id}")
 
@@ -438,7 +438,7 @@ def create_encounter(encounter_date: str, patient_reference: dict, site_referenc
         redcap_repeat_instance = ""
     if not encounter_identifier_suffix:
         encounter_identifier_suffix = ""
-    encounter_id = f"{record.project.base_url}{str(record.project.id)}/{record.id}/{redcap_event_name}/" + \
+    encounter_id = f"{record.project.base_url}{record.project.id}/{record.id}/{redcap_event_name}/" + \
         f"{redcap_repeat_instance}{encounter_identifier_suffix}"
 
     encounter_identifier = create_identifier(

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -17,7 +17,7 @@ from id3c.cli.command.de_identify import generate_hash
 from id3c.cli.redcap import is_complete, Record as REDCapRecord
 from seattleflu.id3c.cli.command import age_ceiling
 from .redcap_map import *
-from .redcap import *
+from .redcap import normalize_net_id
 from .fhir import *
 from . import race, first_record_instance, required_instruments
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -1,27 +1,13 @@
 """
 Process DETs for the UW Reopening (Husky Coronavirus Testing) REDCap projects.
 """
-import re
-import click
-import json
 import logging
-from uuid import uuid4
-from typing import Any, Callable, Dict, List, Mapping, Match, NamedTuple, Optional, Union, Tuple
-from cachetools import TTLCache
 from dateutil.relativedelta import relativedelta
-from decimal import Decimal
 from enum import Enum
-from id3c.db.session import DatabaseSession
 from id3c.cli.command.etl import redcap_det
-from id3c.cli.command.geocode import get_response_from_cache_or_geocoding
-from id3c.cli.command.location import location_lookup
-from id3c.cli.command.de_identify import generate_hash
 from id3c.cli.redcap import is_complete, Record as REDCapRecord
 from seattleflu.id3c.cli.command import age_ceiling
-from .redcap import normalize_net_id
-from .redcap_map import map_sex, map_symptom, UnknownVaccineResponseError
-from .fhir import *
-from . import race, first_record_instance, required_instruments
+from .redcap import *
 
 
 LOG = logging.getLogger(__name__)
@@ -62,6 +48,7 @@ REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
 ENROLLMENT_EVENT_NAME = "enrollment_arm_1"
 ENCOUNTER_EVENT_NAME = "encounter_arm_1"
+SWAB_AND_SEND_SITE = 'UWReopeningSwabNSend'
 
 REQUIRED_ENROLLMENT_INSTRUMENTS = [
     'eligibility_screening',
@@ -124,14 +111,49 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
         LOG.debug("The participant is < 18 years old and we do not have parental consent. Skipping record.")
         return None
 
-    patient_entry, patient_reference = create_patient(enrollment)
-    birthdate = parse_birth_date(enrollment)
+    # Create the participant resource entry and reference.
+    # Assumes that the project language is the participant's preferred language
+    netid = normalize_net_id(enrollment.get('netid'))
+
+    if netid:
+        patient_entry, patient_reference = create_patient_using_unique_identifier(
+            sex = enrollment['core_sex'],
+            preferred_language = LANGUAGE_CODE[project_id],
+            unique_identifier = netid,
+            redcap_url = REDCAP_URL,
+            redcap_project_id = project_id,
+            redcap_record_id = record_id,
+            system_identifier = INTERNAL_SYSTEM)
+    else:
+        patient_entry, patient_reference = create_patient_using_demographics(
+            sex = enrollment['core_sex'],
+            preferred_language = LANGUAGE_CODE[project_id],
+            first_name = enrollment['core_participant_first_name'],
+            last_name = enrollment['core_participant_last_name'],
+            birth_date = enrollment['core_birthdate'],
+            zipcode = enrollment['core_zipcode'],
+            redcap_url = REDCAP_URL,
+            redcap_project_id = project_id,
+            redcap_record_id = record_id,
+            system_identifier = INTERNAL_SYSTEM)
 
     if not patient_entry:
         LOG.warning("Skipping record with insufficient information to construct patient")
         return None
 
-    location_resource_entries = locations(db, cache, enrollment)
+    birthdate = parse_date_from_string(enrollment.get('core_birthdate'))
+
+    location_resource_entries = build_location_resources(
+        db = db,
+        cache = cache,
+        housing_type = enrollment.get('core_housing_type'),
+        primary_street_address = enrollment['core_home_street'],
+        secondary_street_address = enrollment['core_apartment_number'],
+        city = enrollment['core_home_city'],
+        state = enrollment['core_home_state'],
+        zipcode = enrollment['core_zipcode'],
+        system_identifier = INTERNAL_SYSTEM)
+
     persisted_resource_entries = [patient_entry, *location_resource_entries]
 
     for redcap_record_instance in redcap_record_instances:
@@ -161,11 +183,74 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
                     continue
 
         # site_reference refers to where the sample was collected
-        site_reference = create_site_reference(redcap_record_instance, collection_method, event_type)
+        record_location = None
+
+        if collection_method == CollectionMethod.KIOSK:
+            record_location = redcap_record_instance.get('location_type')
+
+        location_site_map = {
+            'bothell':  'UWBothell',
+            'odegaard': 'UWOdegaardLibrary',
+            'slu':      'UWSouthLakeUnion',
+            'tacoma':   'UWTacoma',
+            'uw_club':  'UWClub'
+            }
+
+        site_reference = create_site_reference(
+            location = record_location,
+            site_map = location_site_map,
+            default_site = SWAB_AND_SEND_SITE,
+            system_identifier = INTERNAL_SYSTEM)
+
+        # Handle various symptoms.
+        contained: List[dict]
+        diagnosis: List[dict]
+
+        # Map the various symptoms variables to their onset date.
+        # For daily_symptoms_covid_like we don't know the actual onset date. The questions asks
+        # "in the past 24 hours"
+        if event_type == EventType.ENCOUNTER:
+            symptom_onset_map = {
+                'daily_symptoms_covid_like': None,
+                'symptoms': redcap_record_instance['symptom_onset'],
+                'symptoms_kiosk': redcap_record_instance['symptom_duration_kiosk'],
+                'symptoms_swabsend': redcap_record_instance['symptom_duration_swabsend']
+            }
+        elif event_type == EventType.ENROLLMENT:
+            symptom_onset_map = {'symptoms_base': redcap_record_instance['symptom_onset_base']}
+
+        contained, diagnosis = build_contained_and_diagnosis(
+            patient_reference = patient_reference,
+            record = redcap_record_instance,
+            symptom_onset_map = symptom_onset_map,
+            system_identifier = INTERNAL_SYSTEM)
+
+        collection_code = None
+        if event_type == EventType.ENROLLMENT or collection_method == CollectionMethod.SWAB_AND_SEND:
+            collection_code = CollectionCode.HOME_HEALTH
+        elif collection_method == CollectionMethod.KIOSK:
+            collection_code = CollectionCode.FIELD
+
+        encounter_date = get_encounter_date(redcap_record_instance, event_type)
 
         initial_encounter_entry, initial_encounter_reference = create_encounter(
-            redcap_record_instance, patient_reference, site_reference,
-            location_resource_entries, event_type, collection_method)
+            encounter_date = encounter_date,
+            patient_reference = patient_reference,
+            site_reference = site_reference,
+            locations = location_resource_entries,
+            diagnosis = diagnosis,
+            contained = contained,
+            collection_code = collection_code,
+            parent_encounter_reference = None,
+            encounter_reason_code = None,
+            encounter_identifier_suffix = None,
+            system_identifier = INTERNAL_SYSTEM,
+            redcap_uri = create_redcap_uri(redcap_record_instance),
+            redcap_url = REDCAP_URL,
+            redcap_project_id = project_id,
+            redcap_record_id = record_id,
+            redcap_event_name = redcap_record_instance['redcap_event_name'],
+            redcap_repeat_instance = redcap_record_instance['redcap_repeat_instance'])
 
         # Skip the entire record if we can't create the enrollment encounter.
         # Otherwise, just skip the record instance.
@@ -185,14 +270,30 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
             is_complete('kiosk_registration_4c7f', redcap_record_instance))
 
         if specimen_received:
-            specimen_entry, specimen_reference = create_specimen(redcap_record_instance, patient_reference, collection_method)
+            # Use barcode fields in this order.
+            prioritized_barcodes = [
+                redcap_record_instance["collect_barcode_kiosk"],
+                redcap_record_instance["return_utm_barcode"],
+                redcap_record_instance["pre_scan_barcode"]]
+
+            specimen_entry, specimen_reference = create_specimen(
+                prioritized_barcodes = prioritized_barcodes,
+                patient_reference = patient_reference,
+                collection_date = get_collection_date(redcap_record_instance, collection_method),
+                sample_received_time = redcap_record_instance['samp_process_date'],
+                able_to_test = redcap_record_instance['able_to_test'],
+                system_identifier = INTERNAL_SYSTEM)
+
             specimen_observation_entry = create_specimen_observation_entry(
-                specimen_reference, patient_reference, initial_encounter_reference)
+                specimen_reference = specimen_reference,
+                patient_reference = patient_reference,
+                encounter_reference = initial_encounter_reference)
         else:
             LOG.info("Creating encounter for record instance without sample")
 
         if specimen_received and not specimen_entry:
-            LOG.warning("Skipping record instance with insufficent information to construct a specimen")
+            LOG.warning("Skipping record instance. We think the specimen was received," \
+                + " but we're unable to create the specimen_entry.")
             continue
 
         computed_questionnaire_entry = None
@@ -205,7 +306,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
 
         computed_questionnaire_entry = create_computed_questionnaire_response(
             redcap_record_instance, patient_reference, initial_encounter_reference,
-            birthdate, datetime.strptime(initial_encounter_entry['resource']['period']['start'], '%Y-%m-%d'))
+            birthdate, parse_date_from_string(initial_encounter_entry['resource']['period']['start']))
 
         if event_type == EventType.ENROLLMENT:
             enrollment_questionnaire_entry = create_enrollment_questionnaire_response(
@@ -220,13 +321,32 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
                 redcap_record_instance, patient_reference, initial_encounter_reference)
 
             if is_complete('week_followup', redcap_record_instance):
-                follow_up_encounter_entry, follow_up_encounter_reference = create_follow_up_encounter(
-                    redcap_record_instance, patient_reference, site_reference, initial_encounter_reference)
+
+                follow_up_encounter_entry, follow_up_encounter_reference = create_encounter(
+                    encounter_date = redcap_record_instance['fu_timestamp'].split()[0],
+                    patient_reference = patient_reference,
+                    site_reference = site_reference,
+                    locations = None, # Don't set locationd because the f/u survey doesn't ask for home address.
+                    diagnosis = None,
+                    contained = None,
+                    collection_code = CollectionCode.HOME_HEALTH,
+                    parent_encounter_reference = initial_encounter_reference,
+                    encounter_reason_code = follow_up_encounter_reason_code(),
+                    encounter_identifier_suffix = "_follow_up",
+                    system_identifier = INTERNAL_SYSTEM,
+                    redcap_uri = create_redcap_uri(redcap_record_instance),
+                    redcap_url = REDCAP_URL,
+                    redcap_project_id = project_id,
+                    redcap_record_id = record_id,
+                    redcap_event_name = redcap_record_instance['redcap_event_name'],
+                    redcap_repeat_instance = redcap_record_instance['redcap_repeat_instance'])
+
+
                 follow_up_questionnaire_entry = create_follow_up_questionnaire_response(
                 redcap_record_instance, patient_reference, follow_up_encounter_reference)
                 follow_up_computed_questionnaire_entry = create_computed_questionnaire_response(
                 redcap_record_instance, patient_reference, follow_up_encounter_reference,
-                birthdate, datetime.strptime(follow_up_encounter_entry['resource']['period']['start'], '%Y-%m-%d'))
+                birthdate, parse_date_from_string(follow_up_encounter_entry['resource']['period']['start']))
 
 
         current_instance_entries = [
@@ -252,259 +372,8 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
         entries = list(filter(None, persisted_resource_entries))
     )
 
-
-def parse_birth_date(record: dict) -> Optional[datetime]:
-    """ Returns a participant's birth date from a given *record* as a datetime
-    object if it can be parsed. Otherwise, emits a warning and returns None. """
-    try:
-        birth_date = datetime.strptime(record['core_birthdate'], '%Y-%m-%d')
-    except ValueError:
-        LOG.warning("Invalid `core_birthdate`.")
-        birth_date = None
-
-    return birth_date
-
-def create_site_reference(record: dict, collection_method: CollectionMethod, event_type: EventType) -> Optional[Dict[str,dict]]:
-    """
-    Create a Location reference for site of the sample collection encounter based
-    on how the sample was collected.
-    """
-    if collection_method == CollectionMethod.KIOSK:
-        record_location = record.get('location_type')
-        if record_location:
-            site = site_map(record_location)
-    else:
-        site = 'UWReopeningSwabNSend'
-
-    return {
-        "location": create_reference(
-            reference_type = "Location",
-            identifier = create_identifier(f"{INTERNAL_SYSTEM}/site", site)
-        )
-    }
-
-
-def site_map(record_location: str) -> str:
-    """
-    Maps *record_location* to the corresponding site name.
-    """
-    location_site_map = {
-        'bothell':  'UWBothell',
-        'odegaard': 'UWOdegaardLibrary',
-        'slu':      'UWSouthLakeUnion',
-        'tacoma':   'UWTacoma',
-        'uw_club':  'UWClub'
-    }
-
-    if record_location not in location_site_map:
-        raise UnknownRedcapRecordLocation(f"Found unknown location type «{record_location}»")
-
-    return location_site_map[record_location]
-
-
-def locations(db: DatabaseSession, cache: TTLCache, record: dict) -> list:
-    """ Creates a list of Location resource entries from a REDCap record. """
-    lodging_options = [
-        'shelter',
-        'afl',
-        'snf',
-        'ltc',
-        'be',
-        'pst',
-        'cf',
-        'none'
-    ]
-
-    if record.get('core_housing_type') in lodging_options:
-        housing_type = 'lodging'
-    else:
-        housing_type = 'residence'
-
-    address = {
-        'street': record['core_home_street'],
-        'secondary': record['core_apartment_number'],
-        'city': record['core_home_city'],
-        'state': record['core_home_state'],
-        'zipcode': record['core_zipcode'],
-    }
-
-    lat, lng, canonicalized_address = get_response_from_cache_or_geocoding(address, cache)
-    if not canonicalized_address:
-        return []  # TODO
-
-    tract_location = residence_census_tract(db, (lat, lng), housing_type)
-    # TODO what if tract_location is null?
-    tract_full_url = generate_full_url_uuid()
-    tract_entry = create_resource_entry(tract_location, tract_full_url)
-
-    address_hash = generate_hash(canonicalized_address)
-    address_location = create_location(
-        f"{INTERNAL_SYSTEM}/location/address",
-        address_hash,
-        housing_type,
-        tract_full_url
-    )
-    address_entry = create_resource_entry(address_location, generate_full_url_uuid())
-
-    return [tract_entry, address_entry]
-
-
-def residence_census_tract(db: DatabaseSession, lat_lng: Tuple[float, float],
-    housing_type: str) -> Optional[dict]:
-    """
-    Creates a new Location Resource for the census tract containing the given
-    *lat_lng* coordintes and associates it with the given *housing_type*.
-    """
-    location = location_lookup(db, lat_lng, 'tract')
-
-    if location and location.identifier:
-        return create_location(
-            f"{INTERNAL_SYSTEM}/location/tract", location.identifier, housing_type
-        )
-    else:
-        LOG.warning("No census tract found for given location.")
-        return None
-
-
-def create_location(system: str, value: str, location_type: str, parent: str=None) -> dict:
-    """ Returns a FHIR Location resource. """
-    location_type_system = "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-    location_type_map = {
-        "residence": "PTRES",
-        "school": "SCHOOL",
-        "work": "WORK",
-        "site": "HUSCS",
-        "lodging": "PTLDG",
-    }
-
-    location_type_cc = create_codeable_concept(location_type_system,
-                                            location_type_map[location_type])
-    location_identifier = create_identifier(system, value)
-    part_of = None
-    if parent:
-        part_of = create_reference(reference_type="Location", reference=parent)
-
-    return create_location_resource([location_type_cc], [location_identifier], part_of)
-
-
-def create_patient(record: REDCapRecord) -> tuple:
-    """ Returns a FHIR Patient resource entry and reference. """
-    gender = map_sex(record['core_sex'])
-
-    language_codeable_concept = create_codeable_concept(
-        system = 'urn:ietf:bcp:47',
-        code = LANGUAGE_CODE[record.project.id]
-    )
-    communication = [{
-        'language' : language_codeable_concept,
-        'preferred': True # Assumes that the project language is the patient's preferred language
-    }]
-
-    net_id = normalize_net_id(record.get('netid'))
-    if net_id:
-        patient_id = generate_hash(net_id)
-    else:
-        patient_id = generate_patient_hash(
-            names       = (record['core_participant_first_name'], record['core_participant_last_name']),
-            gender      = gender,
-            birth_date  = record['core_birthdate'],
-            postal_code = record['core_zipcode'])
-
-    if not patient_id:
-        # Some piece of information was missing, so we couldn't generate a
-        # hash.  Fallback to treating this individual as always unique by using
-        # the REDCap record id.
-        patient_id = generate_hash(f"{REDCAP_URL}{record.project.id}/{record['record_id']}")
-
-    LOG.debug(f"Generated individual identifier {patient_id}")
-
-    patient_identifier = create_identifier(f"{INTERNAL_SYSTEM}/individual", patient_id)
-    patient_resource = create_patient_resource([patient_identifier], gender, communication)
-
-    return create_entry_and_reference(patient_resource, "Patient")
-
-
-def create_encounter(record: REDCapRecord, patient_reference: dict,
-    site_reference: dict, locations: list, event_type: EventType,
-    collection_method: CollectionMethod) -> tuple:
-    """
-    Returns a FHIR Encounter resource entry and reference for the encounter in the study.
-    """
-
-    def grab_symptom_key(key: str, variable_name: str) -> Optional[Match[str]]:
-        if record[key] == '1':
-            return re.match(f"{variable_name}___[a-z_]+", key)
-        else:
-            return None
-
-    def build_condition(symptom: str, onset_date: str) -> dict:
-        return create_resource_condition(record, symptom, patient_reference, onset_date)
-
-    def build_diagnosis(symptom: str) -> Optional[dict]:
-        mapped_symptom = map_symptom(symptom)
-        if not mapped_symptom:
-            return None
-
-        return { "condition": { "reference": f"#{mapped_symptom}" } }
-
-    def build_locations_list(location: dict) -> dict:
-        return {
-            "location": create_reference(
-                reference_type = "Location",
-                reference = location["fullUrl"]
-            )
-        }
-
-    def non_tract_locations(resource: dict):
-        return bool(resource) \
-            and resource['resource']['identifier'][0]['system'] != f"{INTERNAL_SYSTEM}/location/tract"
-
-    # Map the various symptoms variables to their onset date.
-    # For daily_symptoms_covid_like we don't know the actual onset date. The questions asks
-    # "in the past 24 hours"
-    if event_type == EventType.ENCOUNTER:
-        symptom_onset_map = {
-            'daily_symptoms_covid_like': None,
-            'symptoms': record['symptom_onset'],
-            'symptoms_kiosk': record['symptom_duration_kiosk'],
-            'symptoms_swabsend': record['symptom_duration_swabsend']
-        }
-    elif event_type == EventType.ENROLLMENT:
-        symptom_onset_map = {'symptoms_base': record['symptom_onset_base']}
-
-    contained = []
-    diagnosis = []
-
-    for symptom_variable in symptom_onset_map:
-        symptom_keys = []
-
-        for redcap_key in record.keys():
-            symptom_key = grab_symptom_key(redcap_key, symptom_variable)
-            if symptom_key:
-                symptom_keys.append(symptom_key.string)
-
-        symptoms = list(map(lambda x: re.sub('[a-z_]+___', '', x), symptom_keys))
-        for symptom in symptoms:
-            contained.append(build_condition(symptom, symptom_onset_map[symptom_variable]))
-            diagnosis.append(build_diagnosis(symptom))
-
-    encounter_identifier = create_identifier(
-        system = f"{INTERNAL_SYSTEM}/encounter",
-        value = f"{REDCAP_URL}{record.project.id}/{record['record_id']}/{record['redcap_event_name']}/{record['redcap_repeat_instance']}"
-    )
-
-    collection_code = None
-
-    # See https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html for
-    # possible collection codes.
-    # HH = 'home health'
-    # FLD = 'field'
-    if event_type == EventType.ENROLLMENT or collection_method == CollectionMethod.SWAB_AND_SEND:
-        collection_code = "HH"
-    elif collection_method == CollectionMethod.KIOSK:
-        collection_code = "FLD"
-
-    # For the encounter_date for an ENCOUNTER, first try the attestation_date
+def get_encounter_date(record: dict, event_type: EventType) -> Optional[str]:
+    # First try the attestation_date
     # from the daily attestation survey then try nasal_swab_timestamp from
     # the kiosk registration and finally the swab-and-send order date.
     encounter_date = None
@@ -524,120 +393,13 @@ def create_encounter(record: REDCapRecord, patient_reference: dict,
     elif event_type == EventType.ENROLLMENT:
         encounter_date = record.get('enrollment_date')
 
-    if not encounter_date:
-        return None, None
-
-    encounter_class_coding = create_coding(
-        system = "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        code = collection_code
-    )
-
-    non_tracts = list(filter(non_tract_locations, locations))
-    non_tract_references = list(map(build_locations_list, non_tracts))
-    # Add hard-coded site Location reference
-    if site_reference:
-        non_tract_references.append(site_reference)
-
-    encounter_resource = create_encounter_resource(
-        encounter_source = create_redcap_uri(record),
-        encounter_identifier = [encounter_identifier],
-        encounter_class = encounter_class_coding,
-        encounter_date = encounter_date,
-        patient_reference = patient_reference,
-        location_references = non_tract_references,
-        diagnosis = diagnosis,
-        contained = contained
-    )
-
-    return create_entry_and_reference(encounter_resource, "Encounter")
-
-
-def create_resource_condition(record: dict, symptom_name: str, patient_reference: dict, onset_date:str) -> Optional[dict]:
-    """ Returns a FHIR Condition resource. """
-    mapped_symptom_name = map_symptom(symptom_name)
-    if not mapped_symptom_name:
+    else:
         return None
 
-    # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
-    # 3.8.  Until then, there's no reasonable way to type this data structure
-    # better than Any.
-    #   -trs, 24 Oct 2019
-    condition: Any = {
-        "resourceType": "Condition",
-        "id": f'{mapped_symptom_name}',
-        "code": {
-            "coding": [
-                {
-                    "system": f"{INTERNAL_SYSTEM}/symptom",
-                    "code": mapped_symptom_name
-                }
-            ]
-        },
-        "subject": patient_reference
-    }
-
-    if onset_date:
-        condition["onsetDateTime"] = onset_date
-
-    return condition
+    return encounter_date
 
 
-def create_specimen(record: dict, patient_reference: dict, collection_method: CollectionMethod) -> tuple:
-    """ Returns a FHIR Specimen resource entry and reference """
-
-    def specimen_barcode() -> Optional[str]:
-        """
-        Return specimen barcode from REDCap record.
-        """
-         # Normalize all barcode fields upfront.
-        barcode_fields = {
-            # Kiosk related
-            "collect_barcode_kiosk", # from	kiosk_registration_4c7f
-
-            # Swab and Send related
-            "pre_scan_barcode", # from test_fulfillment_form
-            "barcode_swabsend",	# from husky_test_kit_registration
-            "return_utm_barcode", # from post_collection_data_entry_qc
-        }
-
-        for barcode_field in barcode_fields:
-            record[barcode_field] = record[barcode_field].strip().lower()
-
-        return record["collect_barcode_kiosk"] or record["return_utm_barcode"] or \
-            record["pre_scan_barcode"] or None
-
-
-    barcode = specimen_barcode()
-
-    if not barcode:
-        LOG.warning("Could not create Specimen Resource due to lack of barcode.")
-        return None, None
-
-    specimen_identifier = create_identifier(
-        system = f"{INTERNAL_SYSTEM}/sample",
-        value = barcode
-    )
-
-    # YYYY-MM-DD HH:MM:SS in REDCap
-    received_time = record['samp_process_date'].split()[0] if record.get('samp_process_date') else None
-
-    note = None
-
-    if record['able_to_test'] == 'no':
-        note = 'never-tested'
-    else:
-        note = 'can-test'
-
-    specimen_type = 'NSECR'  # Nasal swab.
-    specimen_resource = create_specimen_resource(
-        [specimen_identifier], patient_reference, specimen_type, received_time,
-        collection_date(record, collection_method), note
-    )
-
-    return create_entry_and_reference(specimen_resource, "Specimen")
-
-
-def collection_date(record: dict, collection_method: CollectionMethod) -> Optional[str]:
+def get_collection_date(record: dict, collection_method: CollectionMethod) -> Optional[str]:
     """
     Determine sample/specimen collection date from the given REDCap *record*.
     """
@@ -648,24 +410,9 @@ def collection_date(record: dict, collection_method: CollectionMethod) -> Option
     else:
         return None
 
-def combine_multiple_fields(record: Dict[Any, Any], field_prefix: str, field_suffix: str = "") -> Optional[List]:
-        """
-        Handles the combining of multiple fields asking the same question such
-        as country and state traveled.
-        """
-        regex = rf'^{re.escape(field_prefix)}[0-9]+{re.escape(field_suffix)}$'
-        empty_value = ''
-        answered_fields = list(filter(lambda f: filter_fields(f, record[f], regex, empty_value), record))
 
-        if not answered_fields:
-            return None
-
-        return list(map(lambda x: record[x], answered_fields))
-
-
-
-def create_enrollment_questionnaire_response(record: dict, patient_reference: dict,
-                                            encounter_reference: dict) -> Optional[dict]:
+def create_enrollment_questionnaire_response(record: REDCapRecord, patient_reference: dict,
+    encounter_reference: dict) -> Optional[dict]:
     """
     Returns a FHIR Questionnaire Response resource entry for the enrollment
     encounter (i.e. encounter of enrollment into the study)
@@ -800,236 +547,19 @@ def create_enrollment_questionnaire_response(record: dict, patient_reference: di
         tier = 3
     record['tier'] = tier
 
-    return questionnaire_response(record, question_categories, patient_reference, encounter_reference, True)
+    vaccine_item = create_vaccine_item(record["vaccine"], record['vaccine_year'], record['vaccine_month'], 'dont_know')
 
-
-def filter_fields(field: str, field_value: str, regex: str, empty_value: str) -> bool:
-    """
-    Function that filters for *field* matching given *regex* and the
-    *field_value* must not equal the expected *empty_value.
-    """
-    if re.match(regex, field) and field_value != empty_value:
-        return True
-
-    return False
-
-
-def combine_checkbox_answers(record: dict, coded_question: str) -> Optional[List]:
-    """
-    Handles the combining "select all that apply"-type checkbox
-    responses into one list.
-
-    Uses our in-house mapping for race and symptoms
-    """
-    regex = rf'{re.escape(coded_question)}___[\w]*$'
-    empty_value = '0'
-    answered_checkboxes = list(filter(lambda f: filter_fields(f, record[f], regex, empty_value), record))
-    # REDCap checkbox fields have format of {question}___{answer}
-    answers = list(map(lambda k: k.replace(f"{coded_question}___", ""), answered_checkboxes))
-
-    if coded_question == 'race':
-        return race(answers)
-
-    if re.match(r'fu_[1-4]_symptoms$', coded_question):
-        return list(map(lambda a: map_symptom(a), answers))
-
-    return answers
-
-def map_vaccine(vaccine_response: str) -> Optional[bool]:
-    """
-    Maps a vaccine response to FHIR immunization status codes
-    (https://www.hl7.org/fhir/valueset-immunization-status.html)
-    """
-    vaccine_map = {
-        'yes': True,
-        'no': False,
-        'dont_know': None,
-        '': None
-    }
-
-    if vaccine_response not in vaccine_map:
-        raise UnknownVaccineResponseError(f"Unknown vaccine response «{vaccine_response}»")
-
-    return vaccine_map[vaccine_response]
-
-def vaccine(record: Any) -> Optional[dict]:
-    """
-    For a given *record*, return a questionnaire response item with the vaccine
-    response(s) encoded.
-    """
-    vaccine_status = map_vaccine(record["vaccine"])
-    if vaccine_status is None:
-        return None
-
-    answers: List[Dict[str, Any]] = [{ 'valueBoolean': vaccine_status }]
-
-    date = vaccine_date(record)
-    if vaccine_status and date:
-        answers.append({ 'valueDate': date })
-
-    return create_questionnaire_response_item('vaccine', answers)
-
-
-def vaccine_date(record: dict) -> Optional[str]:
-    """ Converts a vaccination date to 'YYYY' or 'YYYY-MM' format. """
-    year = record['vaccine_year']
-    month = record['vaccine_month']
-
-    if year == '' or year == 'dont_know':
-        return None
-
-    if month == 'dont_know':
-        return datetime.strptime(year, '%Y').strftime('%Y')
-
-    return datetime.strptime(f'{month} {year}', '%B %Y').strftime('%Y-%m')
-
-
-def questionnaire_response(record: dict,
-                           question_categories: Dict[str, list],
-                           patient_reference: dict,
-                           encounter_reference: dict,
-                           include_vaccine_item: bool) -> Optional[dict]:
-    """
-    Provided a dictionary of *question_categories* with the key being the value
-    type and the value being a list of field names, return a FHIR
-    Questionnaire Response resource entry.
-    """
-    def build_questionnaire_items(question: str) -> Optional[dict]:
-        return questionnaire_item(record, question, category)
-
-    items: List[dict] = []
-    for category in question_categories:
-        category_items = list(map(build_questionnaire_items, question_categories[category]))
-        for item in category_items:
-            if item:
-                items.append(item)
-
-    if include_vaccine_item:
-        vaccine_item = vaccine(record)
-        if vaccine_item:
-            items.append(vaccine_item)
-
-    if items:
-        questionnaire_reseponse_resource = create_questionnaire_response_resource(
-            patient_reference, encounter_reference, items
-        )
-        full_url = generate_full_url_uuid()
-        return create_resource_entry(questionnaire_reseponse_resource, full_url)
-
-    return None
-
-
-def questionnaire_item(record: dict, question_id: str, response_type: str) -> Optional[dict]:
-    """ Creates a QuestionnaireResponse internal item from a REDCap record.
-    """
-    response = record.get(question_id)
-    if not response:
-        return None
-
-    def cast_to_coding(string: str):
-        """ Currently the only QuestionnaireItem we code is race. """
-        return create_coding(
-            system = f"{INTERNAL_SYSTEM}/race",
-            code = string,
-        )
-
-    def cast_to_string(string: str) -> Optional[str]:
-        if string != '':
-            return string.strip()
-        return None
-
-    def cast_to_integer(string: str) -> Optional[int]:
-        try:
-            return int(string)
-        except ValueError:
-            return None
-
-    def cast_to_float(string: str) -> Optional[float]:
-        try:
-            return float(string)
-        except ValueError:
-            return None
-
-    def cast_to_boolean(string: str) -> Optional[bool]:
-        if (string and string.lower() == 'yes') or string == '1':
-            return True
-        elif (string and string.lower() == 'no') or string == '0':
-            return False
-        return None
-
-    def build_response_answers(response: Union[str, List]) -> List:
-        answers = []
-        if not isinstance(response, list):
-            response = [response]
-
-        for item in response:
-            type_casted_item = casting_functions[response_type](item)
-
-            # cast_to_boolean can return False, so must be `is not None`
-            if type_casted_item is not None:
-                answers.append({ response_type: type_casted_item })
-
-        return answers
-
-    casting_functions: Mapping[str, Callable[[str], Any]] = {
-        'valueCoding': cast_to_coding,
-        'valueInteger': cast_to_integer,
-        'valueBoolean': cast_to_boolean,
-        'valueString': cast_to_string,
-        'valueDate': cast_to_string,
-        'valueDecimal': cast_to_float
-    }
-
-    answers = build_response_answers(response)
-    if answers:
-        return create_questionnaire_response_item(question_id, answers)
-
-    return None
-
-
-def create_follow_up_encounter(record: REDCapRecord,
-                               patient_reference: dict,
-                               site_reference: dict,
-                               initial_encounter_reference: dict) -> tuple:
-    """
-    Returns a FHIR Encounter resource entry and reference for a follow-up
-    encounter
-    """
-    if not record.get('fu_timestamp'):
-        return None, None
-
-    encounter_identifier = create_identifier(
-        system = f"{INTERNAL_SYSTEM}/encounter",
-        value = f"{REDCAP_URL}{record.project.id}/{record['record_id']}/{record['redcap_event_name']}/{record['redcap_repeat_instance']}_follow_up"
-    )
-    encounter_class_coding = create_coding(
-        system = "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        code = "HH"
-    )
-    encounter_reason_code = create_codeable_concept(
-        system = "http://snomed.info/sct",
-        code = "390906007",
-        display = "Follow-up encounter"
-    )
-
-    # YYYY-MM-DD HH:MM in REDCap
-    encounter_date = record['fu_timestamp'].split()[0]
-    encounter_resource = create_encounter_resource(
-        encounter_source = create_redcap_uri(record),
-        encounter_identifier = [encounter_identifier],
-        encounter_class = encounter_class_coding,
-        encounter_date = encounter_date,
+    return create_questionnaire_response(
+        record = record,
+        question_categories = question_categories,
         patient_reference = patient_reference,
-        location_references = [site_reference],
-        reason_code = [encounter_reason_code],
-        part_of = initial_encounter_reference
-    )
-
-    return create_entry_and_reference(encounter_resource, "Encounter")
+        encounter_reference = encounter_reference,
+        system_identifier = INTERNAL_SYSTEM,
+        additional_items = [vaccine_item])
 
 
-def create_follow_up_questionnaire_response(record: dict, patient_reference: dict,
-                                            encounter_reference: dict) -> Optional[dict]:
+def create_follow_up_questionnaire_response(record: REDCapRecord, patient_reference: dict,
+    encounter_reference: dict) -> Optional[dict]:
     """
     Returns a FHIR Questionnaire Response resource entry for the follow-up
     encounter.
@@ -1126,10 +656,18 @@ def create_follow_up_questionnaire_response(record: dict, patient_reference: dic
     for field in checkbox_fields:
         record[field] = combine_checkbox_answers(record, field)
 
-    return questionnaire_response(record, question_categories, patient_reference, encounter_reference, False)
+    return create_questionnaire_response(
+        record = record,
+        question_categories = question_categories,
+        patient_reference = patient_reference,
+        encounter_reference = encounter_reference,
+        system_identifier = INTERNAL_SYSTEM,
+        additional_items = None)
 
-def create_testing_determination_internal_questionnaire_response(record: dict, patient_reference: dict,
-                                            encounter_reference: dict) -> Optional[dict]:
+
+
+def create_testing_determination_internal_questionnaire_response(record: REDCapRecord, patient_reference: dict,
+    encounter_reference: dict) -> Optional[dict]:
     """
     Returns a FHIR Questionnaire Response resource entry for the
     testing_determination_internal instrument. This instrument is used
@@ -1151,11 +689,17 @@ def create_testing_determination_internal_questionnaire_response(record: dict, p
         'valueString': string_questions,
     }
 
-    return questionnaire_response(record, question_categories, patient_reference, encounter_reference, False)
+    return create_questionnaire_response(
+        record = record,
+        question_categories = question_categories,
+        patient_reference = patient_reference,
+        encounter_reference = encounter_reference,
+        system_identifier = INTERNAL_SYSTEM,
+        additional_items = None)
 
-def create_computed_questionnaire_response(record: dict, patient_reference: dict,
-                                            encounter_reference: dict,
-                                            birthdate: datetime, encounter_date: datetime) -> Optional[dict]:
+
+def create_computed_questionnaire_response(record: REDCapRecord, patient_reference: dict,
+    encounter_reference: dict, birthdate: datetime, encounter_date: datetime) -> Optional[dict]:
     """
     Returns a FHIR Questionnaire Response resource entry for a
     computed questionnaire. This "computed questionnaire" produces
@@ -1179,10 +723,17 @@ def create_computed_questionnaire_response(record: dict, patient_reference: dict
         'valueInteger': integer_questions
     }
 
-    return questionnaire_response(record, question_categories, patient_reference, encounter_reference, False)
+    return create_questionnaire_response(
+        record = record,
+        question_categories = question_categories,
+        patient_reference = patient_reference,
+        encounter_reference = encounter_reference,
+        system_identifier = INTERNAL_SYSTEM,
+        additional_items = None)
 
-def create_daily_questionnaire_response(record: dict, patient_reference: dict,
-                                            encounter_reference: dict) -> Optional[dict]:
+
+def create_daily_questionnaire_response(record: REDCapRecord, patient_reference: dict,
+    encounter_reference: dict) -> Optional[dict]:
     """
     Returns a FHIR Questionnaire Response resource entry for the daily
     attestation questionnaire.
@@ -1245,20 +796,10 @@ def create_daily_questionnaire_response(record: dict, patient_reference: dict,
     record['countries_visited'] = combine_multiple_fields(record, 'country')
     record['states_visited'] = combine_multiple_fields(record, 'state')
 
-    return questionnaire_response(record, question_categories, patient_reference, encounter_reference, False)
-
-
-class UnknownRedcapZipCode(ValueError):
-    """
-    Raised by :function: `zipcode_map` if a provided *redcap_code* is not
-    among a set of expected values.
-    """
-    pass
-
-
-class UnknownRedcapRecordLocation(ValueError):
-    """
-    Raised by :function: `site_map` if a provided *redcap_location* is not
-    among a set of expected values.
-    """
-    pass
+    return create_questionnaire_response(
+        record = record,
+        question_categories = question_categories,
+        patient_reference = patient_reference,
+        encounter_reference = encounter_reference,
+        system_identifier = INTERNAL_SYSTEM,
+        additional_items = None)

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -120,9 +120,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
             sex = enrollment['core_sex'],
             preferred_language = LANGUAGE_CODE[project_id],
             unique_identifier = netid,
-            redcap_url = REDCAP_URL,
-            redcap_project_id = project_id,
-            redcap_record_id = record_id,
+            record = enrollment,
             system_identifier = INTERNAL_SYSTEM)
     else:
         patient_entry, patient_reference = create_patient_using_demographics(
@@ -132,9 +130,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
             last_name = enrollment['core_participant_last_name'],
             birth_date = enrollment['core_birthdate'],
             zipcode = enrollment['core_zipcode'],
-            redcap_url = REDCAP_URL,
-            redcap_project_id = project_id,
-            redcap_record_id = record_id,
+            record = enrollment,
             system_identifier = INTERNAL_SYSTEM)
 
     if not patient_entry:
@@ -245,12 +241,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
             encounter_reason_code = None,
             encounter_identifier_suffix = None,
             system_identifier = INTERNAL_SYSTEM,
-            redcap_uri = create_redcap_uri(redcap_record_instance),
-            redcap_url = REDCAP_URL,
-            redcap_project_id = project_id,
-            redcap_record_id = record_id,
-            redcap_event_name = redcap_record_instance['redcap_event_name'],
-            redcap_repeat_instance = redcap_record_instance['redcap_repeat_instance'])
+            record = redcap_record_instance)
 
         # Skip the entire record if we can't create the enrollment encounter.
         # Otherwise, just skip the record instance.
@@ -334,12 +325,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
                     encounter_reason_code = follow_up_encounter_reason_code(),
                     encounter_identifier_suffix = "_follow_up",
                     system_identifier = INTERNAL_SYSTEM,
-                    redcap_uri = create_redcap_uri(redcap_record_instance),
-                    redcap_url = REDCAP_URL,
-                    redcap_project_id = project_id,
-                    redcap_record_id = record_id,
-                    redcap_event_name = redcap_record_instance['redcap_event_name'],
-                    redcap_repeat_instance = redcap_record_instance['redcap_repeat_instance'])
+                    record = redcap_record_instance)
 
 
                 follow_up_questionnaire_entry = create_follow_up_questionnaire_response(

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -42,7 +42,7 @@ class EventType(Enum):
     ENROLLMENT = 'enrollment'
     ENCOUNTER = 'encounter'
 
-REVISION = 2
+REVISION = 3
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -514,12 +514,6 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     record['countries_visited_base'] = combine_multiple_fields(record, 'country', '_base')
     record['states_visited_base'] = combine_multiple_fields(record, 'state', '_base')
 
-    # Age Ceiling
-    try:
-        record['core_age_years'] = age_ceiling(int(record['core_age_years']))
-    except ValueError:
-        record['core_age_years'] = record['core_age_years'] = None
-
     # Set the study tier
     tier = None
     if record['tier_1'] == '1':
@@ -692,10 +686,16 @@ def create_computed_questionnaire_response(record: REDCapRecord, patient_referen
     """
     # A birthdate of None will return a falsy relativedelta() object
     delta = relativedelta(encounter_date, birthdate)
+
     if not delta:
         age = None
     else:
-        age = delta.years
+        # Age Ceiling
+        try:
+            age = age_ceiling(delta.years)
+        except ValueError:
+            age = None
+
     record['age'] = age
 
     integer_questions = [

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -351,7 +351,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
     return create_bundle_resource(
         bundle_id = str(uuid4()),
         timestamp = datetime.now().astimezone().isoformat(),
-        source = f"{REDCAP_URL}{str(redcap_record_instance.project.id)}/{redcap_record_instance.id}",
+        source = f"{REDCAP_URL}{enrollment.project.id}/{enrollment.id}",
         entries = list(filter(None, persisted_resource_entries))
     )
 


### PR DESCRIPTION
This change moves common code from redcap_det_uw_reopening.py to redcap.py so that the code can be reused for other REDCap ETL projects.

The work was primarily cut-and-paste, but some elements were parameterized to accommodate differences between REDCap projects and future needs. For example, in redcap.py, the internal system ("https://seattleflu.org" in redcap_det_uw_reopening.py) is passed in as a parameter.

For testing, I processed the same test record through the code in the master branch and through this feature branch. In a diff I see that the only differences are the reference and fullUrl uuids and the timestamp at the head of the document.