### PR TITLE
Testing trigger

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -56,7 +56,7 @@ class EventType(Enum):
     ENROLLMENT = 'enrollment'
     ENCOUNTER = 'encounter'
 
-REVISION = 1
+REVISION = 2
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -1137,14 +1137,17 @@ def create_testing_determination_internal_questionnaire_response(record: dict, p
     questionnaire we do want to return answers for all questions even if they are
     not answered.
     """
+    boolean_questions = [
+        'testing_trigger',
+    ]
 
     string_questions = [
-        'testing_trigger',
         'testing_type',
     ]
 
     question_categories = {
-        'valueString': string_questions
+        'valueBoolean': boolean_questions,
+        'valueString': string_questions,
     }
 
     return questionnaire_response(record, question_categories, patient_reference, encounter_reference, False)

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -1141,7 +1141,6 @@ def create_testing_determination_internal_questionnaire_response(record: dict, p
     string_questions = [
         'testing_trigger',
         'testing_type',
-        'surge_selected'
     ]
 
     question_categories = {

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -1139,6 +1139,7 @@ def create_testing_determination_internal_questionnaire_response(record: dict, p
     """
     boolean_questions = [
         'testing_trigger',
+        'surge_selected_flag',
     ]
 
     string_questions = [


### PR DESCRIPTION
Convert `testing_trigger` to a boolean, and stop ingesting the free text field `surge_selected`.

Depends on the `surge_selected_flag` to be in the production REDCap.