### PR TITLE
redcap.py: Skip additional_items that are None

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -675,7 +675,7 @@ def create_questionnaire_response(record: REDCapRecord, question_categories: Dic
                 items.append(item)
 
     if additional_items:
-        items.extend(additional_items)
+        items.extend(list(filter(None, additional_items)))
 
     if items:
         questionnaire_reseponse_resource = create_questionnaire_response_resource(


### PR DESCRIPTION
When building questionnaire items, don't add additional_items to the
items list if they are None.