### PR TITLE
Add valueDecimal support to a shipping view

### DIFF
--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -141,6 +141,7 @@ create materialized view shipping.fhir_questionnaire_responses_v1 as
            bool_and("valueBoolean") as boolean_response,
            array_remove(array_agg("valueDate" order by "valueDate"), null) as date_response,
            array_remove(array_agg("valueInteger" order by "valueInteger"), null) as integer_response,
+           array_remove(array_agg("valueDecimal" order by "valueDecimal"), null) as double_response,
            array_remove(array_agg("code" order by "code"), null) as code_response
       from warehouse.encounter,
            jsonb_to_recordset(details -> 'QuestionnaireResponse') as q("item" jsonb),
@@ -149,6 +150,7 @@ create materialized view shipping.fhir_questionnaire_responses_v1 as
                                                   "valueBoolean" bool,
                                                   "valueDate" text,
                                                   "valueInteger" integer,
+                                                  "valueDecimal" double precision,
                                                   "valueCoding" jsonb),
            jsonb_to_record("valueCoding") as code("code" text)
     -- Don't need age because it is formalized in `warehouse.encounter.age`

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -2602,8 +2602,8 @@ create or replace view shipping.uw_reopening_enrollment_fhir_encounter_details_v
   ,(select integer_response[1] from shipping.fhir_questionnaire_responses_v1 where encounter_id = encounter.encounter_id and link_id = 'height_total') as height_total
   ,(select integer_response[1] from shipping.fhir_questionnaire_responses_v1 where encounter_id = encounter.encounter_id and link_id = 'tier') as tier
 
-  --numeric questions:
-  --,(select decimal_response[1] from shipping.fhir_questionnaire_responses_v1 where encounter_id = encounter.encounter_id and link_id = 'bmi') as bmi
+  --double questions:
+  ,(select double_response[1] from shipping.fhir_questionnaire_responses_v1 where encounter_id = encounter.encounter_id and link_id = 'bmi') as bmi
 
   --date questions:
   ,(select date_response[1] from shipping.fhir_questionnaire_responses_v1 where encounter_id = encounter.encounter_id and link_id = 'today_consent') as today_consent
@@ -2757,7 +2757,7 @@ create or replace view shipping.uw_reopening_encounters_v1 as
   , enroll_details.height_total
   , enroll_details.tier
 
-   -- , enroll_details.bmi
+  , enroll_details.bmi
 
   , enroll_details.today_consent
   , enroll_details.enrollment_date_time

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -1079,8 +1079,10 @@ create or replace view shipping.hcov19_observation_v1 as
         upper(age_bin_fine_v2.range) as age_range_fine_upper,
         sex,
 
-        -- Misc cruft
-        sample.details->>'sample_origin' as manifest_origin
+        -- Sample detail columns
+        sample.details->>'sample_origin' as manifest_origin,
+        sample.details->>'swab_type' as swab_type,
+        sample.details->>'collection_matrix' as collection_matrix
 
         /* Extra variables from SCAN REDCap project are available in
         * shipping.fhir_encounter_details_v2. Roy from IDM has opted

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -250,3 +250,4 @@ shipping/views [shipping/views@2020-10-27] 2020-10-27T22:44:31Z Kristen Schwabe-
 @2020-10-28 2020-10-28T18:20:34Z Kristen Schwabe-Fry <2600836+kschwabefry@users.noreply.github.com> # Schema as of 28 October 2020
 
 shipping/views [shipping/views@2020-10-28] 2020-10-28T19:19:01Z Chris Craft <jccraft@uw.edu> # Add valueDecimal support to fhir_questionnaire_responses_v1
+@2020-10-28b 2020-10-28T22:43:46Z Chris Craft <jccraft@uw.edu> # Schema as of later on 28 October 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -248,3 +248,5 @@ shipping/views [shipping/views@2020-10-14] 2020-10-23T16:56:08Z Kristen Schwabe-
 @2020-10-27 2020-10-27T20:03:52Z Kristen Schwabe-Fry <2600836+kschwabefry@users.noreply.github.com> # Schema as of 27 October 2020
 shipping/views [shipping/views@2020-10-27] 2020-10-27T22:44:31Z Kristen Schwabe-Fry <2600836+kschwabefry@users.noreply.github.com> # Add sample swab type and media type to shipping.hcov19_observation_v1
 @2020-10-28 2020-10-28T18:20:34Z Kristen Schwabe-Fry <2600836+kschwabefry@users.noreply.github.com> # Schema as of 28 October 2020
+
+shipping/views [shipping/views@2020-10-28] 2020-10-28T19:19:01Z Chris Craft <jccraft@uw.edu> # Add valueDecimal support to fhir_questionnaire_responses_v1


### PR DESCRIPTION
In recent projects we started capturing questionnaire items as the
valueDecimal FHIR value type. Today, we're capturing `bmi` as valueDecimal.
We need to expose these in the shipping.fhir_questionnaire_responses_v1
view.

In python we capture these as `float`. In the shipping view we expose them
as the postgres `double precision` type. This type allows for 15 digits
of precision. We probably don't need that much precision for `bmi` but we
may for other items that get stored as valueDecimal.

** I'll create the sqitch tag just before deploying.