### PR TITLE
etl redcap-det: Ignore float values which are non-finite (NaN and ±Inf)

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -3,6 +3,7 @@ Functions shared by REDCap DET ETL
 """
 from datetime import datetime
 from enum import Enum
+from math import isfinite
 import re
 from typing import Dict, List, Mapping, Match, Optional, Tuple, Union
 
@@ -611,9 +612,11 @@ def questionnaire_item(record: REDCapRecord, question_id: str, response_type: st
 
     def cast_to_float(string: str) -> Optional[float]:
         try:
-            return float(string)
+            n = float(string)
         except ValueError:
             return None
+
+        return n if isfinite(n) else None
 
 
     def cast_to_boolean(string: str) -> Optional[bool]:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
@@ -409,11 +409,6 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, study_arm: St
 
     record['study_arm'] = study_arm.value
 
-    # Having weight but not height will yield a BMI of 'INF' and cause
-    # an `Out of range float values are not JSON compliant` error.
-    if record.get('bmi') == 'INF':
-        record['bmi'] = None
-
     for field in checkbox_fields:
         record[field] = combine_checkbox_answers(record, field)
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -543,11 +543,6 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         tier = 3
     record['tier'] = tier
 
-    # Having weight but not height will yield a BMI of 'INF' and cause
-    # an `Out of range float values are not JSON compliant` error.
-    if record.get('bmi') == 'INF':
-        record['bmi'] = None
-
     vaccine_item = create_vaccine_item(record["vaccine"], record['vaccine_year'], record['vaccine_month'], 'dont_know')
 
     return create_questionnaire_response(


### PR DESCRIPTION
Generalize non-finite float handling and remove special-casing. Details in commits.