### PR TITLE
Lower log level when no quota exists for uw offers

### DIFF
--- a/lib/seattleflu/id3c/cli/command/offer_uw_testing.py
+++ b/lib/seattleflu/id3c/cli/command/offer_uw_testing.py
@@ -89,11 +89,11 @@ def offer_uw_testing(*, at: str, log_offers: bool, db: DatabaseSession, action: 
         """, (at,))
 
     if not quota:
-        LOG.warning(f"No quota row found, aborting")
+        LOG.info(f"No quota row found, aborting")
         return
 
     if not quota.remaining > 0:
-        LOG.warning(f"No quota remaining for {quota.name} during {quota.timespan}, aborting")
+        LOG.info(f"No quota remaining for {quota.name} during {quota.timespan}, aborting")
         return
 
     LOG.info(


### PR DESCRIPTION
We expect the job to run all the time, but we will purposefully not
configure quotas for hours outside "waking" hours as not to annoy
participants with alerts from REDCap. This change lowers the log
level from WARNING to INFO for two cases when the job doesn't find
a quota to work with.