### PR TITLE
Create new versions of our modeling views

### DIFF
--- a/schema/deploy/shipping/views@2020-12-01.sql
+++ b/schema/deploy/shipping/views@2020-12-01.sql
@@ -41,7 +41,6 @@ drop view if exists shipping.flu_assembly_jobs_v1;
 drop view if exists shipping.scan_follow_up_encounters_v1;
 drop materialized view if exists shipping.scan_encounters_v1;
 drop view if exists shipping.hcov19_observation_v1;
-drop view if exists shipping.hcov19_presence_absence_result_v1;
 
 drop view if exists shipping.observation_with_presence_absence_result_v2;
 drop view if exists shipping.observation_with_presence_absence_result_v1;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -40,15 +40,18 @@ drop view if exists shipping.flu_assembly_jobs_v1;
 
 drop view if exists shipping.scan_follow_up_encounters_v1;
 drop materialized view if exists shipping.scan_encounters_v1;
-drop view if exists shipping.hcov19_observation_v1;
-drop view if exists shipping.hcov19_presence_absence_result_v1;
 
+drop view if exists shipping.observation_with_presence_absence_result_v3;
 drop view if exists shipping.observation_with_presence_absence_result_v2;
 drop view if exists shipping.observation_with_presence_absence_result_v1;
 
+drop view if exists shipping.incidence_model_observation_v4;
 drop view if exists shipping.incidence_model_observation_v3;
 drop view if exists shipping.incidence_model_observation_v2;
 drop view if exists shipping.incidence_model_observation_v1;
+
+drop view if exists shipping.hcov19_observation_v1;
+drop view if exists shipping.hcov19_presence_absence_result_v1;
 
 drop view if exists shipping.fhir_encounter_details_v2;
 drop view if exists shipping.fhir_encounter_details_v1;

--- a/schema/revert/shipping/views@2020-12-01.sql
+++ b/schema/revert/shipping/views@2020-12-01.sql
@@ -41,7 +41,6 @@ drop view if exists shipping.flu_assembly_jobs_v1;
 drop view if exists shipping.scan_follow_up_encounters_v1;
 drop materialized view if exists shipping.scan_encounters_v1;
 drop view if exists shipping.hcov19_observation_v1;
-drop view if exists shipping.hcov19_presence_absence_result_v1;
 
 drop view if exists shipping.observation_with_presence_absence_result_v2;
 drop view if exists shipping.observation_with_presence_absence_result_v1;
@@ -2930,7 +2929,6 @@ create or replace view shipping.__uw_priority_queue_v1 as (
               encounter_id,
               individual.identifier as individual,
               encountered::date as encountered,
-              encounter.details -> '_provenance' -> 'redcap' ->> 'url' as redcap_url,
               encounter.details -> '_provenance' -> 'redcap' ->> 'project_id' as redcap_project_id,
               encounter.details -> '_provenance' -> 'redcap' ->> 'record_id' as redcap_record_id,
               encounter.details -> '_provenance' -> 'redcap' ->> 'event_name' as redcap_event_name,
@@ -2944,7 +2942,6 @@ create or replace view shipping.__uw_priority_queue_v1 as (
         select
             all_uw_instances.*,
             (select boolean_response from shipping.fhir_questionnaire_responses_v1 where encounter_id = all_uw_instances.encounter_id and link_id = 'screen_positive') as screen_positive,
-            (select boolean_response from shipping.fhir_questionnaire_responses_v1 where encounter_id = all_uw_instances.encounter_id and link_id = 'prev_pos') as prev_pos,
             (select boolean_response from shipping.fhir_questionnaire_responses_v1 where encounter_id = all_uw_instances.encounter_id and link_id = 'daily_symptoms') as daily_symptoms,
             (select case string_response[1] when 'yes' then true else false end from shipping.fhir_questionnaire_responses_v1 where encounter_id = all_uw_instances.encounter_id and link_id = 'daily_exposure') as daily_exposure,
             (select case string_response[1] when 'yes' then true else false end from shipping.fhir_questionnaire_responses_v1 where encounter_id = all_uw_instances.encounter_id and link_id = 'daily_exposure_known_pos') as daily_exposure_known_pos,
@@ -2960,7 +2957,6 @@ create or replace view shipping.__uw_priority_queue_v1 as (
         select
             all_uw_instances.*,
             tier,
-            current_prev_pos,
             latest_invite_date,
             latest_collection_date
         from all_uw_instances
@@ -2969,20 +2965,11 @@ create or replace view shipping.__uw_priority_queue_v1 as (
             -- Use a subquery instead of CTE for better query runtimes.
             select
                 individual,
-                /* Get PT's prev_pos response in today's attestation if available
-                 * so that we can filter out PTs who have tested positive in the
-                 * previous week for baseline and surveillance testing.
-                 * Use the `bool_or` aggregate to always capture when an
-                 * individual attests that they have tested positive.
-                 *    -Jover, 23 Nov 2020
-                 */
-                bool_or(prev_pos) filter (where encountered = current_date) as current_prev_pos,
                 max(encountered) filter (where testing_trigger is true) as latest_invite_date,
                 max(sample_collection_date) filter (where sample_collection_date is not null) as latest_collection_date
             from uw_encounters
             where testing_trigger is true
             or sample_collection_date is not null
-            or encountered = current_date
             group by individual
         ) as latest_dates using (individual)
         where redcap_event_name = 'enrollment_arm_1'
@@ -2991,7 +2978,6 @@ create or replace view shipping.__uw_priority_queue_v1 as (
     -- Select encounters for testing based on positive daily attestations
     positive_daily_attestations as (
         select
-            uw_encounters.redcap_url,
             uw_encounters.redcap_project_id,
             uw_encounters.redcap_record_id,
             uw_encounters.redcap_event_name,
@@ -3017,8 +3003,8 @@ create or replace view shipping.__uw_priority_queue_v1 as (
                  * at days 3–5.
                  *    -trs, 19 Oct 2020
                  */
-                when daily_exposure_known_pos and age(uw_encounters.encountered) >= '2 days' then 1
-                when daily_exposure and age(uw_encounters.encountered) >= '2 days' then 4
+                when daily_exposure_known_pos and age(uw_encounters.encountered) >= '2 days' then 2
+                when daily_exposure and age(uw_encounters.encountered) >= '2 days' then 3
                 else null
             end as priority,
             case
@@ -3039,14 +3025,11 @@ create or replace view shipping.__uw_priority_queue_v1 as (
         and testing_trigger is null
         -- Filter for postive daily attestations only
         and screen_positive
-        -- Filter for participants who have not tested positive in the past week
-        and prev_pos is not true
     ),
 
     -- Select enrollments for testing baseline and surveillance purposes
     baseline_and_surveillance as (
         select
-            redcap_url,
             redcap_project_id,
             redcap_record_id,
             redcap_event_name,
@@ -3057,8 +3040,8 @@ create or replace view shipping.__uw_priority_queue_v1 as (
             latest_invite_date,
             latest_collection_date,
             case
-                when coalesce(latest_invite_date, latest_collection_date) is null and tier = '1' then 5
-                when coalesce(latest_invite_date, latest_collection_date) is null and tier in ('2', '3') then 6
+                when coalesce(latest_invite_date, latest_collection_date) is null and tier = '1' then 4
+                when coalesce(latest_invite_date, latest_collection_date) is null and tier in ('2', '3') then 5
                 when tier = '1' then 7
                 when tier in ('2', '3') then 8
                 else null
@@ -3075,8 +3058,6 @@ create or replace view shipping.__uw_priority_queue_v1 as (
         where (latest_invite_date is null or latest_invite_date < current_date - interval '7 days')
         -- Filter to enrollments have never had a sample collected or last sample collection was over 7 days before today
         and (latest_collection_date is null or latest_collection_date < current_date - interval '7 days')
-        -- Filter for participants who have not tested positive in the past week
-        and current_prev_pos is not true
     ),
 
     /**
@@ -3086,7 +3067,6 @@ create or replace view shipping.__uw_priority_queue_v1 as (
     **/
     surge_testing as (
         select
-            uw_encounters.redcap_url,
             uw_encounters.redcap_project_id,
             uw_encounters.redcap_record_id,
             uw_encounters.redcap_event_name,
@@ -3096,7 +3076,7 @@ create or replace view shipping.__uw_priority_queue_v1 as (
             tier,
             latest_invite_date,
             latest_collection_date,
-            3 as priority,
+            6 as priority,
             'surge_testing' as priority_reason
         from uw_encounters
         join uw_enrollments using (individual)
@@ -3104,8 +3084,6 @@ create or replace view shipping.__uw_priority_queue_v1 as (
         where surge_selected_flag is true
         -- Filter for instances that do no already have testing_trigger filled
         and testing_trigger is null
-        -- Filter for participants who have not tested positive in the past week
-        and prev_pos is not true
     )
 
     select * from positive_daily_attestations
@@ -3123,7 +3101,6 @@ comment on view shipping.__uw_priority_queue_v1 is
 create or replace view shipping.uw_priority_queue_v1 as (
     with distinct_individuals as (
         select distinct on (individual)
-            redcap_url,
             redcap_project_id,
             redcap_record_id,
             redcap_event_name,

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -266,3 +266,4 @@ roles/uw-priority-queue-processor/grants [roles/uw-priority-queue-processor/gran
 @2020-12-01 2020-12-01T15:53:22Z Chris Craft <jccraft@uw.edu> # Schema as of 01 December 2020
 
 shipping/views [shipping/views@2020-12-01] 2020-12-02T23:24:52Z Kairsten Fay <kfay@fredhutch.org> # Create new modeling views
+@2020-12-7 2020-12-07T18:05:27Z Kairsten Fay <kfay@fredhutch.org> # Schema as of 7 December 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -264,3 +264,5 @@ operations/test-quota 2020-11-30T19:13:57Z Thomas Sibley <tsibley@fredhutch.org>
 shipping/views [shipping/views@2020-10-30] 2020-11-30T19:14:57Z Jover Lee <joverlee@fredhutch.org> # Rework shipping/views
 roles/uw-priority-queue-processor/grants [roles/uw-priority-queue-processor/grants@2020-10-30] 2020-11-30T19:15:57Z Jover Lee <joverlee@fredhutch.org> # Rework to add grants for operations
 @2020-12-01 2020-12-01T15:53:22Z Chris Craft <jccraft@uw.edu> # Schema as of 01 December 2020
+
+shipping/views [shipping/views@2020-12-01] 2020-12-02T23:24:52Z Kairsten Fay <kfay@fredhutch.org> # Create new modeling views

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -67,7 +67,17 @@ select 1/(count(*) = 1)::int
 select 1/(count(*) = 1)::int
   from information_schema.views
  where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v4');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v3');
 
 select 1/(count(*) = 1)::int
   from information_schema.views

--- a/schema/verify/shipping/views@2020-12-01.sql
+++ b/schema/verify/shipping/views@2020-12-01.sql
@@ -164,9 +164,4 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.uw_priority_queue_v1');
 
-select 1/(count(*) = 1)::int
-  from information_schema.views
- where array[table_schema, table_name]::text[]
-     = pg_catalog.parse_ident('shipping.hcov19_presence_absence_result_v1');
-
 rollback;


### PR DESCRIPTION
Create a new version of the incidence modeling view and observation with presence absence modeling view.

Also refactor many of our existing hCoV-19 presence-absence CTE queries into a new view for reduced duplication across our view definitions.

~I'm waiting on one confirmation from Roy as to whether he wants all samples _and_ all encounters in these new views, or just all samples.~
