### PR TITLE
UW Reopening ETL changes for Winter

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -470,7 +470,8 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'pronouns',
         'on_campus_freq',
         'vaccine_method',
-        'vaccine_where'
+        'vaccine_where',
+        'uw_housing_group',
     ]
 
     date_questions = [
@@ -502,7 +503,9 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'travel_states_phs_base',
         'swab_and_send_calc',
         'kiosk_calc',
-        'covid_test_week_base'
+        'covid_test_week_base',
+        'uw_housing_resident',
+        'on_campus_2x_week',
     ]
 
     decimal_questions = [
@@ -552,6 +555,25 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     record['tier'] = tier
 
     vaccine_item = create_vaccine_item(record["vaccine"], record['vaccine_year'], record['vaccine_month'], 'dont_know')
+
+    # Set the UW housing group
+    housing_group = None
+    if record.get('uw_housing_group_a') == '1':
+        housing_group = 'a'
+    elif record.get('uw_housing_group_b') == '1':
+        housing_group = 'b'
+    elif record.get('uw_housing_group_c') == '1':
+        housing_group = 'c'
+    elif record.get('uw_housing_group_d') == '1':
+        housing_group = 'd'
+    elif record.get('uw_housing_group_e') == '1':
+        housing_group = 'e'
+    elif record.get('uw_housing_group_f') == '1':
+        housing_group = 'f'
+    elif record.get('uw_housing_group_g') == '1':
+        housing_group = 'g'
+    record['uw_housing_group'] = housing_group
+
 
     return create_questionnaire_response(
         record = record,


### PR DESCRIPTION
This PR:
1. Brings in new fields added to the enrollment questionnaire.
2. Removes asserts/LOG.error (replaces the meaningful ones with LOG.warning) so that the job doesn't stop when we see an odd record.

I'm not bumping the revision # on this one. I'll do that after Jessica sets values for the new fields.