### PR TITLE
Uw reopening system dates

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -688,3 +688,17 @@ def create_questionnaire_response(record: REDCapRecord, question_categories: Dic
         return create_resource_entry(questionnaire_reseponse_resource, full_url)
 
     return None
+
+
+def extract_date_from_survey_timestamp(record: REDCapRecord, survey_name: str) -> Optional[str]:
+    """
+    Extracts as a string the date component of the *survey_name* REDCap survey timestamp, the system
+    timestamp that is captured automatically and is not dependent on the client. This timestamp
+    is in local (Pacific) time. The timestamp will be populated only if the instrument was filled out
+    as a survey. The timestamp field cannot be set via a REDCap data import.
+    """
+    if record and survey_name and record.get(f'{survey_name}_timestamp'):
+        return datetime.strptime(record.get(f'{survey_name}_timestamp'),
+            '%Y-%m-%d %H:%M:%S').strftime('%Y-%m-%d')
+
+    return None

--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -14,7 +14,7 @@ from .fhir import *
 from .redcap_map import map_sex, map_symptom, UnknownVaccineResponseError
 from id3c.cli.command.geocode import get_geocoded_address
 from id3c.cli.command.location import location_lookup
-from id3c.cli.redcap import Record as REDCapRecord
+from id3c.cli.redcap import is_complete, Record as REDCapRecord
 from id3c.db.session import DatabaseSession
 import logging
 
@@ -697,7 +697,7 @@ def extract_date_from_survey_timestamp(record: REDCapRecord, survey_name: str) -
     is in local (Pacific) time. The timestamp will be populated only if the instrument was filled out
     as a survey. The timestamp field cannot be set via a REDCap data import.
     """
-    if record and survey_name and record.get(f'{survey_name}_timestamp'):
+    if record and survey_name and is_complete(survey_name, record) and record.get(f'{survey_name}_timestamp'):
         return datetime.strptime(record.get(f'{survey_name}_timestamp'),
             '%Y-%m-%d %H:%M:%S').strftime('%Y-%m-%d')
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -362,19 +362,24 @@ def get_encounter_date(record: REDCapRecord, event_type: EventType) -> Optional[
     # First try the attestation_date
     # from the daily attestation survey then try nasal_swab_timestamp from
     # the kiosk registration and finally the swab-and-send order date.
+    # For all surveys, try the survey _timestamp field (which is in Pacific time)
+    # before custom fields because the custom fields aren't always populated and when
+    # they are populated they use the browser's time zone.
+    # testing_determination_internal is not enabled as a survey, but we attempt to get its
+    # timestamp just in case it ever is enabled as a survey.
     encounter_date = None
 
     if event_type == EventType.ENCOUNTER:
-        if record.get('attestation_date'):
-            encounter_date = record.get('attestation_date')
-        elif record.get('nasal_swab_timestamp'):
-            encounter_date = datetime.strptime(record.get('nasal_swab_timestamp'),
-                '%Y-%m-%d %H:%M:%S').strftime('%Y-%m-%d')
-        elif record.get('time_test_order'):
-            encounter_date = datetime.strptime(record.get('time_test_order'),
-                '%Y-%m-%d %H:%M:%S').strftime('%Y-%m-%d')
-        elif record.get('testing_date'): # from the 'Testing Determination - Internal' instrument
-            encounter_date = record.get('testing_date')
+        encounter_date = extract_date_from_survey_timestamp(record, 'daily_attestation') \
+            or record.get('attestation_date') \
+            or extract_date_from_survey_timestamp(record, 'kiosk_registration_4c7f') \
+            or (record.get('nasal_swab_timestamp') and datetime.strptime(record.get('nasal_swab_timestamp'),
+                '%Y-%m-%d %H:%M:%S').strftime('%Y-%m-%d')) \
+            or extract_date_from_survey_timestamp(record, 'test_order_survey') \
+            or (record.get('time_test_order') and datetime.strptime(record.get('time_test_order'),
+                '%Y-%m-%d %H:%M:%S').strftime('%Y-%m-%d')) \
+            or extract_date_from_survey_timestamp(record, 'testing_determination_internal') \
+            or record.get('testing_date')
 
         # We have seen cases when the `attestation_date` is not getting set
         # by REDCap in the `daily_attesation` instrument. Here, we get the date
@@ -384,7 +389,8 @@ def get_encounter_date(record: REDCapRecord, event_type: EventType) -> Optional[
             encounter_date = get_date_from_repeat_instance(record.repeat_instance)
 
     elif event_type == EventType.ENROLLMENT:
-        encounter_date = record.get('enrollment_date')
+        encounter_date = extract_date_from_survey_timestamp(record, 'enrollment_questionnaire') \
+            or record.get('enrollment_date')
 
     return encounter_date
 


### PR DESCRIPTION
Favor REDCap survey timestamps over custom date fields when available when determining the encounter date or the sample collection date.
For sample collection date, do not use a value that the participants writes on the tube if that value is in the future.

I did not bump the ETL revision number in this PR. We're going to need to process all DETs soon once some new REDCap calculations get backfilled.