### PR TITLE
Remove never-used ETL data class property referencing REDCAP_API_TOKEN

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
@@ -17,18 +17,16 @@ LOG = logging.getLogger(__name__)
 class ChildcareProject():
     id: int
     lang: str
-    api_token_env_var: str
     command_name: str
 
 
-    def __init__(self, project_id: int, lang: str, api_token_env_var: str, command_name: str) -> None:
+    def __init__(self, project_id: int, lang: str, command_name: str) -> None:
         self.id = project_id
         self.lang = lang
-        self.api_token_env_var = api_token_env_var
         self.command_name = command_name
 
 PROJECTS = [
-        ChildcareProject(23740, 'en', 'REDCAP_API_TOKEN', 'childcare')
+        ChildcareProject(23740, 'en', 'childcare')
     ]
 
 LANGUAGE_CODE = {

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -16,18 +16,16 @@ LOG = logging.getLogger(__name__)
 class HuskyProject():
     id: int
     lang: str
-    api_token_env_var: str
     command_name: str
 
 
-    def __init__(self, project_id: int, lang: str, api_token_env_var: str, command_name: str) -> None:
+    def __init__(self, project_id: int, lang: str, command_name: str) -> None:
         self.id = project_id
         self.lang = lang
-        self.api_token_env_var = api_token_env_var
         self.command_name = command_name
 
 PROJECTS = [
-        HuskyProject(23854, "en", "REDCAP_API_TOKEN", "uw-reopening")
+        HuskyProject(23854, "en", "uw-reopening")
     ]
 
 LANGUAGE_CODE = {


### PR DESCRIPTION
Never used, noticed while I'm auditing all usages of REDCAP_API_TOKEN in
order to retire it.