### PR TITLE
Don't warn for unexpected event names for UW-reopening

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -169,8 +169,9 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
             elif is_complete('test_order_survey', redcap_record_instance):
                 collection_method = CollectionMethod.SWAB_AND_SEND
         else:
-            LOG.warning(f"The record instance has an unexpected event name: {redcap_record_instance.event_name!r} "
-                f"for record: {redcap_record_instance.get('record_id')}")
+            LOG.info(f"Skipping event: {redcap_record_instance.event_name!r} for record "
+            f"{redcap_record_instance.get('record_id')} because the event is not one "
+            "that we process")
             continue
 
         # Skip an ENCOUNTER instance if we don't have the data we need to


### PR DESCRIPTION
The UW reopening (HCT) project now includes an event for each month. This
event contains only a monthly survey. We don't ingest that
survey, so it makes sense to skip the record instance that this event
is in. Rather than log a warning, now log info when we see an event
that is not `enrollment` or `encounter`.