### PR TITLE
Childcare ETL: Use survey timestamp correctly

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
@@ -369,8 +369,9 @@ def get_collection_date(record: REDCapRecord) -> Optional[str]:
     """
     Determine sample/specimen collection date from the given REDCap *record*.
     """
-    return record['date_on_tube'] or record['kit_reg_date'] or record['symptom_check_timestamp'] or \
-        record['back_end_scan_date']
+    return record['date_on_tube'] or record['kit_reg_date'] \
+        or extract_date_from_survey_timestamp(record, 'symptom_check') \
+        or record['back_end_scan_date']
 
 
 def create_enrollment_questionnaire_response(record: REDCapRecord, study_arm: StudyArm,


### PR DESCRIPTION
When using a REDCap server generated survey timestamp, we should do so
by using the `extract_date_from_survey_timestamp` function instead
of accessing the timestmap variable directly. If the survey has not
been completed, a value of `[not completed]` will be returned for
the timestamp. The function handles this correctly.

After this is merged, generate a DET for the 2021 Childcare project record 178.
For example:
REDCAP_API_URL="https://redcap.iths.org/api/" envdir /home/jccraft/gitroot/backoffice/id3c-production/env.d/redcap id3c redcap-det generate --project-id=29351 "178" > /home/jccraft/jccraft_temp/det_work/det.ndjson 