### PR TITLE
Use the symptom_check_timestamp the right way

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
@@ -555,6 +555,8 @@ def create_operational_questionnaire_response(record: REDCapRecord, patient_refe
         record['date_on_tube_match_kit_reg_text'] = \
             date_on_tube_match_kit_reg_map[record['date_on_tube_match_kit_reg']]
 
+    record['symptom_check_timestamp'] = extract_date_from_survey_timestamp(record, 'symptom_check')
+
     return create_questionnaire_response(
         record = record,
         question_categories = question_categories,


### PR DESCRIPTION
In the Childcare ETL I fixed how we use the `symptom_check_timestamp` for the
collection_date, but I missed the second place where we use it. This
commit calls `extract_date_from_survey_timestamp` to use the
`symptom_check_timestamp` for the questionnaire item.

After this is merged, generate a DET for the 2021 Childcare project record 178.
For example:
REDCAP_API_URL="https://redcap.iths.org/api/" envdir /home/jccraft/gitroot/backoffice/id3c-production/env.d/redcap id3c redcap-det generate --project-id=29351 "178" > /home/jccraft/jccraft_temp/det_work/det.ndjson