### PR TITLE
Accommodate unset UW housing group variables

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -874,7 +874,7 @@ def check_enrollment_data_quality(record: REDCapRecord) -> None:
 
     # UW Housing residence groups: a participant should be in at most 1 group.
     housing_groups = [f'uw_housing_group_{i}' for i in 'abcdefg']
-    housing_group_count = sum(map(lambda group: int(record[group]), housing_groups))
+    housing_group_count = sum(map(lambda group: int(record[group] or 0), housing_groups))
     if housing_group_count > 1:
         LOG.warning(f"Record {record['record_id']} enrollment data quality issue: "
         f"In {housing_group_count} UW Housing residence groups")


### PR DESCRIPTION
The UW Reopening ETL's data quality check needs to accommodate records
that didn't have their UW Housing Group variables set when the REDCap
calculations were implemented. If the value is '' consider it 0 for the
housing group count.