### PR TITLE
etl clinical: Add latest SCH values to value maps

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -82,8 +82,11 @@ def race(races: Optional[Any]) -> list:
     # Keys must be lowercase for case-insensitive lookup
     race_map = {
         "americanindianoralaskanative": "americanIndianOrAlaskaNative",
+        "american indian": "americanIndianOrAlaskaNative",
+        "american indian and alaska native": "americanIndianOrAlaskaNative",
         "american indian or alaska native": "americanIndianOrAlaskaNative",
         "amerind": "americanIndianOrAlaskaNative",
+        "native american": "americanIndianOrAlaskaNative",
         "native_american": "americanIndianOrAlaskaNative",
         "indian": "americanIndianOrAlaskaNative",
         "native": "americanIndianOrAlaskaNative",
@@ -95,6 +98,7 @@ def race(races: Optional[Any]) -> list:
         "black": "blackOrAfricanAmerican",
 
         "nativehawaiian": "nativeHawaiian",
+        "native hawaiian and other pacific islander" : "nativeHawaiian",
         "native hawaiian or other pacific islander": "nativeHawaiian",
         "native hawaiian or other pacific islande": "nativeHawaiian",
         "hawaiian-pacislander": "nativeHawaiian",
@@ -103,12 +107,15 @@ def race(races: Optional[Any]) -> list:
         "ha_pi": "nativeHawaiian",
 
         "white": "white",
+        "white or caucasian": "white",
 
         "other": "other",
         "other race": "other",
         "multiple races": "other",
+        "more than one race": "other",
 
         "refused": None,
+        "patient refused": None,
         "prefer not to say": None,
         "did not wish to indicate": None,
         "unknown": None,

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -177,6 +177,7 @@ def sex(sex_name) -> str:
         1.0: "male",
         0.0: "female",
         "other": "other",
+        "unknown": None,
     }
 
     def standardize_sex(sex):
@@ -225,11 +226,14 @@ def hispanic_latino(ethnic_group: Optional[Any]) -> list:
     ethnic_map = {
         "Not Hispanic or Latino": "no",
         "Non-Hispanic/Latino": "no",
+        "Non-Hispanic": "no",
         "Hispanic or Latino": "yes",
         "Hispanic/Latino": "yes",
+        "Hispanic": "yes",
         0.0: "no",
         1.0: "yes",
         "Patient Refused/Did Not Wish To Indicate": None,
+        "Patient Refused": None,
         "Unknown": None,
     }
 


### PR DESCRIPTION
SCH retrospective metadata includes new values for sex, race,
and hispanic_latino fields.