### PR TITLE
reportable_conditions: send Yakima notifications to schools channel

### DIFF
--- a/lib/seattleflu/id3c/cli/command/reportable_conditions.py
+++ b/lib/seattleflu/id3c/cli/command/reportable_conditions.py
@@ -88,7 +88,10 @@ def notify(*, action: str):
         },
 
         {
-            "collection_sets": {"collections-school-testing-home", "collections-school-testing-observed"},
+            "collection_sets": {"collections-school-testing-home",
+              "collections-school-testing-observed",
+              "collections-radxup-yakima-schools-home",
+              "collections-radxup-yakima-schools-observed"},
             "slack_channel_name": "ncov-reporting-schools",
             "slack_webhook": webhook("HCOV19_SCHOOLS"),
         }


### PR DESCRIPTION
Send reportable conditions notifications for Yakima schools home and
observed results to the slack channel ncov-reporting-schools in
addition to the standard ncov-reporting. The schools channel is also
used by the Snohomish schools study.