### PR TITLE
Extract Metabase details for each connection from the query comment 

### DIFF
--- a/schema/deploy/roles/idle-session-disconnector/grants@2021-04-22.sql
+++ b/schema/deploy/roles/idle-session-disconnector/grants@2021-04-22.sql
@@ -9,12 +9,9 @@ revoke all on all tables in schema receiving, warehouse, shipping from "idle-ses
 grant connect on database :"DBNAME" to "idle-session-disconnector";
 
 -- Regular users cannot see the state of sessions that they don't own. Create a
--- new view + function using security definer with limited columns that this
--- role can access to see a session's state.
-drop view public.pg_stat_activity_nonsuperuser;
-drop function public.pg_stat_get_activity_nonsuperuser();
-
-create function public.pg_stat_get_activity_nonsuperuser() returns table(
+-- new view using security definer with limited columns that this role can
+-- access to see a session's state.
+create or replace function public.pg_stat_get_activity_nonsuperuser() returns table(
     pid integer, usename name, application_name text, client_addr inet,
     state_change timestamp with time zone, state text) as
     $$
@@ -35,7 +32,7 @@ grant execute
     on function public.pg_stat_get_activity_nonsuperuser
     to "idle-session-disconnector";
 
-create view public.pg_stat_activity_nonsuperuser as
+create or replace view public.pg_stat_activity_nonsuperuser as
     select * from public.pg_stat_get_activity_nonsuperuser();
 
 grant select

--- a/schema/revert/roles/idle-session-disconnector/grants.sql
+++ b/schema/revert/roles/idle-session-disconnector/grants.sql
@@ -1,23 +1,47 @@
--- Revert seattleflu/id3c-customizations:roles/idle-session-disconnector/grants from pg
+-- Deploy seattleflu/id3c-customizations:roles/idle-session-disconnector/grants to pg
 
 begin;
 
-revoke pg_signal_backend from "idle-session-disconnector";
+revoke all on database :"DBNAME" from "idle-session-disconnector";
+revoke all on schema receiving, warehouse, shipping from "idle-session-disconnector";
+revoke all on all tables in schema receiving, warehouse, shipping from "idle-session-disconnector";
 
-revoke select
-    on public.pg_stat_activity_nonsuperuser
-  from "idle-session-disconnector";
+grant connect on database :"DBNAME" to "idle-session-disconnector";
 
+-- Regular users cannot see the state of sessions that they don't own. Create a
+-- new view + function using security definer with limited columns that this
+-- role can access to see a session's state.
 drop view public.pg_stat_activity_nonsuperuser;
+drop function public.pg_stat_get_activity_nonsuperuser();
+
+create function public.pg_stat_get_activity_nonsuperuser() returns table(
+    pid integer, usename name, application_name text, client_addr inet,
+    state_change timestamp with time zone, state text) as
+    $$
+    select
+        pid, usename, application_name, client_addr, state_change, state
+        from pg_catalog.pg_stat_activity;
+    $$
+    language sql
+    volatile
+    security definer
+    set search_path = pg_catalog;
 
 revoke execute
     on function public.pg_stat_get_activity_nonsuperuser
-  from "idle-session-disconnector";
+  from public;
 
-drop function public.pg_stat_get_activity_nonsuperuser;
+grant execute
+    on function public.pg_stat_get_activity_nonsuperuser
+    to "idle-session-disconnector";
 
-revoke all on database :"DBNAME" from "idle-session-disconnector";
-revoke all on all tables in schema public from "idle-session-disconnector";
-revoke all on schema public from "idle-session-disconnector";
+create view public.pg_stat_activity_nonsuperuser as
+    select * from public.pg_stat_get_activity_nonsuperuser();
+
+grant select
+    on public.pg_stat_activity_nonsuperuser
+    to "idle-session-disconnector";
+
+grant pg_signal_backend to "idle-session-disconnector";
 
 commit;

--- a/schema/revert/roles/idle-session-disconnector/grants@2021-04-22.sql
+++ b/schema/revert/roles/idle-session-disconnector/grants@2021-04-22.sql
@@ -1,0 +1,23 @@
+-- Revert seattleflu/id3c-customizations:roles/idle-session-disconnector/grants from pg
+
+begin;
+
+revoke pg_signal_backend from "idle-session-disconnector";
+
+revoke select
+    on public.pg_stat_activity_nonsuperuser
+  from "idle-session-disconnector";
+
+drop view public.pg_stat_activity_nonsuperuser;
+
+revoke execute
+    on function public.pg_stat_get_activity_nonsuperuser
+  from "idle-session-disconnector";
+
+drop function public.pg_stat_get_activity_nonsuperuser;
+
+revoke all on database :"DBNAME" from "idle-session-disconnector";
+revoke all on all tables in schema public from "idle-session-disconnector";
+revoke all on schema public from "idle-session-disconnector";
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -323,3 +323,4 @@ shipping/views [shipping/views@2021-03-18] 2021-04-02T23:03:42Z Jover Lee <jover
 
 shipping/views [shipping/views@2021-04-05] 2021-04-21T18:01:02Z Kristen Schwabe-Fry <2600836+kschwabefry@users.noreply.github.com> # Include yakima schools study in RoR shipping views
 @2021-04-22 2021-04-22T16:39:09Z Kristen Schwabe-Fry <2600836+kschwabefry@users.noreply.github.com> # Schema as of 22 April 2021
+roles/idle-session-disconnector/grants [roles/idle-session-disconnector/grants@2021-04-22] 2021-05-25T18:57:21Z Thomas Sibley <tsibley@fredhutch.org> # Add "metabase" column

--- a/schema/verify/roles/idle-session-disconnector/grants@2021-04-22.sql
+++ b/schema/verify/roles/idle-session-disconnector/grants@2021-04-22.sql
@@ -1,0 +1,14 @@
+-- Verify seattleflu/id3c-customizations:roles/idle-session-disconnector/grants on pg
+
+begin;
+
+select 1/pg_catalog.has_database_privilege('idle-session-disconnector', :'DBNAME', 'connect')::int;
+select 1/pg_catalog.has_schema_privilege('idle-session-disconnector', 'public', 'usage')::int;
+select 1/pg_catalog.has_table_privilege('idle-session-disconnector', 'public.pg_stat_activity_nonsuperuser', 'select')::int;
+select 1/pg_catalog.has_function_privilege('idle-session-disconnector', 'public.pg_stat_get_activity_nonsuperuser()', 'execute')::int;
+
+select 1/(not pg_catalog.has_table_privilege('idle-session-disconnector', 'pg_catalog.pg_stat_activity', 'insert,update,delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('idle-session-disconnector', 'public.pg_stat_activity_nonsuperuser', 'insert,update,delete'))::int;
+select 1/(not pg_catalog.has_function_privilege('public', 'public.pg_stat_get_activity_nonsuperuser()', 'execute'))::int;
+
+rollback;


### PR DESCRIPTION
These details will let our connection watchdog processes (e.g. for slow
queries) be more selective in what they terminate without revealing the
full query of every connection to non-superusers.

The format of this comment (or "remark" in Metabase's parlance) is
reasonably guessable, but I also checked the code.¹  If the format
changes in the future and the parse fails, the new "metabase" column
added here will just be null.  This seems like a reasonable failure
mode.

¹ https://github.com/metabase/metabase/blob/f76d8333/src/metabase/query_processor/util.clj#L26-L37

--- 

See also https://github.com/seattleflu/backoffice/pull/160#issuecomment-848177312.