### PR TITLE
Fix a premature transaction commit in shipping/views

### DIFF
--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -3658,7 +3658,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3740,3 +3739,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-05.sql
+++ b/schema/deploy/shipping/views@2021-01-05.sql
@@ -3317,7 +3317,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3398,3 +3397,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-13.sql
+++ b/schema/deploy/shipping/views@2021-01-13.sql
@@ -3453,7 +3453,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3534,3 +3533,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-15.sql
+++ b/schema/deploy/shipping/views@2021-01-15.sql
@@ -3455,7 +3455,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3536,3 +3535,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-19.sql
+++ b/schema/deploy/shipping/views@2021-01-19.sql
@@ -3464,7 +3464,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3546,3 +3545,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-19b.sql
+++ b/schema/deploy/shipping/views@2021-01-19b.sql
@@ -3464,7 +3464,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3546,3 +3545,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-20.sql
+++ b/schema/deploy/shipping/views@2021-01-20.sql
@@ -3466,7 +3466,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3548,3 +3547,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-25.sql
+++ b/schema/deploy/shipping/views@2021-01-25.sql
@@ -3475,7 +3475,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3557,3 +3556,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-26.sql
+++ b/schema/deploy/shipping/views@2021-01-26.sql
@@ -3481,7 +3481,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3563,3 +3562,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-01-29.sql
+++ b/schema/deploy/shipping/views@2021-01-29.sql
@@ -3487,7 +3487,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3569,3 +3568,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-02-09.sql
+++ b/schema/deploy/shipping/views@2021-02-09.sql
@@ -3489,7 +3489,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3571,3 +3570,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-02-19.sql
+++ b/schema/deploy/shipping/views@2021-02-19.sql
@@ -3490,7 +3490,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3572,3 +3571,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-02-24.sql
+++ b/schema/deploy/shipping/views@2021-02-24.sql
@@ -3494,7 +3494,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3576,3 +3575,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-03-15.sql
+++ b/schema/deploy/shipping/views@2021-03-15.sql
@@ -3538,7 +3538,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3620,3 +3619,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-03-18.sql
+++ b/schema/deploy/shipping/views@2021-03-18.sql
@@ -3545,7 +3545,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3627,3 +3626,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-04-05.sql
+++ b/schema/deploy/shipping/views@2021-04-05.sql
@@ -3600,7 +3600,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3682,3 +3681,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-07-02.sql
+++ b/schema/deploy/shipping/views@2021-07-02.sql
@@ -3608,7 +3608,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3690,3 +3689,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/deploy/shipping/views@2021-07-13.sql
+++ b/schema/deploy/shipping/views@2021-07-13.sql
@@ -3658,7 +3658,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3740,3 +3739,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -3658,7 +3658,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3740,3 +3739,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-13.sql
+++ b/schema/revert/shipping/views@2021-01-13.sql
@@ -3318,7 +3318,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3399,3 +3398,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-15.sql
+++ b/schema/revert/shipping/views@2021-01-15.sql
@@ -3453,7 +3453,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3534,3 +3533,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-19.sql
+++ b/schema/revert/shipping/views@2021-01-19.sql
@@ -3455,7 +3455,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3536,3 +3535,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-19b.sql
+++ b/schema/revert/shipping/views@2021-01-19b.sql
@@ -3464,7 +3464,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3546,3 +3545,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-20.sql
+++ b/schema/revert/shipping/views@2021-01-20.sql
@@ -3464,7 +3464,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3546,3 +3545,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-25.sql
+++ b/schema/revert/shipping/views@2021-01-25.sql
@@ -3466,7 +3466,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3548,3 +3547,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-26.sql
+++ b/schema/revert/shipping/views@2021-01-26.sql
@@ -3475,7 +3475,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3557,3 +3556,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-01-29.sql
+++ b/schema/revert/shipping/views@2021-01-29.sql
@@ -3481,7 +3481,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3563,3 +3562,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-02-09.sql
+++ b/schema/revert/shipping/views@2021-02-09.sql
@@ -3487,7 +3487,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3569,3 +3568,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-02-19.sql
+++ b/schema/revert/shipping/views@2021-02-19.sql
@@ -3489,7 +3489,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3571,3 +3570,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-02-24.sql
+++ b/schema/revert/shipping/views@2021-02-24.sql
@@ -3490,7 +3490,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3572,3 +3571,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-03-15.sql
+++ b/schema/revert/shipping/views@2021-03-15.sql
@@ -3494,7 +3494,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3576,3 +3575,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-03-18.sql
+++ b/schema/revert/shipping/views@2021-03-18.sql
@@ -3538,7 +3538,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3620,3 +3619,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-04-05.sql
+++ b/schema/revert/shipping/views@2021-04-05.sql
@@ -3546,7 +3546,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3628,3 +3627,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-07-02.sql
+++ b/schema/revert/shipping/views@2021-07-02.sql
@@ -3600,7 +3600,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3682,3 +3681,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;

--- a/schema/revert/shipping/views@2021-07-13.sql
+++ b/schema/revert/shipping/views@2021-07-13.sql
@@ -3608,7 +3608,6 @@ grant select
   on shipping.uw_priority_queue_v1
   to "uw-priority-queue-processor";
 
-commit;
 
 
 create or replace view shipping.linelist_data_for_wa_doh_v1 as (
@@ -3690,3 +3689,5 @@ grant select
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
+
+commit;


### PR DESCRIPTION
Retroactively updates all the affected Sqitch changes to be correct for
posterity (e.g. future dev instances which deploy from scratch).

This bug caused a recent sqitch deploy to fail but still make changes,
presumably because it failed after the commit when re-creating
shipping.linelist_data_for_wa_doh_v1.

Separately, I'll write a CI test to enforce that Sqitch changes include
only final commits and no premature commits.