### PR TITLE
etl redcap: ignore 'not complete' survey timestamps

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -697,7 +697,11 @@ def extract_date_from_survey_timestamp(record: REDCapRecord, survey_name: str) -
     is in local (Pacific) time. The timestamp will be populated only if the instrument was filled out
     as a survey. The timestamp field cannot be set via a REDCap data import.
     """
-    if record and survey_name and is_complete(survey_name, record) and record.get(f'{survey_name}_timestamp'):
+    if (record and
+            survey_name and
+            is_complete(survey_name, record) and
+            record.get(f'{survey_name}_timestamp') and
+            record.get(f'{survey_name}_timestamp') != '[not completed]'):
         return datetime.strptime(record.get(f'{survey_name}_timestamp'),
             '%Y-%m-%d %H:%M:%S').strftime('%Y-%m-%d')
 


### PR DESCRIPTION
We've recently started seeing redcap records with survey instruments that
have a status of complete, but the automated timestamp value is the string
['not complete'] instead of an actual timestamp.

When looking for survey timestamps, we can consider that 'not complete'
value to mean the survey is indeed not complete, and return no extracted
timestamp, instead of throwing an error.