### PR TITLE
etl uw-reopening: Include kit registration barcodes

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -271,7 +271,8 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
             prioritized_barcodes = [
                 redcap_record_instance["collect_barcode_kiosk"],
                 redcap_record_instance["return_utm_barcode"],
-                redcap_record_instance["pre_scan_barcode"]]
+                redcap_record_instance["pre_scan_barcode"],
+                redcap_record_instance["barcode_swabsend"]]
 
             specimen_entry, specimen_reference = create_specimen(
                 prioritized_barcodes = prioritized_barcodes,


### PR DESCRIPTION
When creating encounters in the uw reopening ETL, consider kit
registration barcode when trying to create the specimen.

There has been a change in the testing workflow, such that some
samples will be unobserved testing (not kiosk, but also not
swab and send), and they won't have a PCDEQC filled out.
For these records, the way to link the redcap encounter to
the sample is to use the kit registration barcode field,
called barcode_swabsend.