### PR TITLE
Handle missing provenance workbook value in Slack post function

### DIFF
--- a/lib/seattleflu/id3c/cli/command/reportable_conditions.py
+++ b/lib/seattleflu/id3c/cli/command/reportable_conditions.py
@@ -217,7 +217,8 @@ def send_slack_post_request(record: Any, url: str) -> requests.Response:
     }
 
     if not record.site:
-        data["Manifest"] = basename(record.workbook)
+        if record.workbook:
+            data["Manifest"] = basename(record.workbook)
 
         if record.sample_origin:
             data["Manifest origin"] = record.sample_origin


### PR DESCRIPTION
With use of accessioning API, provenance data no longer contains a
`workbook` value. Updating function to avoid exception when workbook
value is null in shipping view.