### PR TITLE
Move check for HCT migrated record encounter present

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -189,7 +189,6 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
 
         elif redcap_record_instance.event_name == ENCOUNTER_EVENT_NAME:
             event_type = EventType.ENCOUNTER
-            migrated_record_encounter_found = True
             if is_complete('kiosk_registration_4c7f', redcap_record_instance):
                 collection_method = CollectionMethod.KIOSK
             elif is_complete('test_order_survey', redcap_record_instance):
@@ -202,12 +201,14 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
 
         # Skip an ENCOUNTER instance if we don't have the data we need to
         # create an encounter.
-        if event_type == EventType.ENCOUNTER \
-            and not is_complete('daily_attestation', redcap_record_instance) \
+        if event_type == EventType.ENCOUNTER:
+            if not is_complete('daily_attestation', redcap_record_instance) \
                 and not collection_method  \
                 and not redcap_record_instance['testing_date']: # from the 'Testing Determination - Internal' instrument
                     LOG.debug("Skipping record instance with insufficient information to construct the initial encounter")
                     continue
+            elif MIGRATED_RECORD:
+                migrated_record_encounter_found = True
 
         # site_reference refers to where the sample was collected
         record_location = None


### PR DESCRIPTION
The boolean to indicate whether or not a non-enrollment encounter is present on
an HCT migrated record was happeneing too early, which was still resulting in
warnings that the FHIR bundle was incomplete because it did not contain any
encounter events (for example when daily attestation form was incomplete).

Setting the boolean flag to True only after checking that daily attestatation,
kiosk registration, or test order survey forms are complete, or that the
`testing_date` from internal testing determination form is not empty, since
those can result in the encounter record being skipped.