### PR TITLE
Reverse order of prioritized timestamps for kiosk specimen collection

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -476,7 +476,7 @@ def get_collection_date(record: REDCapRecord, collection_method: CollectionMetho
     collection_date = None
 
     if collection_method == CollectionMethod.KIOSK:
-        collection_date = extract_date_from_survey_timestamp(record, "kiosk_registration_4c7f") or record.get("nasal_swab_q")
+        collection_date = record.get("nasal_swab_q") or extract_date_from_survey_timestamp(record, "kiosk_registration_4c7f")
 
     elif collection_method in [CollectionMethod.SWAB_AND_SEND, CollectionMethod.UW_DROPBOX]:
         collection_date = record.get("date_on_tube") \


### PR DESCRIPTION
Reversing order of date/timestamps being used to determine specimen
collection date for inclusion in FHIR bundle. The new order will check
for the `nasal_swab_q` field from the instrument first, and the REDCap
built-in instrument completed timestamp second.

This is being done due to cases where the instrument is completed on a
different date, such as during QC/data corrections in REDCap. In those
cases the `nasal_swab_q` date will accurate and the instrument completed
timestamp will not be.