### PR TITLE
Add value to map for clinical ETL

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -236,6 +236,7 @@ def hispanic_latino(ethnic_group: Optional[Any]) -> list:
         "Patient Refused/Did Not Wish To Indicate": None,
         "Patient Refused": None,
         "Unknown": None,
+        "Unavailable or Unknown": None,
     }
 
     if ethnic_group not in ethnic_map:


### PR DESCRIPTION
A new value was seen in incoming clinical data from SCH. Added `Unavailable or Unknown` to existing map.