### PR TITLE
Update parsing and ETL for SCH clinical data files.

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -192,6 +192,10 @@ def parse_sch(sch_filename, output):
     """
     clinical_records = load_file_as_dataframe(sch_filename) \
                         .replace({"": None, "NA": None})
+
+    # drop records with no patient identifier
+    clinical_records.dropna(subset=['pat_id2'],inplace=True)
+
     clinical_records['age'] = clinical_records['age'].astype('float')
 
     clinical_records = trim_whitespace(clinical_records)

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -208,15 +208,10 @@ def parse_sch(sch_filename, output):
         "pat_id2": "individual",
         "study_id": "barcode",
         "drawndate": "encountered",
-        "age": "age",
         "sex": "AssignedSex",
         "ethnicity": "HispanicLatino",
         "race": "Race",
         "vaccine_given": "FluShot",
-        "MedicalInsurance": "MedicalInsurance",
-        "census_tract": "census_tract",
-        "_provenance": "_provenance",
-        "ICD10": "ICD10",
     }
     clinical_records = clinical_records.rename(columns=column_map)
 
@@ -226,12 +221,35 @@ def parse_sch(sch_filename, output):
     clinical_records = drop_missing_rows(clinical_records, 'encountered')
 
     # Drop unnecessary columns
-    columns_to_keep = list(column_map.values()) + [  # Test result columns
+    columns_to_keep = list(column_map.values()) + [
+        "age",
+        "MedicalInsurance",
+        "census_tract",
+        "_provenance",
+
+        # Test result columns
         'adeno',
-        'chlamydia', 'corona229e', 'corona_hku1', 'corona_nl63', 'corona_oc43',
-        'flu_a_h3', 'flu_a_h1_2009', 'flu_b', 'flu_a', 'flu_a_h1', 'hmpv', 'mycoplasma',
-        'paraflu_1_4', 'pertussis', 'rhino_ent', 'rsv'
+        'chlamydia',
+        'corona229e',
+        'corona_hku1',
+        'corona_nl63',
+        'corona_oc43',
+        'flu_a_h3',
+        'flu_a_h1_2009',
+        'flu_b',
+        'flu_a',
+        'flu_a_h1',
+        'hmpv',
+        'mycoplasma',
+        'paraflu_1_4',
+        'pertussis',
+        'rhino_ent',
+        'rsv',
+
+        # ICD-10 codes
+        'ICD10',
     ]
+
     clinical_records = clinical_records[columns_to_keep]
 
     # Convert dtypes

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -26,6 +26,9 @@ from id3c.cli.command.etl import (
     SampleNotFoundError,
     UnknownEthnicGroupError,
     UnknownFluShotResponseError,
+    UnknownCovidScreenError,
+    UnknownCovidShotResponseError,
+    UnknownCovidShotManufacturerError,
     UnknownSiteError,
 )
 from . import race
@@ -219,6 +222,21 @@ def encounter_details(document: dict) -> dict:
     if "ICD10" in document:
         details["responses"]["ICD10"] = document.get("ICD10")
 
+    if "CovidScreen" in document:
+        details["responses"]["CovidScreen"] = covid_screen(document.get("CovidScreen"))
+
+    for k in ["CovidShot1", "CovidShot2"]:
+        if k in document:
+            details["responses"][k] = covid_shot(document[k])
+    
+    if "CovidShotManufacturer" in document:
+        details["responses"]["CovidShotManufacturer"] = covid_shot_maunufacturer(document.get("CovidShotManufacturer"))
+
+    # include vaccine date fields if present and not empty
+    for k in ["FluShotDate", "CovidShot1Date", "CovidShot2Date"]:
+        if document.get(k):
+            details["responses"][k] = [document[k]]
+
     return details
 
 
@@ -285,6 +303,115 @@ def flu_shot(flu_shot_response: Optional[Any]) -> list:
             f"Unknown flu shot response «{flu_shot_response}»")
 
     return [flu_shot_map[flu_shot_response]]
+
+
+def covid_shot(covid_shot_response: Optional[Any]) -> list:
+    """
+    Given a *covid_shot_response*, returns yes/no value for CovidShot key(s).
+
+    >>> covid_shot(0.0)
+    ['no']
+
+    >>> covid_shot('TRUE')
+    ['yes']
+
+    >>> covid_shot('maybe')
+    Traceback (most recent call last):
+        ...
+    id3c.cli.command.etl.UnknownCovidShotResponseError: Unknown COVID shot response «maybe»
+
+    """
+    if covid_shot_response is None:
+        LOG.debug("No COVID shot response found.")
+        return [None]
+
+    if isinstance(covid_shot_response, str):
+        covid_shot_response = covid_shot_response.lower()
+
+    covid_shot_map = {
+        0.0 : "no",
+        1.0 : "yes",
+        "false": "no",
+        "true": "yes",
+    }
+
+    if covid_shot_response not in covid_shot_map:
+        raise UnknownCovidShotResponseError(
+            f"Unknown COVID shot response «{covid_shot_response}»")
+
+    return [covid_shot_map[covid_shot_response]]
+
+
+def covid_shot_maunufacturer(covid_shot_manufacturer_name: Optional[Any]) -> list:
+    """
+    Given a *covid_shot_manufacturer_name*, returns validated and standarized value.
+
+    >>> covid_shot_maunufacturer('PFIZER')
+    ['pfizer']
+
+    >>> covid_shot_maunufacturer('Moderna')
+    ['moderna']
+
+    >>> covid_shot_maunufacturer('SomeCompany')
+    Traceback (most recent call last):
+        ...
+    id3c.cli.command.etl.UnknownCovidShotManufacturerError: Unknown COVID shot manufacturer «somecompany»
+
+    """
+    if covid_shot_manufacturer_name is None:
+        LOG.debug("No COVID shot manufacturer name found.")
+        return [None]
+
+    if isinstance(covid_shot_manufacturer_name, str):
+        covid_shot_manufacturer_name = covid_shot_manufacturer_name.lower().strip()
+
+    valid_covid_manufacturers = [
+        "pfizer",
+        "moderna",
+    ]
+
+    if covid_shot_manufacturer_name not in valid_covid_manufacturers:
+        raise UnknownCovidShotManufacturerError(
+            f"Unknown COVID shot manufacturer «{covid_shot_manufacturer_name}»")
+
+    return [covid_shot_manufacturer_name]
+
+
+def covid_screen(is_covid_screen: Optional[Any]) -> list:
+    """
+    Given a *is_covid_screen*, returns yes/no value for CovidScreen key.
+
+    >>> covid_screen('FALSE')
+    ['no']
+
+    >>> covid_screen('TRUE')
+    ['yes']
+
+    >>> covid_screen('maybe')
+    Traceback (most recent call last):
+        ...
+    id3c.cli.command.etl.UnknownCovidScreenError: Unknown COVID screen «maybe»
+
+    """
+    if is_covid_screen is None:
+        LOG.debug("No COVID screen value found.")
+        return [None]
+
+    if isinstance(is_covid_screen, str):
+        is_covid_screen = is_covid_screen.lower()
+
+    covid_screen_map = {
+        "false": "no",
+        "true": "yes",
+        "unknown": None,
+    }
+
+    if is_covid_screen not in covid_screen_map:
+        raise UnknownCovidScreenError(
+            f"Unknown COVID screen «{is_covid_screen}»")
+
+    return [covid_screen_map[is_covid_screen]]
+
 
 def insurance(insurance_response: Optional[Any]) -> list:
     """

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -198,7 +198,7 @@ def encounter_details(document: dict) -> dict:
     Describe encounter details in a simple data structure designed to be used
     from SQL.
     """
-    return {
+    details = {
             "age": age_to_delete(document.get("age")), # XXX TODO: Remove age from details
 
             # XXX TODO: Remove locations from details
@@ -215,6 +215,12 @@ def encounter_details(document: dict) -> dict:
                 "MedicalInsurance": insurance(document.get("MedicalInsurance"))
             },
         }
+
+    if "ICD10" in document:
+        details["responses"]["ICD10"] = document.get("ICD10")
+
+    return details
+
 
 def hispanic_latino(ethnic_group: Optional[Any]) -> list:
     """


### PR DESCRIPTION
Update parsing for SCH clinical data files to include ICD-10 codes. The
codes are stored in a series of 10-12 new columns in the workbooks and are
converted to an array to be included in JSON output.