### PR TITLE
ETL: REDCap DET - HCT process migrated enrollments and drop unused fields

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -168,7 +168,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
 
         if redcap_record_instance.event_name == ENROLLMENT_EVENT_NAME:
             event_type = EventType.ENROLLMENT
-            check_enrollment_data_quality(redcap_record_instance)
+            #check_enrollment_data_quality(redcap_record_instance)
 
         elif redcap_record_instance.event_name == ENCOUNTER_EVENT_NAME:
             event_type = EventType.ENCOUNTER
@@ -472,8 +472,8 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     # Do not include `core_age_years` because we calculate the age ourselves in the computed questionnaire.
     integer_questions = [
         'weight',
-        'height_total',
-        'tier'
+        #'height_total',
+        #'tier'
     ]
 
     string_questions = [
@@ -532,7 +532,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'uw_medicine_yesno',
         'inperson_classes',
         'uw_job',
-        'uw_greek_member',
+        #'uw_greek_member',
         'live_other_uw',
         'uw_apt_yesno',
         'core_pregnant',
@@ -546,13 +546,15 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'swab_and_send_calc',
         'kiosk_calc',
         'covid_test_week_base',
-        'uw_housing_resident',
-        'on_campus_2x_week',
+        #'uw_housing_resident',
+        #'on_campus_2x_week',
     ]
 
+    '''
     decimal_questions = [
         'bmi'
     ]
+    '''
 
     coding_questions = [
         'core_race'
@@ -576,7 +578,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'valueInteger': integer_questions,
         'valueString': string_questions,
         'valueDate': date_questions,
-        'valueDecimal': decimal_questions
+        #'valueDecimal': decimal_questions
     }
 
     for field in checkbox_fields:
@@ -586,6 +588,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     record['countries_visited_base'] = combine_multiple_fields(record, 'country', '_base')
     record['states_visited_base'] = combine_multiple_fields(record, 'state', '_base')
 
+    '''
     # Set the study tier
     tier = None
     if record['tier_1'] == '1':
@@ -595,9 +598,11 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     elif record['tier_3'] == '1':
         tier = 3
     record['tier'] = tier
+    '''
 
     vaccine_item = create_vaccine_item(record["vaccine"], record['vaccine_year'], record['vaccine_month'], 'dont_know')
 
+    '''
     # Set the UW housing group
     housing_group = None
     if record.get('uw_housing_group_a') == '1':
@@ -615,7 +620,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     elif record.get('uw_housing_group_g') == '1':
         housing_group = 'g'
     record['uw_housing_group'] = housing_group
-
+    '''
 
     return create_questionnaire_response(
         record = record,
@@ -883,7 +888,7 @@ def get_date_from_repeat_instance(instance_id: int) -> str:
     """
     return (STUDY_START_DATE + relativedelta(days=(instance_id -1))).strftime('%Y-%m-%d')
 
-
+'''
 def check_enrollment_data_quality(record: REDCapRecord) -> None:
     """
     Warns if the enrollment record violates data quality checks.
@@ -901,3 +906,4 @@ def check_enrollment_data_quality(record: REDCapRecord) -> None:
     if housing_group_count > 0 and record['added_surveillance_groups']:
         LOG.warning(f"Record {record['record_id']} enrollment data quality issue: "
         "In a UW Housing residence group and has a value for `added_surveillance_groups`")
+'''

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -168,6 +168,8 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
 
         if redcap_record_instance.event_name == ENROLLMENT_EVENT_NAME:
             event_type = EventType.ENROLLMENT
+            # This QC check is not currently needed because it is only checking
+            # uw_housing_group fields which are deprecated as of 2021-09-09.
             #check_enrollment_data_quality(redcap_record_instance)
 
         elif redcap_record_instance.event_name == ENCOUNTER_EVENT_NAME:
@@ -472,8 +474,8 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     # Do not include `core_age_years` because we calculate the age ourselves in the computed questionnaire.
     integer_questions = [
         'weight',
-        #'height_total',
-        #'tier'
+        #'height_total',    # Deprecated as of 2021-09-09
+        #'tier'             # Deprecated as of 2021-09-09
     ]
 
     string_questions = [
@@ -532,7 +534,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'uw_medicine_yesno',
         'inperson_classes',
         'uw_job',
-        #'uw_greek_member',
+        #'uw_greek_member'              # Deprecated as of 2021-09-09
         'live_other_uw',
         'uw_apt_yesno',
         'core_pregnant',
@@ -546,10 +548,11 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'swab_and_send_calc',
         'kiosk_calc',
         'covid_test_week_base',
-        #'uw_housing_resident',
-        #'on_campus_2x_week',
+        #'uw_housing_resident'          # Deprecated as of 2021-09-09
+        #'on_campus_2x_week'            # Deprecated as of 2021-09-09
     ]
 
+    # Deprecated as of 2021-09-09
     '''
     decimal_questions = [
         'bmi'
@@ -578,7 +581,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
         'valueInteger': integer_questions,
         'valueString': string_questions,
         'valueDate': date_questions,
-        #'valueDecimal': decimal_questions
+        #'valueDecimal': decimal_questions      # no decimal questions currently
     }
 
     for field in checkbox_fields:
@@ -588,6 +591,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
     record['countries_visited_base'] = combine_multiple_fields(record, 'country', '_base')
     record['states_visited_base'] = combine_multiple_fields(record, 'state', '_base')
 
+    # Deprecated as of 2021-09-09
     '''
     # Set the study tier
     tier = None
@@ -602,6 +606,7 @@ def create_enrollment_questionnaire_response(record: REDCapRecord, patient_refer
 
     vaccine_item = create_vaccine_item(record["vaccine"], record['vaccine_year'], record['vaccine_month'], 'dont_know')
 
+    # Deprecated as of 2021-09-09
     '''
     # Set the UW housing group
     housing_group = None
@@ -888,6 +893,9 @@ def get_date_from_repeat_instance(instance_id: int) -> str:
     """
     return (STUDY_START_DATE + relativedelta(days=(instance_id -1))).strftime('%Y-%m-%d')
 
+
+# This is no longer functional with the uw_housing_group fields being deprecated. Preserving
+# code for now in case it needs to be revised or repurposed.
 '''
 def check_enrollment_data_quality(record: REDCapRecord) -> None:
     """


### PR DESCRIPTION
Remove filter on migrated enrollments to allow those records and instruments to be ingested from the new HCT REDCap project. This filter was originally implemented when issues were identified with the data migration of records from the old REDCap project to the new one. Now that data cleanup and QC has occurred, this filter can be safely removed.

Also removing fields no longer being used in REDCap from the ETL process. These fields accounted for some of the differences between enrollment records in the old and new projects. Those REDCap fields that are being removed will subsequently be dropped from existing HCT records in ID3C as well as any shipping views that reference them.