### PR TITLE
Fix encounter class mapper

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -372,6 +372,9 @@ def create_encounter_class(redcap_record: dict) -> dict:
     encounter_class = redcap_record.get('patient_class', '')
 
     mapper = {
+        "outpatient" : "AMB",
+        "inpatient"  : "IMP",
+        "emergency"  : "EMER",
         "op"    : "AMB",
         "ed"    : "EMER",  # can also code as "AMB"
         "ip"    : "IMP",


### PR DESCRIPTION
The UW retrospectives ETL is pulling data from an EMR that doesn't
conform to the FHIR specification for encounter class, available at
https://www.hl7.org/fhir/v3/ActEncounterCode/vs.html.

In order to fix this, we set up a table that maps the EMR's values
to FHIR values, but it's missing several of the EMR's values, causing
"Unknown encounter class" exceptions. Add them so the code stops
barfing when it um, encounters one.