### PR TITLE
Handle unknown test results more gracefully

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -556,7 +556,7 @@ def present(redcap_record: dict, test: str) -> Optional[bool]:
     }
 
     if standardized_result not in test_result_map:
-        raise Exception(f"Unknown test result value «{standardized_result}».")
+        raise UnknownTestResult(f"Unknown test result value «{standardized_result}».")
 
     return test_result_map[standardized_result]
 
@@ -598,7 +598,12 @@ def mapped_snomed_test_results(redcap_record: dict) -> Dict[str, bool]:
         if results.get(code):
             continue
 
-        result = present(redcap_record, test)
+        try:
+            result = present(redcap_record, test)
+        except UnknownTestResult as e:
+            LOG.warning(e)
+            continue
+
         # Don't add empty or inconclusive results
         if result is None:
             continue
@@ -619,5 +624,12 @@ class UnknownHospitalDischargeDisposition(ValueError):
     """
     Raised by :function: `discharge_disposition` if it finds
     a discharge disposition value that is not among a set of mapped values
+    """
+    pass
+
+class UnknownTestResult(ValueError):
+    """
+    Raised by :function: `present` if it finds a test result
+    that is not among a set of mapped values
     """
     pass


### PR DESCRIPTION
Add UnknownTestResult exception a la UnknownSampleOrigin/UnknownHospitalDischargeDisposition to gracefully handle bad test result values without dying from the uncaught Exception.

Prior logic said that if a test result isn't one of a very narrow set of values (e.g. 'detected', 'positive', 'negative', 'not detected'), just skip it. This will do the same thing, for all values that are not one we can confidently map to True or False.