### PR TITLE
Update regex on clinical parse collapse_columns function

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -417,6 +417,12 @@ def collapse_columns(df: pd.DataFrame, stub: str, pid='enrollid') -> pd.DataFram
     encoding of multiple race options into a single array in a resulting
     column called "Race". Removes the original "Race*" option columns. Returns
     the new DataFrame.
+
+    >>> df = pd.DataFrame(columns = ['enrollid', 'racewhite', 'raceblack', 'raceasian', 'census_tract'])
+    >>> df.loc[0] = ['WA000000', 1, 1, 1, '00000000000']
+    >>> collapse_columns(df, 'race').columns.values.tolist()
+    ['enrollid', 'census_tract', 'race']
+
     """
     stub_data = df.filter(regex=f'^({pid}|{stub}.*)$', axis='columns')
     stub_columns = list(stub_data)

--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -418,7 +418,7 @@ def collapse_columns(df: pd.DataFrame, stub: str, pid='enrollid') -> pd.DataFram
     column called "Race". Removes the original "Race*" option columns. Returns
     the new DataFrame.
     """
-    stub_data = df.filter(regex=f'{pid}|{stub}*', axis='columns')
+    stub_data = df.filter(regex=f'^({pid}|{stub}.*)$', axis='columns')
     stub_columns = list(stub_data)
     stub_columns.remove(pid)
 


### PR DESCRIPTION
Regex pattern on the collapse_columns function was incorrectly
defined allowing the last character of the `stub` parameter to be
optional. This had the effect of unintentionally collapsing `census_tract`
column when trying to collapse `race` columns because both contain `rac`.

The updated pattern requires all characters of the `stub` parameter to
be present in the column name.