### PR TITLE
Handle missing REDCap instrument when checking completeness

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -106,7 +106,7 @@ def redcap_det_scan(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_r
     # include it in the top list of REQUIRED_INSTRUMENTS since the new
     # SCAN In-Person Enrollment project does not have this instrument.
     #   -Jover, 17 July 2020
-    if is_complete('enrollment_questionnaire', redcap_record) == False:
+    if not is_complete('enrollment_questionnaire', redcap_record):
         LOG.debug("Skipping enrollment with incomplete `enrollment_questionnaire` instrument")
         return None
 
@@ -929,7 +929,7 @@ def create_initial_questionnaire_response(record: dict, patient_reference: dict,
         'contact_symp_negative',
         'vaccine_doses_child',      # Flu vaccine
         'vaccine_doses',            # Flu vaccine
-        'novax_hh',                 # Flu vaccine  
+        'novax_hh',                 # Flu vaccine
         'vac_name_3',               # COVID-19 vaccine
         'no_covid_vax_hh',          # COVID-19 vaccine
         'gender_identity',

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_reopening.py
@@ -115,7 +115,7 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
 
     # If the participant's age < 18 ensure we have parental consent.
     if (enrollment['core_age_years'] == "" or int(enrollment['core_age_years']) < 18) and \
-            (is_complete('parental_consent_form', enrollment) == False or enrollment['signature_parent'] == ''):
+            (not(is_complete('parental_consent_form', enrollment)) or enrollment['signature_parent'] == ''):
         LOG.debug("The participant is < 18 years old and we do not have parental consent. Skipping record.")
         return None
 
@@ -300,9 +300,9 @@ def redcap_det_uw_reopening(*, db: DatabaseSession, cache: TTLCache, det: dict,
                     logging.disable(logging.WARNING)
                     specimen_identifier = find_identifier(db, specimen_barcode)
                     logging.disable(logging.NOTSET)
-                    
+
                     break
-            
+
             if specimen_identifier:
                 specimen_entry, specimen_reference = create_specimen(
                     prioritized_barcodes = prioritized_barcodes,


### PR DESCRIPTION
The `is_complete` function will return `None` if the given instrument
does not exist. Updating in two ETLs where it was comparing the result to
`False` so that it will also handle `None` result appropriately.