### PR TITLE
SCH Retro Additional Field Ingestion

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -214,6 +214,8 @@ def parse_sch(sch_filename, manifest_format, output):
         "sex": "AssignedSex",
         "ethnicity": "HispanicLatino",
         "race": "Race",
+        "admit_during_this_encounter": "AdmitDuringThisEncounter",
+        "admit_to_icu": "AdmitToICU"
     }
 
     # Accounting for differences in format for year 3


### PR DESCRIPTION
The fields, `admit_during_this_encounter` and `admit_to_icu` from Seattle Children's are added for ingestion. These fields gets parsed and ingested, then stored under `details` -> `responses` in the warehouse.encounter table as either `yes` or `no` responses.
Additionally,financial aid and self-pay values were added to the Insurance mapping.

Testing Data Used:
1. SFS_Year1_Main_Data_20210922
2. SFS_Year2_Main_Data_20210923
3. SFS_Year3_Main_Data_20211207
4. SFS_Year4_Main_Data_20220124
5. SFS_Year4_Main_Data_20220208
6. SFS_Year4_Main_Data_20220209

Testing Done Include for All 6 Test Data Under Local:
1. id3c clinical parse-sch
2. id3c clinical upload
3. id3c etl clinical

Testing went well where the fields showed up as expected and the new insurance values were parsed. Y1, Y2, Y3, and Y4 all have the 2 additional fields, thus no pre-processing needed.