### PR TITLE
Update gitignore to ignore data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 # pyproject.toml is auto-generated when using pipenv>=2020.11.15, added here
 # to avoid having it deployed until production is updated to that version
 pyproject.toml
+
+# ignore data files that may have erroneously remained in this directory
+*.csv
+*.ndjson
+*.xls
+*.xlsx


### PR DESCRIPTION
Ignore CSV, NDJSON, XLS, and XLSX files when pushing to this repo. There are
currently two such files in the `locations/data` directory, neither of which
has ever been updated since it was initially pushed. If these files do need to
be updated in the future they can be explicitly excluded in `.gitignore` or
forcefully added and pushed.