### PR TITLE
Add Cascadia Identifiers to Backfill Sample IDs

### DIFF
--- a/lib/seattleflu/id3c/cli/command/backfill_sample_ids.py
+++ b/lib/seattleflu/id3c/cli/command/backfill_sample_ids.py
@@ -25,8 +25,9 @@ def backfill_sample_ids(*, db: DatabaseSession, action: DatabaseSessionAction):
             join warehouse.identifier on sample.collection_identifier = identifier.uuid::text
             join warehouse.identifier_set using (identifier_set_id)
             where identifier is null and
-            identifier_set.name in ('collections-uw-tiny-swabs-home', 'collections-uw-tiny-swabs-observed', 
-                'collections-scan-tiny-swabs', 'collections-adult-family-home-outbreak-tiny-swabs', 'collections-workplace-outbreak-tiny-swabs')
+            identifier_set.name in ('collections-uw-tiny-swabs-home', 'collections-uw-tiny-swabs-observed',
+                'collections-scan-tiny-swabs', 'collections-adult-family-home-outbreak-tiny-swabs', 'collections-workplace-outbreak-tiny-swabs',
+                'collections-cascadia-tiny-swabs-home')
             order by sample.sample_id
             """)
 
@@ -51,6 +52,3 @@ def backfill_sample_ids(*, db: DatabaseSession, action: DatabaseSessionAction):
 
         assert sample.id, "Update sample identifier affected no rows!"
         LOG.info(f"Updated sample {sample.id} with identifier «{sample.identifier}»")
-
-
-


### PR DESCRIPTION
When the Cascadia identifier set was created, the identifier set
was not added to the `backfill-sample-ids` job. This change adds
that identifier set to the job so that samples with `null` identifiers get
backfilled for this collection. I'll also go ahead and add some 
documentation around this task on the barcodes page so that it is 
clearer you need to do this when new collection sets for tinys are created.

This was tested by running `backfill-sample-ids` locally and making
sure that samples that were a part of the `collections-cascadia-tiny-swabs-home`
got pulled in to be backfilled. Since there are currently no Cascadia
samples, I just created one with a `null` identifier and tested that
it got pulled in to be backfilled, which it did.