### PR TITLE
Disable parallel queries and increase memory for offer-uw-testing

### DIFF
--- a/lib/seattleflu/id3c/cli/command/offer_uw_testing.py
+++ b/lib/seattleflu/id3c/cli/command/offer_uw_testing.py
@@ -103,7 +103,14 @@ def offer_uw_testing(*, at: str, log_offers: bool, db: DatabaseSession, action: 
         f"is now {quota.remaining:,} = {quota.max:,} - {quota.used:,} (remaining = max - used)")
 
     # Offer testing to the top entries in our priority queue.
+    #
+    # Disabling parallel queries here, which were occasionally getting stuck with
+    # wait event `IPC: Message Queue Send`. Setting work_mem higher to use memory instead
+    # of disk for sorting and hash tables
+
     next_in_queue = db.fetch_all("""
+        set local max_parallel_workers_per_gather = 0;
+        set local work_mem = '64MB';
         select
             redcap_url,
             redcap_project_id,


### PR DESCRIPTION
This job has been encountering issues related to the select from
__uw_priority_queue_v1 hanging indefinitely. In those cases, the parallel
workers are in different states, some stuck with a wait event of `IPC:
MessageQueueSend` and others being spawed and killed repeatedly.

This change will disable parallel queries when selecting from this
particular view, and increase memory to avoid writing to disk for sorting
and hash tables. The performance is comparable with these changes tested locally.
This may not resolve the issue entirely, but should at least eliminate parallelism
or memory as the root cause.