### PR TITLE
Update mapping for clincial ETL to include new sex value

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -184,6 +184,7 @@ def sex(sex_name) -> str:
         0.0: "female",
         "clinically undetermined": "other",
         "other": "other",
+        "x (non-binary)": "other",
         "unknown": None,
     }
 


### PR DESCRIPTION
A new value was encountered in a recent batch of clinical data for non-binary
sex. Adding to map so that this value can be standardized.