### PR TITLE
Modify clinical ETL to process PHSKC data into FHIR bundles

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -324,9 +324,9 @@ def determine_questionnaire_items(record: dict) -> List[dict]:
     if record["survey_have_symptoms_now"]:
         items["survey_have_symptoms_now"] = [{ 'valueBoolean': survey_have_symptoms_now(record["survey_have_symptoms_now"])}]
 
-    # TODO
-    # add the remaining questionnaire responses:
-    # - survey_testing_because_exposed
+    if record["survey_testing_because_exposed"]:
+        items["survey_testing_because_exposed"] = [{ 'valueString': survey_testing_because_exposed(record["survey_testing_because_exposed"])}]
+
 
     questionnaire_items: List[dict] = []
     for key,value in items.items():
@@ -924,6 +924,43 @@ def survey_have_symptoms_now(survey_have_symptoms_now_response: Optional[Any]) -
         raise Exception(f"Unknown survey_have_symptoms_now_response «{survey_have_symptoms_now_response}»")
 
     return survey_have_symptoms_now_map[survey_have_symptoms_now_response]
+
+
+def survey_testing_because_exposed(survey_testing_because_exposed_response: Optional[Any]) -> Optional[str]:
+    """
+    Given a *survey_testing_because_exposed_response*, returns a standardized value.
+    Raises an :class:`Exception` if the given response is unknown.
+
+    >>> survey_testing_because_exposed("No")
+    'no'
+
+    >>> survey_testing_because_exposed("Yes - Received alert by phone app that I was near a person with COVID")
+    'yes_received_app_alert'
+
+    >>> survey_testing_because_exposed("maybe")
+    Traceback (most recent call last):
+        ...
+    Exception: Unknown survey_testing_because_exposed value «maybe»
+
+    """
+
+    if survey_testing_because_exposed_response is None:
+        LOG.debug("No survey_testing_because_exposed response found.")
+        return None
+
+    survey_testing_because_exposed_map = {
+        "No":                                                                       "no",
+        "Yes - I believe I have been exposed":                                      "yes_believe_exposed",
+        "Yes - referred by a contact such as a friend-family-coworker":             "yes_referred_by_contact",
+        "Yes - Received alert by phone app that I was near a person with COVID":    "yes_received_app_alert",
+        "Yes - referred by Public Health":                                          "yes_referred_by_public_health",
+        "Yes - referred by your health care provider":                              "yes_referred_by_provider"
+    }
+
+    if survey_testing_because_exposed_response not in survey_testing_because_exposed_map:
+        raise Exception(f"Unknown survey_testing_because_exposed value «{survey_testing_because_exposed_response}»")
+
+    return survey_testing_because_exposed_map[survey_testing_because_exposed_response]
 
 
 def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -318,11 +318,13 @@ def determine_questionnaire_items(record: dict) -> List[dict]:
     if record["vaccine_status"]:
         items["vaccine_status"] = [{ 'valueString': covid_vaccination_status(record["vaccine_status"])}]
 
+    if record["inferred_symptomatic"]:
+        items["inferred_symptomatic"] = [{ 'valueBoolean': inferred_symptomatic(record["inferred_symptomatic"])}]
+
     # TODO
     # add the remaining questionnaire responses:
     # - survey_testing_because_exposed
     # - survey_have_symptoms_now
-    # - inferred_symptomatic
 
     questionnaire_items: List[dict] = []
     for key,value in items.items():
@@ -850,6 +852,41 @@ def covid_vaccination_status(covid_vaccination_status_response: Optional[Any]) -
         raise Exception(f"Unknown covid_vaccination_status value «{covid_vaccination_status_response}»")
 
     return covid_vaccination_status_map[covid_vaccination_status_response]
+
+
+def inferred_symptomatic(inferred_symptomatic_response: Optional[Any]) -> Optional[bool]:
+    """
+    Given a *inferred_symptomatic_response*, returns boolean value.
+    Raises an :class:`Exception` if the given response is unknown.
+
+    >>> inferred_symptomatic('FALSE')
+    False
+
+    >>> inferred_symptomatic('TRUE')
+    True
+
+    >>> inferred_symptomatic('maybe')
+    Traceback (most recent call last):
+        ...
+    Exception: Unknown inferred_symptomatic_response «maybe»
+
+    """
+    if inferred_symptomatic_response is None:
+        LOG.debug("No inferred_symptomatic response found.")
+        return None
+
+    if isinstance(inferred_symptomatic_response, str):
+        inferred_symptomatic_response = inferred_symptomatic_response.lower().strip()
+
+    inferred_symptomatic_map = {
+        "false": False,
+        "true": True,
+    }
+
+    if inferred_symptomatic_response not in inferred_symptomatic_map:
+        raise Exception(f"Unknown inferred_symptomatic_response «{inferred_symptomatic_response}»")
+
+    return inferred_symptomatic_map[inferred_symptomatic_response]
 
 
 def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -794,13 +794,16 @@ def if_symptoms_how_long(if_symptoms_how_long_response: Optional[Any]) -> Option
     >>> if_symptoms_how_long("I don't know")
     Traceback (most recent call last):
         ...
-    Exception: Unknown if_symptoms_how_long value «I don't know»
+    Exception: Unknown if_symptoms_how_long value «i don't know»
 
     """
 
     if if_symptoms_how_long_response is None:
         LOG.debug("No if_symptoms_how_long response found.")
         return None
+
+    if isinstance(if_symptoms_how_long_response, str):
+        if_symptoms_how_long_response = if_symptoms_how_long_response.lower().strip()
 
     symptoms_duration_map = {
         "1 day": "1_day",
@@ -812,7 +815,7 @@ def if_symptoms_how_long(if_symptoms_how_long_response: Optional[Any]) -> Option
         "7 days": "7_days",
         "8 days": "8_days",
         "9+ days": "9_or_more_days",
-        "I don't have symptoms": "no_symptoms",
+        "i don't have symptoms": "no_symptoms",
     }
 
     if if_symptoms_how_long_response not in symptoms_duration_map:
@@ -835,7 +838,7 @@ def covid_vaccination_status(covid_vaccination_status_response: Optional[Any]) -
     >>> covid_vaccination_status("I don't know")
     Traceback (most recent call last):
         ...
-    Exception: Unknown covid_vaccination_status value «I don't know»
+    Exception: Unknown covid_vaccination_status value «i don't know»
 
     """
 
@@ -843,11 +846,14 @@ def covid_vaccination_status(covid_vaccination_status_response: Optional[Any]) -
         LOG.debug("No covid_vaccination_status_response response found.")
         return None
 
+    if isinstance(covid_vaccination_status_response, str):
+        covid_vaccination_status_response = covid_vaccination_status_response.lower().strip()
+
     covid_vaccination_status_map = {
-        "Yes I am fully vaccinated.":                                           "fully_vaccinated",
-        "No I am not vaccinated.":                                              "not_vaccinated",
-        "No but I am partially vaccinated (e.g. 1 dose of a 2-dose series).":   "partially_vaccinated",
-        "Yes I am fully vaccinated and I also have received a booster.":        "boosted",
+        "yes i am fully vaccinated.":                                           "fully_vaccinated",
+        "no i am not vaccinated.":                                              "not_vaccinated",
+        "no but i am partially vaccinated (e.g. 1 dose of a 2-dose series).":   "partially_vaccinated",
+        "yes i am fully vaccinated and i also have received a booster.":        "boosted",
     }
 
     if covid_vaccination_status_response not in covid_vaccination_status_map:
@@ -948,13 +954,16 @@ def survey_testing_because_exposed(survey_testing_because_exposed_response: Opti
         LOG.debug("No survey_testing_because_exposed response found.")
         return None
 
+    if isinstance(survey_testing_because_exposed_response, str):
+        survey_testing_because_exposed_response = survey_testing_because_exposed_response.lower().strip()
+
     survey_testing_because_exposed_map = {
-        "No":                                                                       "no",
-        "Yes - I believe I have been exposed":                                      "yes_believe_exposed",
-        "Yes - referred by a contact such as a friend-family-coworker":             "yes_referred_by_contact",
-        "Yes - Received alert by phone app that I was near a person with COVID":    "yes_received_app_alert",
-        "Yes - referred by Public Health":                                          "yes_referred_by_public_health",
-        "Yes - referred by your health care provider":                              "yes_referred_by_provider"
+        "no":                                                                       "no",
+        "yes - i believe i have been exposed":                                      "yes_believe_exposed",
+        "yes - referred by a contact such as a friend-family-coworker":             "yes_referred_by_contact",
+        "yes - received alert by phone app that i was near a person with covid":    "yes_received_app_alert",
+        "yes - referred by public health":                                          "yes_referred_by_public_health",
+        "yes - referred by your health care provider":                              "yes_referred_by_provider"
     }
 
     if survey_testing_because_exposed_response not in survey_testing_because_exposed_map:

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -226,8 +226,7 @@ def create_encounter(db: DatabaseSession,
 
     encounter_class = create_encounter_class(record)
     encounter_status = create_encounter_status(record)
-
-    record_source = f"{record['_provenance']['filename']},row:{record['_provenance']['row']}"
+    record_source = create_provenance(record)
 
     encounter_resource = create_encounter_resource(
         encounter_source = record_source,
@@ -970,6 +969,21 @@ def survey_testing_because_exposed(survey_testing_because_exposed_response: Opti
         raise Exception(f"Unknown survey_testing_because_exposed value «{survey_testing_because_exposed_response}»")
 
     return survey_testing_because_exposed_map[survey_testing_because_exposed_response]
+
+
+def create_provenance(record: dict) -> str:
+    """
+    Create JSON object indicating the source file and row of a given *record*.
+
+    Used in FHIR Encounter resources as the meta.source, which ultimately winds
+    up in ID3C's ``warehouse.encounter.details`` column.
+    """
+    data_scheme = 'data:application/json'
+
+    if '_provenance' in record and set(['filename','row']).issubset(record['_provenance']):
+        return data_scheme + ',' + quote(json.dumps(record['_provenance']))
+    else:
+        raise Exception(f"Error: _provenance missing or incomplete (must contain filename and row)")
 
 
 def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -321,10 +321,12 @@ def determine_questionnaire_items(record: dict) -> List[dict]:
     if record["inferred_symptomatic"]:
         items["inferred_symptomatic"] = [{ 'valueBoolean': inferred_symptomatic(record["inferred_symptomatic"])}]
 
+    if record["survey_have_symptoms_now"]:
+        items["survey_have_symptoms_now"] = [{ 'valueBoolean': survey_have_symptoms_now(record["survey_have_symptoms_now"])}]
+
     # TODO
     # add the remaining questionnaire responses:
     # - survey_testing_because_exposed
-    # - survey_have_symptoms_now
 
     questionnaire_items: List[dict] = []
     for key,value in items.items():
@@ -887,6 +889,41 @@ def inferred_symptomatic(inferred_symptomatic_response: Optional[Any]) -> Option
         raise Exception(f"Unknown inferred_symptomatic_response «{inferred_symptomatic_response}»")
 
     return inferred_symptomatic_map[inferred_symptomatic_response]
+
+
+def survey_have_symptoms_now(survey_have_symptoms_now_response: Optional[Any]) -> Optional[bool]:
+    """
+    Given a *survey_have_symptoms_now_response*, returns boolean value.
+    Raises an :class:`Exception` if the given response is unknown.
+
+    >>> survey_have_symptoms_now('yes')
+    True
+
+    >>> survey_have_symptoms_now('no')
+    False
+
+    >>> survey_have_symptoms_now('maybe')
+    Traceback (most recent call last):
+        ...
+    Exception: Unknown survey_have_symptoms_now_response «maybe»
+
+    """
+    if survey_have_symptoms_now_response is None:
+        LOG.debug("No survey_have_symptoms_now response found.")
+        return None
+
+    if isinstance(survey_have_symptoms_now_response, str):
+        survey_have_symptoms_now_response = survey_have_symptoms_now_response.lower().strip()
+
+    survey_have_symptoms_now_map = {
+        "yes": True,
+        "no": False,
+    }
+
+    if survey_have_symptoms_now_response not in survey_have_symptoms_now_map:
+        raise Exception(f"Unknown survey_have_symptoms_now_response «{survey_have_symptoms_now_response}»")
+
+    return survey_have_symptoms_now_map[survey_have_symptoms_now_response]
 
 
 def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -312,10 +312,13 @@ def determine_questionnaire_items(record: dict) -> List[dict]:
     if record["ethnicity"]:
         items["ethnicity"] = [{ 'valueBoolean': ethnicity(record["ethnicity"]) }]
 
+    if record["if_symptoms_how_long"]:
+        items["if_symptoms_how_long"] = [{ 'valueString': if_symptoms_how_long(record["if_symptoms_how_long"])}]
+
+
     # TODO
     # add the remaining questionnaire responses:
     # - survey_testing_because_exposed
-    # - if_symptoms_how_long
     # - survey_have_symptoms_now
     # - inferred_symptomatic
     # - vaccine_status
@@ -770,6 +773,47 @@ def insurance(insurance_response: Optional[Any]) -> list:
             raise Exception(f"Unknown insurance name «{insurance}»") from None
 
     return list(map(standardize_insurance, insurance_response))
+
+
+def if_symptoms_how_long(if_symptoms_how_long_response: Optional[Any]) -> Optional[str]:
+    """
+    Given a *if_symptoms_how_long_response*, returns a standardized value.
+    Raises an :class:`Exception` if the given response is unknown.
+
+    >>> if_symptoms_how_long('1 day')
+    '1_day'
+
+    >>> if_symptoms_how_long("I don't have symptoms")
+    'no_symptoms'
+
+    >>> if_symptoms_how_long("I don't know")
+    Traceback (most recent call last):
+        ...
+    Exception: Unknown if_symptoms_how_long value «I don't know»
+
+    """
+
+    if if_symptoms_how_long_response is None:
+        LOG.debug("No if_symptoms_how_long response found.")
+        return None
+
+    symptoms_duration_map = {
+        "1 day": "1_day",
+        "2 days": "2_days",
+        "3 days": "3_days",
+        "4 days": "4_days",
+        "5 days": "5_days",
+        "6 days": "6_days",
+        "7 days": "7_days",
+        "8 days": "8_days",
+        "9+ days": "9_or_more_days",
+        "I don't have symptoms": "no_symptoms",
+    }
+
+    if if_symptoms_how_long_response not in symptoms_duration_map:
+        raise Exception(f"Unknown if_symptoms_how_long value «{if_symptoms_how_long_response}»")
+
+    return symptoms_duration_map[if_symptoms_how_long_response]
 
 
 def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:


### PR DESCRIPTION
Updates to clinical ETL for processing of PHSKC data. This data has being parsed and pre-processing
from Excel worksheets, and inserted into the clinical receiving table. This update to the clinical
ETL will transform the data into FHIR bundle format and inserted into the fhir receiving table to be
processed by the FHIR ETL.

This was modeled after the UW Retrospectives process, which is currently the only clinical data ETL that
uses the FHIR format. To expediate the development and avoid duplicating code, it utilizes existing
functions that were originally designed for REDCap ETLs wherever possible.