### PR TITLE
Adding new value to test result mapping function

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -87,7 +87,7 @@ def redcap_det_uw_retrospectives(*,
     for entries in [location_entries, immunization_entries, condition_entries]:
         if entries:
             resource_entries.extend(entries)
-    
+
     if diagnostic_report_resource_entry:
         resource_entries.append(diagnostic_report_resource_entry)
 
@@ -335,7 +335,7 @@ def discharge_disposition(redcap_record: dict) -> Optional[str]:
     disposition = redcap_record['discharge_disposition']
     if not disposition:
         return None
-    
+
     # Lowercase, remove leading number characters, and standardize whitespace
     standardized_disposition = standardize_whitespace(re.sub('^\d+', '', disposition.lower()))
 
@@ -407,9 +407,9 @@ def discharge_disposition(redcap_record: dict) -> Optional[str]:
 
         #raise UnknownHospitalDischargeDisposition("Unknown discharge disposition value "
         #    f"«{standardized_disposition}» for barcode «{redcap_record['barcode']}».")
-    
+
         return None
-        
+
     return mapper[standardized_disposition]
 
 
@@ -569,12 +569,12 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
         if immunization_status not in ["y", "n", ""]:
             raise UnknownImmunizationStatus (f"Unknown immunization status «{immunization_status}».")
 
-        # Standardize vaccine name 
+        # Standardize vaccine name
         if column_map["status"] == "flu_status" and column_map["name"] == None:
             vaccine_name = "flu unspecified"
         else:
             vaccine_name = standardize_whitespace(record[column_map["name"]]).lower()
-        
+
         # Validate vaccine name and determine CVX code
         vaccine_code = None
         if vaccine_name in vaccine_mapper:
@@ -584,11 +584,11 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
 
         # Standardize date format
         immunization_date = record[column_map["date"]]
-        
+
         if immunization_status == "y" and vaccine_code:
             immunization_identifier_hash = generate_hash(f"{record['mrn']}{vaccine_code['code']}{immunization_date}".lower())
             immunization_identifier = create_identifier(f"{SFS}/immunization", immunization_identifier_hash)
-        
+
             immunization_resource = create_immunization_resource(
                 patient_reference = patient_reference,
                 immunization_identifier = [immunization_identifier],
@@ -737,12 +737,13 @@ def present(redcap_record: dict, test: str) -> Optional[bool]:
         'followup testing required'             : None,
         'data entry correction'                 : None,
         'reorder requested'                     : None,
+        'invalid'                               : None,
     }
 
     for prefix in test_result_prefix_map:
         if standardized_result.startswith(prefix):
             return test_result_prefix_map[prefix]
-    
+
     raise UnknownTestResult(f"Unknown test result value «{standardized_result}» for «{redcap_record['barcode']}».")
 
 


### PR DESCRIPTION
Multiple new test result values were encountered during ingestion of UW Retros metadata
that begin with "invalid", which had not been previously seen or mapped. Adding to the
`test_result_prefix_map` to re-process those records that failed and handle these values going forward.