### PR TITLE
offer_uw_testing: dial down redcap batch size

### DIFF
--- a/lib/seattleflu/id3c/cli/command/offer_uw_testing.py
+++ b/lib/seattleflu/id3c/cli/command/offer_uw_testing.py
@@ -32,7 +32,7 @@ STUDY_START_DATE = date(2021, 9, 9)
 
 TESTING_INSTRUMENT = "testing_determination_internal"
 
-REDCAP_BATCH_SIZE = 250
+REDCAP_BATCH_SIZE = 150
 
 
 @cli.command("offer-uw-testing", help = __doc__)


### PR DESCRIPTION
We are seeing 1-2x/daily failures of this job due to timeouts
on the call to redcap to update records. As the project has grown
larger and there have been performance issues in the redcap service,
let's try dialing this threshold down to update only 150 records in
a batch to see if it improves the reliability.