### PR TITLE
uw retro etl: map new encounter_status and encounter_class values

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -425,6 +425,9 @@ def create_encounter_class(redcap_record: dict) -> dict:
 
     mapper = {
         "outpatient" : "AMB",
+        "hospital outpatient surgery": "AMB",
+        "series pt-ot-st": "AMB", # Physical-occupational-speech therapy
+        "deceased - organ donor": "AMB",
         "inpatient"  : "IMP",
         "emergency"  : "EMER",
         "op"    : "AMB",
@@ -433,6 +436,7 @@ def create_encounter_class(redcap_record: dict) -> dict:
         "lim"   : "IMP",
         "obs"   : "IMP",
         "obv"   : "IMP",
+        "observation" : "IMP",
         "field" : "FLD",
     }
 
@@ -466,6 +470,7 @@ def create_encounter_status(redcap_record: dict) -> str:
         'preadmit'  : 'arrived',
         'lwbs'      : 'cancelled',  # LWBS = left without being seen.
         'canceled'  : 'cancelled',
+        'no show'   : 'cancelled',
         'completed' : 'finished',
         'discharged': 'finished',
     }


### PR DESCRIPTION
To reflect data model changes upstream, include new values:

encounter_status:
  no show

encounter_class:
  series pt-ot-st
  deceased - organ donor
  hospital outpatient surgery
  observation

There was some ambiguity in how to map "deceased-organ donor"
as an encounter class (we do already handle it as a discharge
disposition), but we've decided to default to mapping it to an
ambulatory/outpatient encounter because that's generally our
default and there wasn't an unknown option.