### PR TITLE
Ingest result_value field for PHSKC samples

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -33,7 +33,6 @@ from . import (
     group_true_values_into_list,
 )
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -525,7 +524,8 @@ def parse_phskc(phskc_filename: str, phskc_specimen_manifest_filename: str, geoc
 
     column_map = {
         'ethnic_group': 'ethnicity',
-        'barcode': 'phskc_barcode'
+        'barcode': 'phskc_barcode',
+        'collect_ts': 'collection_date'
     }
 
     columns_to_keep = list(column_map.keys()) + [
@@ -548,7 +548,8 @@ def parse_phskc(phskc_filename: str, phskc_specimen_manifest_filename: str, geoc
         'inferred_symptomatic',
         'vaccine_status',
         'patient_class',
-        'encounter_status'
+        'encounter_status',
+        'result_value'
     ]
 
     clinical_records = clinical_records[columns_to_keep]

--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -146,7 +146,7 @@ def ethnicity(ethnicity: str) -> Optional[bool]:
 
     >>> ethnicity("NOT HISPANIC OR LATINO")
     False
-    
+
     >>> ethnicity("NULL") == None
     True
 
@@ -163,7 +163,7 @@ def ethnicity(ethnicity: str) -> Optional[bool]:
     else:
         ethnicity = standardize_whitespace(ethnicity.lower())
 
-    # Leaving this code here to be implemented later. My original approach was to use FHIR 
+    # Leaving this code here to be implemented later. My original approach was to use FHIR
     # coding for ethnicity, which would be preffered, but for consistency with other ETLs
     # I switched to ingesting ethnicity as a boolean. To transition to FHIR codes across all projects will
     # require updating multiple ETLs, shipping views, and re-ingesting data. A card has been added

--- a/lib/seattleflu/id3c/cli/command/etl/fhir.py
+++ b/lib/seattleflu/id3c/cli/command/etl/fhir.py
@@ -61,13 +61,13 @@ def create_patient_resource(patient_identifier: List[dict],
     return patient_resource
 
 
-def create_diagnostic_report(redcap_record:dict,
+def create_diagnostic_report(record:dict,
                              patient_reference: dict,
                              specimen_reference: dict,
                              diagnostic_code: dict,
-                             create_device_result_observation_resource: Callable) -> Optional[dict]:
+                             create_device_result_observation_resources: Callable) -> Optional[dict]:
     """
-    Create FHIR diagnostic report from given *redcap_record*.
+    Create FHIR diagnostic report from given *record*.
 
     Links the generated diagnostic report to a specific *patient_reference* and
     *specimen_reference*.
@@ -77,7 +77,7 @@ def create_diagnostic_report(redcap_record:dict,
     *create_device_result_observation_resource* function which attaches
     observation resources to the diagnostic report.
     """
-    clinical_results = create_device_result_observation_resource(redcap_record)
+    clinical_results = create_device_result_observation_resources(record)
     if not clinical_results:
         return None
 
@@ -89,7 +89,7 @@ def create_diagnostic_report(redcap_record:dict,
         )
         diagnostic_result_references.append(reference)
 
-    collection_datetime = redcap_record['collection_date']
+    collection_datetime = record['collection_date']
 
     diagnostic_report_resource = create_diagnostic_report_resource(
         datetime = collection_datetime,
@@ -348,6 +348,7 @@ def create_specimen_observation(specimen_reference: dict,
         "specimen": specimen_reference
     }
 
+
 def create_immunization_resource(patient_reference: dict,
                                  immunization_identifier: List[dict],
                                  immunization_date: str,
@@ -357,7 +358,7 @@ def create_immunization_resource(patient_reference: dict,
     Create an immunization resource following the FHIR format
     (https://www.hl7.org/fhir/immunization.html)
     """
-    
+
     return({
         "resourceType": "Immunization",
         "identifier": immunization_identifier,
@@ -369,7 +370,7 @@ def create_immunization_resource(patient_reference: dict,
         }
     })
 
-    
+
 def create_questionnaire_response_resource(patient_reference: dict,
                                            encounter_reference: dict,
                                            items: List[dict]) -> dict:


### PR DESCRIPTION
This change allows the PHSKC ingestion pipeline to also ingest the `result_value` and `collect_ts` fields from the PHSKC data into the `presence_absence` table in ID3C.

Functionality was added that adds these fields to the fields that we extract from provided PHSKC sample metadata and parses it into ndjson files. Additionally, this change adds functions that generate FHIR compatible Observations and Diagnostic report resources which can be ingested into ID3C.