### PR TITLE
Document customizations API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # except these files
 !/.gitignore
 !/LICENSE
+!/MANIFEST.in
 !/README.md
 !/Pipfile
 !/Pipfile.lock

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include lib/seattleflu/id3c/api/static/documentation.html

--- a/lib/seattleflu/id3c/.gitignore
+++ b/lib/seattleflu/id3c/.gitignore
@@ -6,6 +6,7 @@
 
 # and these files...
 !*.py
+!*.html
 
 # ...even if in subdirectories
 !/**/

--- a/lib/seattleflu/id3c/api/routes.py
+++ b/lib/seattleflu/id3c/api/routes.py
@@ -1,20 +1,30 @@
 import logging
-from flask import jsonify, request, abort, Response, Blueprint
+from flask import jsonify, request, abort, Response, Blueprint, send_file
 from flask_cors import cross_origin
-from id3c.api.routes import api_v1, blueprints
+from id3c.api.routes import api_v1, blueprints, api_unversioned
 from id3c.api.exceptions import BadRequest
 from id3c.api.utils.routes import authenticated_datastore_session_required
+from pathlib import Path
 from . import datastore
 import os
 import re
 
 LOG = logging.getLogger(__name__)
 
+base_dir     = Path(__file__).parent.resolve()
+
 api_v2 = Blueprint('api_v2', 'api_v2', url_prefix='/v2')
 blueprints.append(api_v2)
 
 api_v3 = Blueprint('api_v3', 'api_v3', url_prefix='/v3')
 blueprints.append(api_v3)
+
+@api_unversioned.route("/documentation/customizations", methods = ['GET'])
+def get_documentation():
+    """
+    Show an index page with documentation for id3c-customizations endpoints.
+    """
+    return send_file(base_dir / "static/documentation.html", "text/html; charset=UTF-8")
 
 @api_v1.route("/shipping/return-results/<barcode>", methods = ['GET'])
 @cross_origin(origins=[

--- a/lib/seattleflu/id3c/api/static/documentation.html
+++ b/lib/seattleflu/id3c/api/static/documentation.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width" />
+    <title>api documentation</title>
+    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css">
+  </head>
+  <body class="sans-serif dark-gray ma0 pa4 measure-wide">
+    <h1 class="mt0">API customizations</h1>
+
+    <h2>Authentication</h2>
+
+    <p>All routes require
+    <a href="https://en.wikipedia.org/wiki/Basic_access_authentication">Basic
+    access authentication</a> over HTTPS unless otherwise noted.
+
+    <h2>Request and response bodies</h2>
+
+    <p>All routes which receive request bodies expect a Content-Type of
+    <code>application/json</code> unless otherwise noted.
+
+    <p>All request bodies must be encoded with UTF-8.  All response bodies are
+    encoded with UTF-8 unless explicitly declared otherwise by a Content-Type
+    header.
+
+    <h2>Status codes</h2>
+
+    <p>All routes use standard HTTP status codes.
+
+    <p>If the Content-Type of a <code>400 Bad Request</code> response is
+    <code>application/json</code>, then the body will be a JSON object with at
+    least the key <code>error</code>.  Additional keys may provide more
+    details.
+
+    <h2>Routes</h2>
+
+
+    <h3 class="code">GET /v2/shipping/return-results/<em>&lt;barcode&gt;</em></h3>
+    <p>Export presence/absence results for a specific collection *barcode*</p>
+
+    <h3 class="code">GET /v3/shipping/augur-build-metadata/</h3>
+    <p>Export metadata needed for SFS augur build</p>
+
+    <h3 class="code">GET /v1/shipping/genomic-data/<em>&lt;lineage&gt;</em>/<em>&lt;segment&gt;</em></h3>
+    <p>Export genomic data needed for SFS augur build based on provided *lineage* and *segment*. The *lineage* should be in the full lineage in ltree format such as 'Influenza.A.H1N1'</p>
+
+    <h3 class="code">GET /v2/shipping/scan-demographics</h3>
+    <p>Export basic demographics for SCAN</p>
+
+    <h3 class="code">GET /v1/shipping/scan-hcov19-positives</h3>
+    <p>Export aggregate numbers of hCoV-19 result counts for SCAN</p>
+
+    <h3 class="code">GET /v2/shipping/scan-hcov19-positives</h3>
+    <p>Export aggregate numbers of hCoV-19 result counts for SCAN, grouped by priority code</p>
+
+    <h3 class="code">GET /v1/shipping/scan-enrollments</h3>
+    <p>Export basic enrollment metadata for SCAN</p>
+
+    <h3 class="code">GET /v1/shipping/scan-enrollments-internal</h3>
+    <p>Export basic enrollment metadata for SCAN internal dashboard</p>
+
+    <h3 class="code">GET /v1/shipping/latest-results</h3>
+    <p>Export latest results without PHI</p>
+
+
+  </body>
+</html>


### PR DESCRIPTION
Add documentation for the API endpoints in the id3c customizations
package. Surface these via /v1/documentation/customizations

Documentation created using comments in from routes.py

Add a manifest to include the documentation static file. When this
and id3c get loaded together, only the static files from id3c will
get picked up automatically by setup tools.

---------------

For local testing, you can start the API with:
`pipenv run python -m id3c.api FLASK_DEBUG=1`

and then visit http://127.0.0.1:5000/v1/documentation/customizations 
(updating that port if necessary locally)

You can also see how the files get packaged and what is included using:
`pipenv run python setup.py sdist`