### PR TITLE
Deprecate ETLs for ended studies

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -272,12 +272,8 @@ class UnknownEthnicityError(ValueError):
 from . import (
     clinical,
     longitudinal,
-    redcap_det_kiosk,
     redcap_det_swab_n_send,
-    redcap_det_swab_and_home_flu,
     redcap_det_uw_retrospectives,
-    redcap_det_asymptomatic_swab_n_send,
     redcap_det_scan,
     redcap_det_uw_reopening,
-    redcap_det_childcare,
 )

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process REDCap DETs that are specific to the
 Seattle Flu Study - Swab and Send - Asymptomatic Enrollments
 """

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_childcare.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process DETs for the Childcare REDCap projects.
 Out of concern for privacy (PII), for this project we decided not
 to store the participant's age on encounters. The `age` column

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process REDCap DETs that are specific to the Kiosk Enrollment Project.
 """
 import logging

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process REDCap DETs that are specific to the
 Seattle Flu Study - Swab & Send + Home Flu Test Project.
 """


### PR DESCRIPTION
Data collection has ended for these studies. Removing from init
will disable the associated `id3c etl redcap-det ...` commands.
We are leaving the command for the various ETLs as a record of
how the data from these studies was historically processed.