### PR TITLE
Only Dump PHSKC NDJSON if Data Exists

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -577,7 +577,8 @@ def parse_phskc(phskc_filename: str, phskc_specimen_manifest_filename: str, geoc
     # drop all columns used for joining; we only need to ingest the joined barcode
     clinical_records.drop(['merge_col', 'main_cid', 'phskc_barcode', 'all_cids'], axis=1, inplace=True)
 
-    dump_ndjson(clinical_records)
+    if not clinical_records.empty:
+        dump_ndjson(clinical_records)
 
 
 def add_phskc_manifest_data(df: pd.DataFrame, manifest_filename: str) -> pd.DataFrame:


### PR DESCRIPTION
PHSKC data is uploaded to Sharepoint prior to the lab adding it to AQ sheets. When this data is parsed the outputted files are non-empty since they have a newline character, making it more difficult to verify if a file is truly non-empty. This change only outputs PHSKC data when the DF is non-empty, ensuring the file is empty if there is no aliquot data to join to and making it simpler to check files downstream for emptiness.