### PR TITLE
Add Encounter Date to PHSKC Shipping View

### DIFF
--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -56,6 +56,7 @@ drop view if exists shipping.incidence_model_observation_v3;
 drop view if exists shipping.incidence_model_observation_v2;
 drop view if exists shipping.incidence_model_observation_v1;
 
+drop view if exists shipping.linelist_data_for_wa_doh_v2;
 drop view if exists shipping.linelist_data_for_wa_doh_v1;
 
 drop view if exists shipping.hcov19_observation_v1;
@@ -1022,7 +1023,8 @@ create or replace view shipping.phskc_encounter_details_v1 as
         phskc_encounters as (
             select encounter_id,
                 age,
-                sex
+                sex,
+                encountered
             from warehouse.encounter
               left join warehouse.individual using (individual_id)
             where site_id = 569
@@ -1062,6 +1064,7 @@ create or replace view shipping.phskc_encounter_details_v1 as
 
     select
         encounter_id,
+        encountered,
         age_in_years(age) as age,
         sex,
         race,

--- a/schema/deploy/shipping/views@2022-06-24.sql
+++ b/schema/deploy/shipping/views@2022-06-24.sql
@@ -56,7 +56,6 @@ drop view if exists shipping.incidence_model_observation_v3;
 drop view if exists shipping.incidence_model_observation_v2;
 drop view if exists shipping.incidence_model_observation_v1;
 
-drop view if exists shipping.linelist_data_for_wa_doh_v2;
 drop view if exists shipping.linelist_data_for_wa_doh_v1;
 
 drop view if exists shipping.hcov19_observation_v1;

--- a/schema/revert/shipping/views@2022-06-24.sql
+++ b/schema/revert/shipping/views@2022-06-24.sql
@@ -56,8 +56,8 @@ drop view if exists shipping.incidence_model_observation_v3;
 drop view if exists shipping.incidence_model_observation_v2;
 drop view if exists shipping.incidence_model_observation_v1;
 
-drop view if exists shipping.linelist_data_for_wa_doh_v2;
 drop view if exists shipping.linelist_data_for_wa_doh_v1;
+drop view if exists shipping.linelist_data_for_wa_doh_v2;
 
 drop view if exists shipping.hcov19_observation_v1;
 drop view if exists shipping.hcov19_presence_absence_result_v1;
@@ -4208,8 +4208,7 @@ create or replace view shipping.linelist_data_for_wa_doh_v1 as (
       where collected >= '2020-06-10 00:00:00 US/Pacific'
       and hcov19_presence_absence_result_v1.details @> '{"assay_type": "Clia"}'
       order by sample_id, encounter_id
-)
-;
+);
 
 comment on view shipping.linelist_data_for_wa_doh_v1 is
   'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
@@ -4222,82 +4221,5 @@ grant select
   on shipping.linelist_data_for_wa_doh_v1
   to "return-results-exporter";
 
-
-
-create or replace view shipping.linelist_data_for_wa_doh_v2 as (
-    select distinct on (sample_id)
-          -- The naming scheme of these columns is an artefact of how we
-          -- originally submitted data to WaDoH from REDCap reports. Now they
-          -- expect columns structured and named in a specific way, and we
-          -- cannot modify those with our current linelist format. We can notify
-          -- WaDoH of our intent to change our submitted data format (e.g.
-          -- custom format or ELFF), but they'll need sufficient advanced
-          -- notice. At that point, we can update this view with different
-          -- column names.
-          --
-          -- kfay, 5 January 2021
-          sample_id,
-          sampleid.barcode as sample_barcode,
-          collectionid.barcode as collection_barcode,
-          sample.details ->> 'clia_barcode' as scan_id,
-          case
-              when present = 't' then 'positive'
-              when present = 'f' then 'negative'
-              else 'inconclusive'
-          end as test_result,
-          -- On 2022-06-21, we began using the more accurate result timestamp from Samplify for `date_tested` on DOH linelists.
-          -- To prevent changing values on previously processed records, results prior to this change will continue using
-          -- `hcov19_result_release_date`.
-          case
-              when hcov19_result_release_date < '2022-06-21' then hcov19_result_release_date
-              else result_ts
-          end as date_tested,
-          best_available_encounter_date as enrollment_date,
-          collected as collection_date,
-          best_available_site as site_name,
-          best_available_site_type as site_context,
-          sex as sex_new,
-          case
-            when hispanic_or_latino = 't' then 'yes'
-            when hispanic_or_latino = 'f' then 'no'
-          end as ethnicity,
-          case
-            when pregnant = 't' then 'yes'
-            when pregnant = 'f' then 'no'
-          end as pregnant_yesno,
-          symptom_onset as symptom_duration
-      from
-          shipping.hcov19_presence_absence_result_v1
-          join warehouse.sample using (sample_id)
-          join shipping.sample_with_best_available_encounter_data_v1 using (sample_id)
-          join warehouse.identifier sampleid on sampleid.uuid::text = sample.identifier
-          join warehouse.identifier collectionid on collectionid.uuid::text = sample.collection_identifier
-          left join warehouse.encounter using (encounter_id)
-          left join warehouse.individual using (individual_id)
-          left join shipping.fhir_encounter_details_v2 using (encounter_id)
-      -- Add a date cutoff so that we only return results from samples
-      -- collected after the SCAN IRB study launched on 2020-06-10.
-      -- `shipping.return_results_v3` uses this same filter.
-      where collected >= '2020-06-10 00:00:00 US/Pacific'
-      and hcov19_presence_absence_result_v1.details @> '{"assay_type": "Clia"}'
-      and not sample.details @> '{"note": "never-tested"}'::jsonb
-      -- Exclude AFH/Workplace results received before 2022-11-22 (when this project was added to the linelist process),
-      -- and all other results before 2021-05-13 (when linelist automation started).
-      and ((best_available_site in ('ClinicalAdultFamilyHomes','ClinicalWorkplace') and hcov19_result_release_date > '2021-11-21')
-          or (best_available_site not in ('ClinicalAdultFamilyHomes','ClinicalWorkplace') and hcov19_result_release_date > '2021-05-12'))
-      order by sample_id, encounter_id
-)
-;
-
-comment on view shipping.linelist_data_for_wa_doh_v2 is
-  'Custom view of hCoV-19 results for preparing linelists for Washington Department of Health';
-
-revoke all
-  on shipping.linelist_data_for_wa_doh_v2
-  from "return-results-exporter";
-
-grant select
-  on shipping.linelist_data_for_wa_doh_v2
-  to "return-results-exporter";
 
 commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -461,3 +461,6 @@ roles/return-results-exporter/grants [roles/return-results-exporter/grants@2022-
 
 warehouse/site/data [warehouse/site/data@2022-06-10] 2022-06-24T18:35:02Z Todd Seidelmann <seidelma@uw.edu> # Add site data for FH AIRS study
 @2022-06-24 2022-06-24T18:36:36Z Todd Seidelmann <seidelma@uw.edu> # Schema as of 6/24/2022
+
+shipping/views [shipping/views@2022-06-24] 2022-06-27T20:53:45Z Ben Capodanno <capodb@uw.edu> # Add encounter date to PHSKC shipping view.
+@2022-06-27 2022-06-27T20:56:50Z Ben Capodanno <capodb@uw.edu> # Schema as of 27 June 2022

--- a/schema/verify/shipping/views@2022-06-24.sql
+++ b/schema/verify/shipping/views@2022-06-24.sql
@@ -1,0 +1,212 @@
+-- Verify seattleflu/id3c-customizations:shipping/views on pg
+-- requires: seattleflu/schema:shipping/schema
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.reportable_condition_v1');
+
+-- Verify that the view has been dropped
+select 1/(count(*) = 0)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.genomic_sequences_for_augur_build_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.flu_assembly_jobs_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v1');
+
+select 1/(count(*) = 1)::int
+  from pg_matviews
+ where array[schemaname, matviewname]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_questionnaire_responses_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_encounter_details_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v4');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.observation_with_presence_absence_result_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.metadata_for_augur_build_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.sample_with_best_available_encounter_data_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.fhir_encounter_details_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.hcov19_observation_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_return_results_v1');
+
+select 1/(count(*) = 1)::int
+  from pg_matviews
+ where array[schemaname, matviewname]::text[]
+     = pg_catalog.parse_ident('shipping.scan_encounters_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_follow_up_encounters_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_encounters_with_best_available_vaccination_data_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_demographics_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_demographics_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_hcov19_result_counts_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_hcov19_result_counts_v2');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_enrollments_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.scan_redcap_enrollments_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.return_results_v3');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.uw_reopening_enrollment_fhir_encounter_details_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.uw_reopening_encounters_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.uw_reopening_ehs_reporting_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.__uw_priority_queue_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.uw_priority_queue_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.hcov19_presence_absence_result_v1');
+
+select 1/(count(*) = 1)::int
+  from pg_matviews
+ where array[schemaname, matviewname]::text[]
+     = pg_catalog.parse_ident('shipping.__uw_encounters');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+where array[table_schema, table_name]::text[]
+    = pg_catalog.parse_ident('shipping.linelist_data_for_wa_doh_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+where array[table_schema, table_name]::text[]
+    = pg_catalog.parse_ident('shipping.linelist_data_for_wa_doh_v2');
+
+select 1/(count(*) =1)::int
+  from information_schema.views
+where array[table_schema, table_name]::text[]
+    = pg_catalog.parse_ident('shipping.genome_submission_metadata_v1');
+
+rollback;


### PR DESCRIPTION
This change adds the encounter date to the PHSKC shipping view for use in downstream
analysis.