### PR TITLE
Add value to vaccine map

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -533,6 +533,11 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
             "code": "218",
             "display": "COVID-19, mRNA, LNP-S, PF, 10 mcg/0.2 mL dose, tris-sucrose",
         },
+        "covid-19 pfizer mrna tris-sucrose 5-11 yrs old": {
+            "system": "http://hl7.org/fhir/sid/cvx",
+            "code": "218",
+            "display": "COVID-19, mRNA, LNP-S, PF, 10 mcg/0.2 mL dose, tris-sucrose",
+        },
         "covid-19 pfizer mrna tris-sucrose gray cap": {
             "system": "http://hl7.org/fhir/sid/cvx",
             "code": "208",


### PR DESCRIPTION
A new value was received in UW Retros project with a slight variation from a
previously mapped value ("years" vs. "yrs"). Adding the new value to the map.