### PR TITLE
Use timezone aware encountered value for age calc in PHSKC parsing

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -499,7 +499,7 @@ def parse_phskc(phskc_filename: str, phskc_specimen_manifest_filename: str, geoc
     clinical_records['age'] = clinical_records.apply(
         lambda row: age_ceiling(
                 relativedelta(
-                    row['collect_ts'],
+                    row['encountered'],
                     row['birth_date']
                 ).years
             ), axis=1


### PR DESCRIPTION
The `encountered` and `birth_date` values were recently updated to be timezone-aware, so the age
calculation should use those two values rather than `birth_date` and `collect_ts` (which is timezone-naive).