### PR TITLE
Check Existence of Location Before Accessing its Identifier

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -653,8 +653,10 @@ def encode_addresses(db: DatabaseSession, row: pd.Series) -> pd.Series:
     address, encodes that data into census tract information and hashes
     the address.
     """
-    if row['lat'] and row['lng']:
-        row['census_tract'] = location_lookup(db, (row['lat'], row['lng']), 'tract')[1]
+    location = location_lookup(db, (row.get('lat'), row.get('lng')), 'tract')
+
+    if location:
+        row['census_tract'] = location.identifier
     else:
         row['census_tract'] = None
 


### PR DESCRIPTION
Previously the `encode_addresses` function attempted to directly access the location identifier, however this location has the potential of being a null value. We should first make sure the location exists before accessing its identifier.

Although I'm not sure if this fixes the root cause of the PHSKC parsing failure from 7/29, I think it is still an improvement to the code logic.