### PR TITLE
AIRS ETL updates

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap.py
@@ -544,6 +544,7 @@ def map_vaccine(vaccine_response: str) -> Optional[bool]:
         'no': False,
         '0': False,
         'dont_know': None,
+        'unknown': None,
         '': None
     }
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_fh_airs.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_fh_airs.py
@@ -142,7 +142,7 @@ def redcap_det_fh_airs(*, db: DatabaseSession, cache: TTLCache, det: dict,
         return None
 
     patient_entry, patient_reference = airs_build_patient(enrollment)
-    
+
     if not patient_entry:
         LOG.warning(f"Skipping record {enrollment.get('subject_id')} with insufficient information to construct patient")
         return None
@@ -177,15 +177,6 @@ def redcap_det_fh_airs(*, db: DatabaseSession, cache: TTLCache, det: dict,
             f"{redcap_record_instance.get('subject_id')} because the event is not one "
             "that we process")
             continue
-
-        if event_type == EventType.ENCOUNTER:
-            if not is_complete('weekly', redcap_record_instance):
-                LOG.debug("Skipping record id: "
-                    f"{redcap_record_instance.get('subject_id')}, "
-                    " encounter: "
-                    f"{redcap_record_instance.get('event_name')}, "
-                    ": insufficient information to construct encounter")
-                continue
 
         site_reference = create_site_reference(
             location = None,
@@ -269,7 +260,7 @@ def redcap_det_fh_airs(*, db: DatabaseSession, cache: TTLCache, det: dict,
             redcap_record_instance,
             patient_reference,
             initial_encounter_reference,
-            birthdate, 
+            birthdate,
             parse_date_from_string(
                 initial_encounter_entry['resource']['period']['start'])
             )
@@ -334,7 +325,7 @@ def airs_get_encounter_date(record: REDCapRecord, event_type: EventType) -> Opti
         encounter_date = record.get('enr_date_complete') and \
             datetime.strptime(record.get('enr_date_complete'), '%Y-%m-%d').strftime('%Y-%m-%d')
     else:
-        # We should never get here, but we should also never have an 
+        # We should never get here, but we should also never have an
         #  if/elif without an else
         LOG.error(f"Invalid date: {record.event_name!r} for record "
                   f"{record.get('subject_id')} contains event_type {event_type}, "
@@ -514,7 +505,7 @@ def airs_create_weekly_questionnaire_response(record: REDCapRecord, patient_refe
         'wk_diarrhea',
         'wk_nausea',
         'wk_stomach_pain',
-        'wk_vomiting',    
+        'wk_vomiting',
     ]
 
     boolean_questions = [

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_fh_airs.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_fh_airs.py
@@ -55,7 +55,7 @@ class SwabKitInstrumentSet(Enum):
     FIRST = 1
     SECOND = 2
 
-REVISION = 1
+REVISION = 2
 
 INTERNAL_SYSTEM = "https://seattleflu.org"
 ENROLLMENT_EVENT_NAME = "screening_and_enro_arm_1"
@@ -658,6 +658,7 @@ def airs_create_weekly_questionnaire_response(record: REDCapRecord, patient_refe
         vacc_other_field = 'wk_vacc_other_4'
 
     # map vaccine manufacturer values in weekly instrument to match those used in screening instrument
+    # plus moderna and pfizer bivalent which were added later to the weekly instrument
     vaccine_manufacturer_map = {
         '1':    'moderna',
         '2':    'novovax',
@@ -665,6 +666,8 @@ def airs_create_weekly_questionnaire_response(record: REDCapRecord, patient_refe
         '4':    'pfizer',
         '5':    'other',
         '6':    'dont_know',
+        '7':    'moderna_bivalent',
+        '8':    'pfizer_bivalent',
     }
     # Replace vaccine manufacturer integers with str values to match screening instrument
     if vacc_name_field and vacc_other_field:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_fh_airs.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_fh_airs.py
@@ -11,7 +11,7 @@ from id3c.cli.redcap import is_complete, Record as REDCapRecord
 from id3c.db import find_identifier
 from seattleflu.id3c.cli.command import age_ceiling
 from .redcap import *
-from .redcap_map import *
+from .redcap_map import UnknownSexError
 
 LOG = logging.getLogger(__name__)
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
@@ -36,17 +36,16 @@ def map_vaccine(vaccine_response: str) -> Optional[bool]:
     (https://www.hl7.org/fhir/valueset-immunization-status.html)
     """
     vaccine_map = {
-        'yes': True,
-        'no': False,
-        'do not know': None,
-        'unknown': None,
+        'Yes': True,
+        'No': False,
+        'Do not know': None,
         '': None,
     }
 
-    if vaccine_response.lower().strip() not in vaccine_map:
+    if vaccine_response not in vaccine_map:
         raise UnknownVaccineResponseError(f"Unknown vaccine response «{vaccine_response}»")
 
-    return vaccine_map[vaccine_response.lower().strip()]
+    return vaccine_map[vaccine_response]
 
 
 def map_symptom(symptom_name: str) -> Optional[str]:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
@@ -39,6 +39,7 @@ def map_vaccine(vaccine_response: str) -> Optional[bool]:
         'yes': True,
         'no': False,
         'do not know': None,
+        'unknown': None,
         '': None,
     }
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
@@ -36,16 +36,16 @@ def map_vaccine(vaccine_response: str) -> Optional[bool]:
     (https://www.hl7.org/fhir/valueset-immunization-status.html)
     """
     vaccine_map = {
-        'Yes': True,
-        'No': False,
-        'Do not know': None,
+        'yes': True,
+        'no': False,
+        'do not know': None,
         '': None,
     }
 
-    if vaccine_response not in vaccine_map:
+    if vaccine_response.lower().strip() not in vaccine_map:
         raise UnknownVaccineResponseError(f"Unknown vaccine response «{vaccine_response}»")
 
-    return vaccine_map[vaccine_response]
+    return vaccine_map[vaccine_response.lower().strip()]
 
 
 def map_symptom(symptom_name: str) -> Optional[str]:


### PR DESCRIPTION
Rework of AIRS ETL based on a full review of the REDCap project design and discussions with the Study Team.

These changes include:
- mapping integer values to strings where needed
- correctly associating REDCap instruments with encounter type (weekly instrument as initial encounter; symptoms instrument as follow-up encounter)
- correctly processing two sets of swab kit instruments to associate each sample with encounter which triggered the kit
- mapping race to match standard ID3C coding
- ingesting detailed symptoms as Questionnaire Responses
- generalizing detailed symptoms to standard ID3C coding and ingesting as Conditions
- correctly ingesting vaccination responses from enrollment and weekly instruments
- bumped revision number