### PR TITLE
Add New `Freestanding` Encounter Class to UW Retros Encounter Map

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/clinical_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical_retrospectives.py
@@ -114,6 +114,7 @@ def create_encounter_class(record: dict) -> dict:
         "field" : "FLD",
         "surgery overnight stay" : "IMP",
         "surgery admit": "IMP",
+        "freestanding": "IMP",
     }
 
     standardized_encounter_class = standardize_whitespace(encounter_class.lower())


### PR DESCRIPTION
The UW Retros ETL got back on track on 2022.10.26, and since then over 1000 records were updated in the progress. In the updates, a new encounter class (`freestanding`) was added. This change adds that class to the encounter mapper, mapping it to IMP since it seemed the most appropriate.

Tested by generating DETs for records updated in the retros project after 10-25. Freestanding was the only new value I found after running through those DETs.

