### PR TITLE
Mark deprecated ETL modules

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/longitudinal.py
+++ b/lib/seattleflu/id3c/cli/command/etl/longitudinal.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process longitudinal documents into the relational warehouse.
 """
 import click

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_scan.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process DETs for the greater Seattle Coronavirus Assessment Network (SCAN) REDCap projects.
 """
 import re

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process REDCap DET documents into the relational warehouse.
 
 Contains some hard-coded logic for which project ID correlates to which project


### PR DESCRIPTION
Marking deprecated ETLs for projects that have ended and cron jobs disabled.