### PR TITLE
Add new value to race map

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -118,6 +118,7 @@ def race(races: Optional[Any]) -> list:
         "other race": "other",
         "multiple races": "other",
         "more than one race": "other",
+        "another race": "other",
 
         "refused": None,
         "patient refused": None,


### PR DESCRIPTION
Adding newly encountered value 'another race' from UW retrospective data to Redcap DET ETL race mapping function.