### PR TITLE
Add another new value to race map

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -91,6 +91,7 @@ def race(races: Optional[Any]) -> list:
         "native_american": "americanIndianOrAlaskaNative",
         "indian": "americanIndianOrAlaskaNative",
         "native": "americanIndianOrAlaskaNative",
+        "alaska native": "americanIndianOrAlaskaNative",
 
         "asian": "asian",
 


### PR DESCRIPTION
Adding newly encountered value 'alaska native' from UW retrospective data to Redcap DET ETL race mapping function.