### PR TITLE
Force PHSKC Barcode and CID Comparisons to be Uppercase

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -612,6 +612,14 @@ def add_phskc_manifest_data(df: pd.DataFrame, manifest_filename: str) -> pd.Data
         LOG.warning(f'Dropping {duplicated_cids.sum()} rows with duplicated CID(s) from PHSKC manifest data')
         manifest_data = manifest_data[~duplicated_cids]
 
+    # ensure all of our comparison columns are uppercase so barcodes can be compared
+    df[['main_cid', 'all_cids', 'phskc_barcode']] = df[['main_cid', 'all_cids', 'phskc_barcode']].apply(
+        lambda col: col.str.upper().str.strip()
+    )
+    manifest_data[['merge_col', 'barcode']] = manifest_data[['merge_col', 'barcode']].apply(
+        lambda col: col.str.upper().str.strip()
+    )
+
     # Since we get two CIDs with each PHSKC record and they aren't guaranteed
     # to be the same, we should try both if they are not the same (note: they
     # are almost always the same). If main_cid is in the AQ sheet, we will give


### PR DESCRIPTION
Original implementation of the PHSKC ETL assumed that barcodes and CID values would always be provided as uppercase. This turned out to not be the case, and this caused many samples from October 2022 to not be linked to the associated metadata. This change forces all columns which will be compared for metadata associations to be uppercase.