### PR TITLE
Add `Native Hawaiian` Race to Clinical ETL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - ubuntu-18.04
         python:
           - 3.6
           - 3.7

--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -101,6 +101,7 @@ def race(races: Optional[Any]) -> list:
         "black or african-american": "blackOrAfricanAmerican",
 
         "nativehawaiian": "nativeHawaiian",
+        "native hawaiian": "nativeHawaiian",
         "native hawaiian and other pacific islander" : "nativeHawaiian",
         "native hawaiian or other pacific islander": "nativeHawaiian",
         "native hawaiian or other pacific islande": "nativeHawaiian",


### PR DESCRIPTION
Adds a new race mapping, `native hawaiian` to our clinical ETL. This race mapping was present before without a space, but a new value parsed out by our ETL includes a space.