### PR TITLE
Drop python 3.6 and 3.7 from CI checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,6 @@ jobs:
         os:
           - ubuntu-20.04
         python:
-          - 3.6
-          - 3.7
           - 3.8
           - 3.9
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Prod currently uses python 3.9, and versions 3.6 and 3.7 are causing compatibility issues. Also making this change in ID3C.