### PR TITLE
Update sample table constraint to handle null values

### DIFF
--- a/schema/deploy/warehouse/sample/cascadia-rls-constraint.sql
+++ b/schema/deploy/warehouse/sample/cascadia-rls-constraint.sql
@@ -4,11 +4,14 @@
 begin;
 
 alter table warehouse.sample
+    drop constraint if exists cascadia_rls;
+
+alter table warehouse.sample
     add constraint cascadia_rls check(
         not (details ? 'sample_origin') or
         (
-            (lower(details ->> 'sample_origin') != 'cascadia' and access_role::text != 'cascadia'::text) or
-            (lower(details ->> 'sample_origin') = 'cascadia' and access_role::text = 'cascadia'::text)
+            (lower(details ->> 'sample_origin') != 'cascadia' and coalesce(access_role::text,'') != 'cascadia'::text) or
+            (lower(details ->> 'sample_origin') = 'cascadia' and coalesce(access_role::text,'') = 'cascadia'::text)
         )
     );
 

--- a/schema/deploy/warehouse/sample/cascadia-rls-constraint@2023-08-18.sql
+++ b/schema/deploy/warehouse/sample/cascadia-rls-constraint@2023-08-18.sql
@@ -4,9 +4,6 @@
 begin;
 
 alter table warehouse.sample
-    drop constraint if exists cascadia_rls;
-
-alter table warehouse.sample
     add constraint cascadia_rls check(
         not (details ? 'sample_origin') or
         (

--- a/schema/revert/warehouse/sample/cascadia-rls-constraint@2023-08-18.sql
+++ b/schema/revert/warehouse/sample/cascadia-rls-constraint@2023-08-18.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/id3c-customizations:warehouse/sample/cascadia-rls-constraint from pg
+
+begin;
+
+alter table warehouse.sample
+    drop constraint cascadia_rls;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -499,3 +499,5 @@ warehouse/consensus-genome/check-consensus-genome-rls 2023-08-16T22:15:21Z Dave 
 warehouse/sequence-read-set/check-sequence-read-set-rls 2023-08-16T23:13:21Z Dave Reinhart <davidrr@uw.edu> # Add trigger to ensure row-level security is set on sequence read set records.
 warehouse/genomic-sequence/check-genomic-sequence-rls 2023-08-16T23:18:42Z Dave Reinhart <davidrr@uw.edu> # Add trigger to ensure row-level security is set on genomic sequence records.
 @2023-08-18 2023-08-18T15:38:15Z Dave Reinhart <davidrr@uw.edu> # Schema as of 18 August 2023
+warehouse/sample/cascadia-rls-constraint [warehouse/sample/cascadia-rls-constraint@2023-08-18] 2023-09-08T18:56:42Z Dave Reinhart <davidrr@uw.edu> # Modify constraint for row-level security to handle nulls
+@2023-09-08 2023-09-08T19:26:10Z Dave Reinhart <davidrr@uw.edu> # Schema as of 08 Sept 2023

--- a/schema/verify/warehouse/sample/cascadia-rls-constraint@2023-08-18.sql
+++ b/schema/verify/warehouse/sample/cascadia-rls-constraint@2023-08-18.sql
@@ -1,0 +1,30 @@
+-- Verify seattleflu/id3c-customizations:warehouse/sample/cascadia-rls-constraint on pg
+
+begin;
+
+do $$
+declare
+    sample_number int;
+begin
+    insert into warehouse.sample (identifier, details, access_role)
+        values (uuid_generate_v4(), '{"sample_origin": "cascadia"}'::jsonb, 'cascadia') returning sample_id into sample_number;
+
+    set local role reporter;
+
+    assert 0 = (
+        select count(*)
+        from warehouse.sample
+        where sample_id = sample_number
+    );
+
+    set local role 'reporter-cascadia';
+
+    assert 1 = (
+        select count(*)
+        from warehouse.sample
+        where sample_id = sample_number
+    );
+end
+$$;
+
+rollback;


### PR DESCRIPTION
The constraint on warehouse.sample table to ensure cascadia row-level security is being used on relevant records was not handling null values correctly. Adding coalesce to ensure constraint logic evaluates to false, rather than null, so that constraint is applied correctly when `access_role` is null.