### PR TITLE
Add Pfizer fall 2023 12+ covid booster to redcap-det uw-retros

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -381,6 +381,11 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
             "code": "301",
             "display": "COVID-19, mRNA, LNP-S, bivalent booster, PF, 10 mcg/0.2 mL dose"
         },
+        309: {
+            "system": "http://hl7.org/fhir/sid/cvx",
+            "code": "309",
+            "display": "COVID-19, mRNA, LNP-S, PF, tris-sucrose, 30 mcg/0.3 mL"            
+        },
         511: {
             "system": "http://hl7.org/fhir/sid/cvx",
             "code": "511",
@@ -421,6 +426,7 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
         "covid-19 pfizer mrna bivalent 12 yrs and older":                   300,
         "covid-19 pfizer mrna bivalent booster 5-11 yrs old":               301,
         "covid-19 pfizer mrna bivalent 5-11 yrs old":                       301,
+        "covid-19 pfizer mrna 2023-24 12 yrs and older (comirnaty)":        309,
         "covid-19 sinovac inactivated, non-us (coronavac)":                 511,
         "": None
     }


### PR DESCRIPTION
Note that the new value in REDCap is "covid-19 pfizer mrna 2023-24 12 yrs and older (comirnaty)" and the CVX code assigned in this update is 309, which maps to the CDC description "Pfizer Fall 2023 12 years and older," without the name Comirnaty. However, the downloadable table [here](https://www.cdc.gov/vaccines/programs/iis/downloads/Fall-2023-COVID-19-Vaccine-Codes-Crosswalk-20230906.xlsx) confirms that 309 is the correct code for this vaccine. 