### PR TITLE
Clinical ETL: assign encounter_status as finished for records missing encounter_status field

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -464,7 +464,8 @@ def create_immunization_kp2023(record: dict, patient_reference: dict) -> list:
             vaccine_code = cvx_codes[213] # covid vaccines are not specified in this study, so assign code for unspecified covid-19 vaccine
 
         if vaccine_code:
-            immunization_identifier_hash = generate_hash(f"{record['mrn']}{vaccine_code['code']}{immunization_date}".lower())
+            # create hash from collection_id, which is hashed individual id, plus vaccine code and date administered
+            immunization_identifier_hash = generate_hash(f"{record['collection_id']}{vaccine_code['code']}{immunization_date}".lower())
             immunization_identifier = create_identifier(f"{SFS}/immunization", immunization_identifier_hash)
 
             immunization_resource = create_immunization_resource(

--- a/lib/seattleflu/id3c/cli/command/etl/clinical_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical_retrospectives.py
@@ -138,7 +138,7 @@ def create_encounter_status(record: dict) -> str:
     This attribute is required by FHIR for an Encounter resource.
     (https://www.hl7.org/fhir/encounter-definitions.html#Encounter.status)
     """
-    status = record['encounter_status']
+    status = record.get('encounter_status', None)
     if not status:
         return 'finished'
 


### PR DESCRIPTION
Previously, encounter_status was assigned as finished for records missing an encounter_status value, but an error was thrown for records missing the encounter_status field entirely. Now, encounter_status is assigned as finished if the value or field is missing.