### PR TITLE
Restore Swab and Send and Kiosk ETLs

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -290,5 +290,8 @@ class UnknownEthnicityError(ValueError):
 
 from . import (
     clinical,
+    redcap_det_swab_n_send,
+    redcap_det_swab_and_home_flu,
+    redcap_det_asymptomatic_swab_n_send,
     redcap_det_uw_retrospectives,
 )

--- a/lib/seattleflu/id3c/cli/command/etl/__init__.py
+++ b/lib/seattleflu/id3c/cli/command/etl/__init__.py
@@ -293,5 +293,6 @@ from . import (
     redcap_det_swab_n_send,
     redcap_det_swab_and_home_flu,
     redcap_det_asymptomatic_swab_n_send,
+    redcap_det_kiosk,
     redcap_det_uw_retrospectives,
 )

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
@@ -359,7 +359,7 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'income_levels',
         'insurance',
         'smoke',
-        'chronic_illness'
+        'chronic_illness',
     ]
 
     question_categories = {
@@ -432,7 +432,7 @@ def questionnaire_item(record: dict, question_id: str, response_type: str) -> Op
     def cast_to_boolean(string: str) -> Optional[bool]:
         if string == 'Yes':
             return True
-        elif re.match(r'^No($|,[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma and text
+        elif re.match(r'^No($|(,|\s-)[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma or space+dash followed by text
             return False
         return None
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
@@ -1,0 +1,498 @@
+"""
+Deprecated, data collection ended
+
+Process REDCap DETs that are specific to the
+Seattle Flu Study - Swab and Send - Asymptomatic Enrollments
+"""
+import re
+import click
+import json
+import logging
+from uuid import uuid4
+from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Union, Tuple
+from datetime import datetime
+from cachetools import TTLCache
+from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
+from id3c.cli.command.etl import redcap_det
+from id3c.cli.command.geocode import get_geocoded_address
+from id3c.cli.command.location import location_lookup
+from seattleflu.id3c.cli.command import age_ceiling
+from .redcap_map import *
+from .fhir import *
+from . import race, first_record_instance, required_instruments
+
+
+LOG = logging.getLogger(__name__)
+
+
+REVISION = 2
+
+REDCAP_URL = 'https://redcap.iths.org/'
+INTERNAL_SYSTEM = "https://seattleflu.org"
+UW_CENSUS_TRACT = '53033005302'
+
+PROJECT_ID = 20190
+REQUIRED_INSTRUMENTS = [
+    'consent_form',
+    'shipping_information',
+    'back_end_mail_scans',
+    'day_0_enrollment_questionnaire',
+    'post_collection_data_entry_qc'
+]
+
+
+@redcap_det.command_for_project(
+    "asymptomatic-swab-n-send",
+    redcap_url = REDCAP_URL,
+    project_id = PROJECT_ID,
+    revision = REVISION,
+    help = __doc__)
+
+@first_record_instance
+@required_instruments(REQUIRED_INSTRUMENTS)
+def redcap_det_asymptomatic_swab_n_send(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
+    location_resource_entries = locations(db, cache, redcap_record)
+    patient_entry, patient_reference = create_patient(redcap_record)
+
+    if not patient_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct patient")
+        return None
+
+    encounter_entry, encounter_reference = create_encounter(redcap_record, patient_reference, location_resource_entries)
+
+    if not encounter_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct an encounter")
+        return None
+
+    questionnaire_entry = create_questionnaire_response(redcap_record, patient_reference, encounter_reference)
+    specimen_entry, specimen_reference = create_specimen(redcap_record, patient_reference)
+
+    if not specimen_entry:
+        LOG.warning("Skipping enrollment with insufficent information to construct a specimen")
+        return None
+
+    specimen_observation_entry = create_specimen_observation_entry(specimen_reference, patient_reference, encounter_reference)
+
+    resource_entries = [
+        patient_entry,
+        encounter_entry,
+        questionnaire_entry,
+        specimen_entry,
+        *location_resource_entries,
+        specimen_observation_entry
+    ]
+
+    return create_bundle_resource(
+        bundle_id = str(uuid4()),
+        timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}",
+        entries = list(filter(None, resource_entries))
+    )
+
+
+def locations(db: DatabaseSession, cache: TTLCache, record: dict) -> list:
+    """ Creates a list of Location resource entries from a REDCap record. """
+    housing_type = 'residence'
+
+    address = {
+        'street': record['home_street'],
+        'secondary': None,
+        'city': record['homecity_other'],
+        'state': record['home_state'],
+        'zipcode': record['home_zipcode_2'],
+    }
+
+    lat, lng, canonicalized_address = get_geocoded_address(address, cache)
+    if not canonicalized_address:
+        return []  # TODO
+
+    tract_location = residence_census_tract(db, (lat, lng), housing_type)
+    # TODO what if tract_location is null?
+    tract_full_url = generate_full_url_uuid()
+    tract_entry = create_resource_entry(tract_location, tract_full_url)
+
+    address_hash = generate_hash(canonicalized_address)
+    address_location = create_location(
+        f"{INTERNAL_SYSTEM}/location/address",
+        address_hash,
+        housing_type,
+        tract_full_url
+    )
+    address_entry = create_resource_entry(address_location, generate_full_url_uuid())
+
+    return [tract_entry, address_entry]
+
+
+def create_location(system: str, value: str, location_type: str, parent: str=None) -> dict:
+    """ Returns a FHIR Location resource. """
+    location_type_system = "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+    location_type_map = {
+        "residence": "PTRES",
+        "school": "SCHOOL",
+        "work": "WORK",
+        "site": "HUSCS",
+        "lodging": "PTLDG",
+    }
+
+    location_type_cc = create_codeable_concept(location_type_system,
+                                            location_type_map[location_type])
+    location_identifier = create_identifier(system, value)
+    part_of = None
+    if parent:
+        part_of = create_reference(reference_type="Location", reference=parent)
+
+    return create_location_resource([location_type_cc], [location_identifier], part_of)
+
+
+def create_patient(record: dict) -> tuple:
+    """ Returns a FHIR Patient resource entry and reference. """
+    gender = map_sex(record["sex"])
+
+    patient_id = generate_patient_hash(
+        names       = (record['participant_first_name'], record['participant_last_name']),
+        gender      = gender,
+        birth_date  = record['birthday'],
+        postal_code = record['home_zipcode_2'])
+
+    if not patient_id:
+        # Some piece of information was missing, so we couldn't generate a
+        # hash.  Fallback to treating this individual as always unique by using
+        # the REDCap record id.
+        patient_id = generate_hash(f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}")
+
+    LOG.debug(f"Generated individual identifier {patient_id}")
+
+    patient_identifier = create_identifier(f"{INTERNAL_SYSTEM}/individual", patient_id)
+    patient_resource = create_patient_resource([patient_identifier], gender)
+
+    return create_entry_and_reference(patient_resource, "Patient")
+
+
+def create_encounter(record: REDCapRecord, patient_reference: dict, locations: list) -> tuple:
+    """ Returns a FHIR Encounter resource entry and reference """
+
+    def grab_symptom_keys(key: str) -> Optional[Match[str]]:
+        if record[key] != '':
+            return re.match('symptoms___[0-9]{1,3}$', key)
+        else:
+            return None
+
+    def build_conditions_list(symptom_key: str) -> dict:
+        return create_resource_condition(record[symptom_key], patient_reference)
+
+    def build_diagnosis_list(symptom_key: str) -> Optional[dict]:
+        mapped_symptom = map_symptom(record[symptom_key])
+        if not mapped_symptom:
+            return None
+
+        return { "condition": { "reference": f"#{mapped_symptom}" } }
+
+    def build_locations_list(location: dict) -> dict:
+        return {
+            "location": create_reference(
+                reference_type = "Location",
+                reference = location["fullUrl"]
+            )
+        }
+
+    def non_tract_locations(resource: dict):
+        return bool(resource) \
+            and resource['resource']['identifier'][0]['system'] != f"{INTERNAL_SYSTEM}/location/tract"
+
+    symptom_keys = list(filter(grab_symptom_keys, record))
+    contained = list(filter(None, map(build_conditions_list, symptom_keys)))
+    diagnosis = list(filter(None, map(build_diagnosis_list, symptom_keys)))
+    encounter_identifier = create_identifier(
+        system = f"{INTERNAL_SYSTEM}/encounter",
+        value = f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}"
+    )
+    encounter_class_coding = create_coding(
+        system = "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        code = "HH"
+    )
+
+    encounter_date = record['enrollment_date']
+    if not encounter_date:
+        return None, None
+
+    non_tracts = list(filter(non_tract_locations, locations))
+    non_tract_references = list(map(build_locations_list, non_tracts))
+    # Site for all swab 'n send Encounters is 'swabNSend'
+    site_reference = {
+        "location": create_reference(
+            reference_type = "Location",
+            identifier = create_identifier(f"{INTERNAL_SYSTEM}/site", 'swabNSend')
+        )
+    }
+    non_tract_references.append(site_reference)
+
+    encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
+        encounter_identifier = [encounter_identifier],
+        encounter_class = encounter_class_coding,
+        encounter_date = encounter_date,
+        patient_reference = patient_reference,
+        location_references = non_tract_references,
+        diagnosis = diagnosis,
+        contained = contained
+    )
+
+    return create_entry_and_reference(encounter_resource, "Encounter")
+
+
+def create_resource_condition(symptom_name: str, patient_reference: dict) -> Optional[dict]:
+    """ Returns a FHIR Condition resource. """
+    mapped_symptom_name = map_symptom(symptom_name)
+    if not mapped_symptom_name:
+        return None
+
+    # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
+    # 3.8.  Until then, there's no reasonable way to type this data structure
+    # better than Any.
+    #   -trs, 24 Oct 2019
+    condition: Any = {
+        "resourceType": "Condition",
+        "id": mapped_symptom_name,
+        "code": {
+            "coding": [
+                {
+                    "system": f"{INTERNAL_SYSTEM}/symptom",
+                    "code": mapped_symptom_name
+                }
+            ]
+        },
+        "subject": patient_reference
+    }
+
+    return condition
+
+
+def create_specimen(record: dict, patient_reference: dict) -> tuple:
+    """ Returns a FHIR Specimen resource entry and reference """
+    def specimen_barcode(record: Any) -> str:
+        """
+        Given a REDCap *record*, returns the barcode or corrected barcode if it
+        exists.
+        """
+        barcode = record['return_utm_barcode'] or record['pre_scan_barcode']
+
+        if not barcode:
+            barcode = record['utm_tube_barcode']
+            reentered_barcode = record['reenter_barcode']
+
+            if record['check_barcodes'] == "No":
+                #TODO: Figure out why 'corrected_barcode' doesn't always exist?
+                barcode = record.get('corrected_barcode')
+
+        return barcode
+
+    barcode = specimen_barcode(record)
+    if not barcode:
+        LOG.warning("Could not create Specimen Resource due to lack of barcode.")
+        return None, None
+
+    specimen_identifier = create_identifier(
+        system = f"{INTERNAL_SYSTEM}/sample",
+        value = barcode
+    )
+
+    # YYYY-MM-DD in REDCap
+    collected_time = record['collection_date'] or None
+
+    # YYYY-MM-DD
+    received_time = record['samp_process_date'] or None
+
+    specimen_type = 'NSECR'  # Nasal swab.  TODO we may want shared mapping function
+    specimen_resource = create_specimen_resource(
+        [specimen_identifier], patient_reference, specimen_type, received_time, collected_time
+    )
+
+    return create_entry_and_reference(specimen_resource, "Specimen")
+
+
+def create_questionnaire_response(record: dict, patient_reference: dict,
+    encounter_reference: dict) -> Optional[dict]:
+    """ Returns a FHIR Questionnaire Response resource entry. """
+
+    def create_custom_coding_key(coded_question: str, record: dict) -> Optional[List]:
+        """
+        Handles the 'race' edge case by combining "select all that apply"-type
+        responses into one list.
+        """
+        coded_keys = list(filter(lambda r: grab_coding_keys(coded_question, r), record))
+        coded_names = list(map(lambda k: record[k], coded_keys))
+
+        if coded_question == 'race':
+            return race(coded_names)
+
+        return None
+
+    def grab_coding_keys(coded_question: str, key: str) -> Optional[Match[str]]:
+        if record[key] == '':
+            return None
+
+        return re.match(f'{coded_question}___[0-9]+$', key)
+
+
+    def build_questionnaire_items(question: str) -> Optional[dict]:
+        return questionnaire_item(record, question, category)
+
+    coding_questions = [
+        'race'
+    ]
+
+    boolean_questions = [
+        'hispanic',
+        'travel_states',
+        'travel_countries',
+    ]
+
+    integer_questions = [
+        'age',
+        'age_months',
+    ]
+
+    string_questions = [
+        'education',
+        'samp_process_date',
+    ]
+
+    question_categories = {
+        'valueCoding': coding_questions,
+        'valueBoolean': boolean_questions,
+        'valueInteger': integer_questions,
+        'valueString': string_questions,
+    }
+
+    # Do some pre-processing
+    record['race'] = create_custom_coding_key('race', record)
+    record['age'] = age_ceiling(int(record['age']))
+    record['age_months'] = age_ceiling(int(record['age_months']) / 12) * 12
+
+    items: List[dict] = []
+    for category in question_categories:
+        category_items = list(map(build_questionnaire_items, question_categories[category]))
+        for item in category_items:
+            if item:
+                items.append(item)
+
+    # Handle edge cases
+    vaccine_item = vaccine(record)
+    if vaccine_item:
+        items.append(vaccine_item)
+
+    if items:
+        questionnaire_reseponse_resource = create_questionnaire_response_resource(
+            patient_reference, encounter_reference, items
+        )
+        full_url = generate_full_url_uuid()
+        return create_resource_entry(questionnaire_reseponse_resource, full_url)
+
+    return None
+
+
+def questionnaire_item(record: dict, question_id: str, response_type: str) -> Optional[dict]:
+    """ Creates a QuestionnaireResponse internal item from a REDCap record. """
+    response = record[question_id]
+
+    def cast_to_coding(string: str):
+        """ Currently the only QuestionnaireItem we code is race. """
+        return create_coding(
+            system = f"{INTERNAL_SYSTEM}/race",
+            code = string,
+        )
+
+    def cast_to_string(string: str) -> Optional[str]:
+        if string != '':
+            return string
+        return None
+
+    def cast_to_integer(string: str) -> Optional[int]:
+        try:
+            return int(string)
+        except ValueError:
+            return None
+
+    def cast_to_boolean(string: str) -> Optional[bool]:
+        if string == 'Yes':
+            return True
+        elif re.match(r'^No($|,[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma and text
+            return False
+        return None
+
+    def build_response_answers(response: Union[str, List]) -> List:
+        answers = []
+        if not isinstance(response, list):
+            response = [response]
+
+        for item in response:
+            type_casted_item = casting_functions[response_type](item)
+
+            # cast_to_boolean can return False, so must be `is not None`
+            if type_casted_item is not None:
+                answers.append({ response_type: type_casted_item })
+
+        return answers
+
+    casting_functions: Mapping[str, Callable[[str], Any]] = {
+        'valueCoding': cast_to_coding,
+        'valueInteger': cast_to_integer,
+        'valueBoolean': cast_to_boolean,
+        'valueString': cast_to_string,
+    }
+
+    answers = build_response_answers(response)
+    if answers:
+        return create_questionnaire_response_item(question_id, answers)
+
+    return None
+
+
+def vaccine(record: Any) -> Optional[dict]:
+    """
+    For a given *record*, return a questionnaire response item with the vaccine
+    response(s) encoded.
+    """
+    vaccine_status = map_vaccine(record["vaccine"])
+    if vaccine_status is None:
+        return None
+
+    answers: List[Dict[str, Any]] = [{ 'valueBoolean': vaccine_status }]
+
+    date = vaccine_date(record)
+    if vaccine_status and date:
+        answers.append({ 'valueDate': date })
+
+    return create_questionnaire_response_item('vaccine', answers)
+
+
+def vaccine_date(record: dict) -> Optional[str]:
+    """ Converts a vaccination date to 'YYYY' or 'YYYY-MM' format. """
+    year = record['vaccine_year']
+    month = record['vaccine_1']
+
+    if year == '' or year == 'Do not know':
+        return None
+
+    if month == 'Do not know':
+        return datetime.strptime(year, '%Y').strftime('%Y')
+
+    return datetime.strptime(f'{month} {year}', '%B %Y').strftime('%Y-%m')
+
+
+def residence_census_tract(db: DatabaseSession, lat_lng: Tuple[float, float],
+    housing_type: str) -> Optional[dict]:
+    """
+    Creates a new Location Resource for the census tract containing the given
+    *lat_lng* coordintes and associates it with the given *housing_type*.
+    """
+    location = location_lookup(db, lat_lng, 'tract')
+
+    if location and location.identifier:
+        return create_location(
+            f"{INTERNAL_SYSTEM}/location/tract", location.identifier, housing_type
+        )
+    else:
+        LOG.warning("No census tract found for given location.")
+        return None

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_asymptomatic_swab_n_send.py
@@ -343,7 +343,7 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
     ]
 
     boolean_questions = [
-        'hispanic',
+        'ethnicity',
         'travel_states',
         'travel_countries',
     ]
@@ -381,7 +381,8 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
     record['race'] = create_custom_coding_key('race', record)
     record['age'] = age_ceiling(int(record['age']))
     record['age_months'] = age_ceiling(int(record['age_months']) / 12) * 12
-
+    record['ethnicity'] = record['hispanic']
+    
     for field in checkbox_fields:
         record[field] = combine_legacy_checkbox_answers(record, field)
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_kiosk.py
@@ -1,0 +1,1595 @@
+"""
+Deprecated, data collection ended
+
+Process REDCap DETs that are specific to the Kiosk Enrollment Project.
+"""
+import logging
+import re
+from uuid import uuid4
+from datetime import datetime
+from typing import Any, List, Optional, Tuple, Dict
+from cachetools import TTLCache
+from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
+from id3c.cli.redcap import Project as REDCapProject
+from id3c.cli.command.de_identify import generate_hash
+from id3c.cli.command.geocode import get_geocoded_address
+from id3c.cli.command.location import location_lookup
+from id3c.cli.command.etl import redcap_det, UnknownSiteError
+from seattleflu.id3c.cli.command import age_ceiling
+from .redcap_map import *
+from .fhir import *
+from . import race, first_record_instance, required_instruments
+
+LOG = logging.getLogger(__name__)
+
+SFS = 'https://seattleflu.org'
+
+REDCAP_URL = 'https://redcap.iths.org/'
+
+PROJECT_ID = 16691
+
+REQUIRED_INSTRUMENTS = [
+    'screening',
+    'main_consent_form',
+    'enrollment_questionnaire'
+]
+
+# This revision number is stored in the processing_log of each REDCap DET
+# record when the REDCap DET record is successfully processed by this ETL
+# routine. The routine finds new-to-it records to process by looking for
+# REDCap DET records lacking this revision number in their log.  If a
+# change to the ETL routine necessitates re-processing all REDCap DET records,
+# this revision number should be incremented.
+REVISION = 6
+
+
+@redcap_det.command_for_project(
+    "kiosk",
+    redcap_url = REDCAP_URL,
+    project_id = PROJECT_ID,
+    revision = REVISION,
+    help = __doc__)
+
+@first_record_instance
+@required_instruments(REQUIRED_INSTRUMENTS)
+def redcap_det_kiosk(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
+    if redcap_record['staff_name_uw'] == 'DEMO MODE' or redcap_record['staff_name_sch'] == 'DEMO MODE':
+        LOG.warning("Skipping enrollment with staff name equal to `DEMO MODE`.")
+        return None
+
+    if redcap_record['language_questions'] == 'Spanish':
+        LOG.info("Processing Spanish enrollment")
+        redcap_record = overwrite_english_questionnaire_responses(redcap_record)
+
+    patient_entry, patient_reference = create_patient(redcap_record)
+
+    if not patient_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct a patient")
+        return None
+
+    specimen_resource_entry, specimen_reference = create_specimen(redcap_record, patient_reference)
+
+    if not specimen_resource_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct a specimen")
+        return None
+
+    # Create diagnostic report resource if the participant agrees
+    # to do the rapid flu test on site
+    diagnostic_report_resource_entry = None
+    if redcap_record['poc_yesno'] == 'Yes':
+
+        diagnostic_code = create_codeable_concept(
+            system = 'http://loinc.org',
+            code = '85476-0',
+            display = 'FLUAV and FLUBV and RSV pnl NAA+probe (Upper resp)'
+        )
+
+        diagnostic_report_resource_entry = create_diagnostic_report(
+            redcap_record,
+            patient_reference,
+            specimen_reference,
+            diagnostic_code,
+            create_cepheid_result_observation_resource
+        )
+
+    encounter_locations = determine_encounter_locations(db, cache, redcap_record)
+    location_resource_entries, location_references = create_locations(encounter_locations)
+
+    symptom_resources, symptom_references = create_symptoms(
+        redcap_record,
+        patient_reference
+    )
+
+    encounter_resource_entry, encounter_reference = create_encounter(
+        redcap_record,
+        patient_reference,
+        location_references,
+        symptom_resources,
+        symptom_references
+    )
+
+    if not encounter_resource_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct an encounter")
+        return None
+
+    questionnaire_response_resource_entry = create_questionnaire_response_entry(
+        redcap_record,
+        patient_reference,
+        encounter_reference
+    )
+
+    specimen_observation_resource_entry = create_specimen_observation_entry(
+        specimen_reference,
+        patient_reference,
+        encounter_reference
+    )
+
+    all_resource_entries = [
+        patient_entry,
+        *location_resource_entries,
+        encounter_resource_entry,
+        questionnaire_response_resource_entry,
+        specimen_resource_entry,
+        specimen_observation_resource_entry,
+    ]
+
+    if diagnostic_report_resource_entry:
+        all_resource_entries.append(diagnostic_report_resource_entry)
+
+    return create_bundle_resource(
+        bundle_id = str(uuid4()),
+        timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}",
+        entries = list(filter(None, all_resource_entries))
+    )
+
+
+# FUNCTIONS SPECIFIC TO SFS KIOSK ENROLLMENT PROJECT
+def overwrite_english_questionnaire_responses(redcap_record: Dict[str, Any]):
+    overwritten_data = {k: v for k, v in redcap_record.items()}
+
+    for key in redcap_record.keys():
+        if key.startswith("s_"):
+            overwritten_data[key.lstrip("s_")] = redcap_record[key]
+
+    return REDCapRecord(project=REDCapProject(url=REDCAP_URL, project_id=PROJECT_ID), data=overwritten_data)
+
+
+def create_patient(record: dict) -> tuple:
+    """ Returns a FHIR Patient resource entry and reference. """
+    gender = map_sex(record["sex_new"] or record["sex"])
+
+    patient_id = generate_patient_hash(
+        names       = participant_names(record),
+        gender      = gender,
+        birth_date  = record['birthday'],
+        postal_code = participant_zipcode(record))
+
+    if not patient_id:
+        # Some piece of information was missing, so we couldn't generate a
+        # hash.  Fallback to treating this individual as always unique by using
+        # the REDCap record id.
+        patient_id = generate_hash(f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}")
+
+    LOG.debug(f"Generated individual identifier {patient_id}")
+
+    patient_identifier = create_identifier(f"{SFS}/individual",patient_id)
+    patient_resource = create_patient_resource([patient_identifier], gender)
+
+    return create_entry_and_reference(patient_resource, "Patient")
+
+
+def participant_names(redcap_record: dict) -> Tuple[str, ...]:
+    """
+    Extracts a tuple of names for the participant from the given
+    *redcap_record*.
+    """
+    if redcap_record['participant_first_name']:
+        return (redcap_record['participant_first_name'], redcap_record['participant_last_name'])
+    else:
+        return (redcap_record['part_name_sp'],)
+
+
+def participant_zipcode(redcap_record: dict) -> str:
+    """
+    Extract the home zipcode for the participant from the given
+    *redcap_record*.
+
+    If no zipcode could be found for the participant, then it returns
+    «{PROJECT_ID}-{record_id}»
+    """
+    if redcap_record.get('home_zipcode'):
+        return redcap_record['home_zipcode']
+
+    elif redcap_record.get('home_zipcode_notus'):
+        return redcap_record['home_zipcode_notus']
+
+    elif redcap_record.get('shelter_name') and redcap_record['shelter_name'] != 'Other/none of the above':
+        address = determine_shelter_address(redcap_record['shelter_name'])
+        return address['zipcode']
+
+    elif redcap_record.get('uw_dorm') and redcap_record['uw_dorm'] != 'Other':
+        address = determine_dorm_address(redcap_record['uw_dorm'])
+        return address['zipcode']
+
+    return None
+
+
+def determine_vaccine_date(vaccine_year: str, vaccine_month: str) -> Optional[str]:
+    """
+    Determine date of vaccination and return in datetime format as YYYY or
+    YYYY-MM
+    """
+    if vaccine_year == '' or vaccine_year == 'Do not know':
+        return None
+
+    if vaccine_month == '' or vaccine_month == 'Do not know':
+        return datetime.strptime(vaccine_year, '%Y').strftime('%Y')
+
+    return datetime.strptime(f'{vaccine_month} {vaccine_year}', '%B %Y').strftime('%Y-%m')
+
+
+def create_specimen(redcap_record: dict, patient_reference: dict) -> tuple:
+    """
+    Create FHIR specimen resource entry and reference from given *redcap_record*
+    """
+    sfs_sample_barcode = get_sfs_barcode(redcap_record)
+
+    if not sfs_sample_barcode:
+        return None, None
+
+    specimen_identifier = create_identifier(f"{SFS}/sample", sfs_sample_barcode)
+
+    specimen_type = 'NSECR'  # Nasal swab.  TODO we may want shared mapping function
+    specimen_resource = create_specimen_resource(
+        [specimen_identifier], patient_reference, specimen_type
+    )
+
+    return create_entry_and_reference(specimen_resource, "Specimen")
+
+
+def get_sfs_barcode(redcap_record: dict) -> str:
+    """
+    Find SFS barcode within *redcap_record*.
+
+    SFS barcode should be scanned into `sfs_barcode`, but if the scanner isn't
+    working then barcode will be manually entered into `sfs_barcode_manual`
+    """
+    barcode = redcap_record['sfs_barcode']
+
+    if barcode == '':
+        barcode = redcap_record['sfs_barcode_manual']
+
+    return barcode
+
+
+def create_cepheid_result_observation_resource(redcap_record: dict) -> List[Observation]:
+    """
+    Determine the cepheid results based on responses in *redcap_record* and
+    create observation resources for each result following the FHIR format
+    (http://www.hl7.org/implement/standards/fhir/observation.html)
+    """
+    code_map = {
+        'Influenza A +': {
+            'system': 'http://snomed.info/sct',
+            'code': '181000124108',
+            'display': 'Influenza A virus present'
+        },
+        'Influenza B +': {
+            'system': 'http://snomed.info/sct',
+            'code': '441345003',
+            'display': 'Influenza B virus present'
+        },
+        'RSV +': {
+            'system': 'http://snomed.info/sct',
+            'code': '441278007',
+            'display': 'Respiratory syncytial virus untyped strain present'
+        },
+        'Inconclusive': {
+            'system': 'http://snomed.info/sct',
+            'code': '911000124104',
+            'display': 'Virus inconclusive'
+        }
+    }
+
+    cepheid_results = find_selected_options('cepheid_results___', redcap_record)
+
+    # Create observation resources for all potential results in Cepheid test
+    diagnostic_results: dict[str, Observation] = {}
+    for index, result in enumerate(code_map):
+        new_observation = observation_resource('Cepheid')
+        new_observation['id'] = 'result-' + str(index+1)
+        new_observation['code']['coding'] = [code_map[result]]
+        diagnostic_results[result] = (new_observation)
+
+    # Mark all results as False if not positive for anything
+    if "Not positive for anything" in cepheid_results:
+        for result in diagnostic_results:
+            diagnostic_results[result]['valueBoolean'] = False
+
+    # Mark inconclusive as True and all other results as False if inconclusive
+    elif "Inconclusive" in cepheid_results:
+        for result in diagnostic_results:
+            if result == 'Inconclusive':
+                diagnostic_results[result]['valueBoolean'] = True
+            else:
+                diagnostic_results[result]['valueBoolean'] = False
+
+    else:
+        for result in diagnostic_results:
+            if result in cepheid_results:
+                diagnostic_results[result]['valueBoolean'] = True
+                cepheid_results.remove(result)
+            else:
+                diagnostic_results[result]['valueBoolean'] = False
+
+        if len(cepheid_results) != 0:
+            raise UnknownCepheidResultError(f"Unknown Cepheid result «{cepheid_results}»")
+
+    return list(diagnostic_results.values())
+
+
+def create_locations(encounter_locations: dict) -> tuple:
+    """
+    Create FHIR location resources and reference from a given *redcap_record*
+    """
+    location_resource_entries = []
+    location_references = []
+    for location in encounter_locations:
+        # Locations related to encounter site only needs a logical reference
+        # since we expect site to already exist within ID3C warehouse.site
+        if location == 'site':
+            if not encounter_locations['site']:
+                return [], None
+
+            location_reference = create_reference(
+                reference_type = 'Location',
+                identifier = {
+                    'system': f'{SFS}/site',
+                    'value': encounter_locations['site']
+                }
+            )
+
+        else:
+            location_fullUrl = encounter_locations[location]['fullUrl']
+            location_id = encounter_locations[location]['value']
+            scale = 'tract' if location.endswith('-tract') else 'address'
+            location_identifier = create_identifier(
+                system = f'{SFS}/location/{scale}',
+                value = location_id
+            )
+
+            # Only create partOf if location is an address to reference the
+            # related tract Location resource.
+            part_of = None
+
+            # Only create a literal location reference for the Encounter if
+            # the location is an address
+            location_reference = None
+
+            if scale == 'address':
+                address_tract = f'{location}-tract'
+                # Check that the address has corresponding census tract
+                assert address_tract in encounter_locations, \
+                    f'Found address without census-tract for {location}'
+
+                tract_fullUrl = encounter_locations[address_tract]['fullUrl']
+                part_of = create_reference(
+                    reference_type = 'Location',
+                    reference = tract_fullUrl
+                )
+                location_reference = create_reference(
+                    reference_type = 'Location',
+                    reference = location_fullUrl
+                )
+
+            location_resource = create_location_resource(
+                location_type = [determine_location_type_code(location)],
+                location_identifier = [location_identifier],
+                location_partOf = part_of
+            )
+
+            location_resource_entries.append(create_resource_entry(
+                resource = location_resource,
+                full_url = location_fullUrl
+            ))
+
+        if location_reference:
+            location_references.append({'location': location_reference})
+
+    return location_resource_entries, location_references
+
+
+def determine_encounter_locations(db: DatabaseSession, cache: TTLCache, redcap_record: dict) -> dict:
+    """
+    Find all locations within a *redcap_record* that are relevant to
+    an encounter
+    """
+    locations = {
+        'site': determine_site_name(redcap_record)
+    }
+
+    def construct_location(db: DatabaseSession, cache: TTLCache, lat_lng: Tuple[int, int],
+        canonicalized_address: Any, location_type: str) -> dict:
+        return ({
+            f'{location_type}-tract': {
+                'value': location_lookup(db, lat_lng, 'tract').identifier,  # TODO what if null?
+                'fullUrl': generate_full_url_uuid()
+            },
+            location_type: {
+                'value': generate_hash(canonicalized_address),
+                'fullUrl': generate_full_url_uuid()
+            }
+        })
+
+    address: Dict[str, str] = {}
+    if redcap_record['shelter_name'] and redcap_record['shelter_name'] != 'Other/none of the above':
+        address = determine_shelter_address(redcap_record['shelter_name'])
+        housing_type = 'lodging'
+
+    elif redcap_record['uw_dorm'] and redcap_record['uw_dorm'] != 'Other':
+        address = determine_dorm_address(redcap_record['uw_dorm'])
+        housing_type = 'residence'
+
+    elif redcap_record['home_street'] or redcap_record['home_street_optional']:
+        address = determine_home_address(redcap_record)
+        housing_type = 'residence'
+
+    if address:
+        lat, lng, canonicalized_address = get_geocoded_address(address, cache)
+
+        if canonicalized_address:
+            locations.update(construct_location(db, cache, (lat, lng), canonicalized_address, housing_type))
+
+    return locations
+
+
+def determine_site_name(redcap_record: dict) -> Optional[str]:
+    """
+    Given a *redcap_record*, determine the site name for the encounter.
+
+    Will error if there is more than one site name found or if the site
+    name is not in expected values.
+    """
+    potential_site_names = find_selected_options('site_identifier_', redcap_record)
+    if not potential_site_names:
+        return None
+
+    # Check only one site identifier is selected
+    assert len(potential_site_names) == 1, \
+        f"More than one site name found: «{potential_site_names}»"
+
+    site = potential_site_names[0]
+
+    site_name_map = {
+        'UW HUB': 'HUB',
+        'UW Suzzallo Library': 'UWSuzzalloLibrary',
+        'SeaMar': 'UWSeaMar',
+        'UW Hall Health': 'UWHallHealth',
+        "Seattle Children's: Seattle Children's campus site": 'ChildrensHospitalSeattle',
+        "Seattle Children's: Seattle outpatient clinic": 'ChildrensHospitalSeattleOutpatientClinic',
+        'Fred Hutch': 'FredHutchLobby',
+        'Harborview Lobby': 'HarborviewLobby',
+        'Columbia Center': 'ColumbiaCenter',
+        'Seattle Center': 'SeattleCenter',
+        'Westlake Center': 'WestlakeCenter',
+        'King Street Station': 'KingStreetStation',
+        'Westlake Light Rail Station': 'WestlakeLightRailStation',
+        'CapitolHillLightRailStation': 'CapitolHillLightRailStation',
+        'Capitol Hill Light Rail Station': 'CapitolHillLightRailStation',
+        "St. Martin's": 'StMartins',
+    }
+
+    if site not in site_name_map:
+        raise UnknownSiteError(f"Unknown site name «{site}»")
+
+    return site_name_map[site]
+
+
+def determine_shelter_address(shelter_name: str) -> dict:
+    """
+    Return address for a *shelter_name*
+    """
+    shelter_map = {
+        "Aloha Inn": "1911 Aurora Ave N,98109",
+        "Blaine Center Homeless Ministry": "150 Denny Way,98109",
+        "Bread of Life Mission": "97 S Main St,98104",
+        "Compass Housing Alliance":	"77 S Washington St,98104",
+        "DESC (Downtown Emergency Service Center)":	"515 3rd Ave,98104",
+        "Elizabeth Gregory House": "1604 NE 50th St,98105",
+        "Hammond House Women's Shelter": "302 N 78th St,98103",
+        "Jubilee Women's Center": "620 18th Ave E,98112",
+        "King County Men's Winter Shelter":	"500 4th Avenue,98104",
+        "Mary's Place": "1155 N 130th St,98133",
+        "Mary's Place North Seattle": "1155 N 130th St,98133",
+        "Mary's Place White Center": "10821 8th Ave SW,98146",
+        "Mary's Place Burien": "12845 Ambaum Blvd. SW,Burien,WA,98146",
+        "Noel House Women's Referral Center": "118 Bell St,98121",
+        "Pike Market Senior Center": "85 Pike St #200,98101",
+        "Roots Young Adult Shelter": "1415 NE 43rd St,98105",
+        "Sacred Heart Shelter": "232 Warren Ave N,98109",
+        "Saint Martin de Porres Shelter": "1516 Alaskan Way S,98134",
+        "Salvation Army Women's Shelter": "1101 Pike St,98101",
+        "Seattle City Hall Shelter": "600 4th Ave,98104",
+        "Seattle Union Gospel Mission for Men": "318 2nd Ave Ext S,98104",
+        "YMCA Emergency Shelter": "1025 E Fir St,98122"
+    }
+
+    if shelter_name not in shelter_map:
+        raise UnknownShelterError(f"Unknown shelter name «{shelter_name}»")
+
+    if shelter_name == "Mary's Place Burien":
+        street, city, state, zipcode = shelter_map[shelter_name].split(',')
+        return construct_address_dict(street, city, state, zipcode)
+
+    street, zipcode = shelter_map[shelter_name].split(',')
+
+    return construct_address_dict(street, 'Seattle', 'WA', zipcode)
+
+
+def determine_dorm_address(dorm_name: str) -> dict:
+    """
+    Return address for a *dorm_name*
+    """
+    dorm_map = {
+        "Alder Hall": "1315 NE Campus Parkway,98105",
+        "Cedar Apartments":	"1128 NE 41st St,98105",
+        "Elm Hall":	"1218 NE Campus Parkway,98105",
+        "Haggett Hall":	"4290 Whitman Ct NE,98195",
+        "Hansee Hall": "4294 Whitman Ln NE,98195",
+        "Lander Hall": "1201 NE Campus Parkway,98105",
+        "Madrona Hall":	"4320 Whitman Ln NE,98195",
+        "Maple Hall": "1135 NE Campus Parkway,98105",
+        "McCarty Hall":	"2100 NE Whitman Ln,98195",
+        "McMahon Hall":	"4200 Whitman Ct. NE,98195",
+        "Mercer Court Apartments": "3925 Adams Ln NE,98105",
+        "Poplar Hall":	"1302 NE Campus Parkway,98105",
+        "Stevens Court Apartments": "3801 Brooklyn Ave NE,98105",
+        "Terry Hall": "1035 NE Campus Parkway,98105",
+        "Willow Hall": "4294 Whitman Ln NE,98195",
+    }
+
+    if dorm_name not in dorm_map:
+        raise UnknownDormError(f"Unknown dorm name «{dorm_name}»")
+
+    street, zipcode = dorm_map[dorm_name].split(',')
+
+    return construct_address_dict(street, 'Seattle', 'WA', zipcode)
+
+
+def construct_address_dict(street: str,
+                           city: str,
+                           state: str,
+                           zipcode: str) -> dict:
+    """
+    Construct an address dict for Seatte, WA specific addresses with provided
+    *street* and *zipcode*
+    """
+    return ({
+        'street': street,
+        'secondary': None,
+        'city': city,
+        'state': state,
+        'zipcode': zipcode
+    })
+
+
+def determine_home_address(redcap_record: dict) -> dict:
+    """
+    Parse a home address from a given REDCap *redcap_record* and return as a dict
+    with each address field.
+    """
+    if redcap_record['home_street'] != '':
+        street = redcap_record['home_street']
+    else:
+        street = redcap_record['home_street_optional']
+
+    # City and State
+    if redcap_record['seattle_home'] == 'Seattle':
+        city = 'Seattle'
+        state = 'WA'
+    else:
+        city = redcap_record['homecity_other']
+        state = redcap_record['home_state']
+
+    # Zip Code
+    zipcode = redcap_record['home_zipcode']
+
+    return construct_address_dict(street, city, state, zipcode)
+
+
+def determine_location_type_code(location_type: str) -> dict:
+    """
+    Given an ID3C *location_type*, return the location type codeable concept
+    using FHIR codes
+    (http://www.hl7.org/implement/standards/fhir/v3/ServiceDeliveryLocationRoleType/vs.html)
+    """
+    location_type_system = 'http://terminology.hl7.org/CodeSystem/v3-RoleCode'
+
+    type_map = {
+        'site': 'HUSCS',
+        'work': 'WORK',
+        'residence': 'PTRES',
+        'residence-tract': 'PTRES',
+        'lodging': 'PTLDG',
+        'lodging-tract': 'PTLDG',
+        'school': 'SCHOOL'
+    }
+
+    return create_codeable_concept(location_type_system, type_map[location_type])
+
+
+def create_symptoms(redcap_record: dict, patient_reference: dict) -> tuple:
+    """
+    Create FHIR condition resources and references for symptoms selected in
+    given *redcap_record*
+    """
+    symptom_codes = determine_symptoms_codes(redcap_record)
+
+    if not symptom_codes:
+        return None, None
+
+    # YYYY-MM-DD in REDCap
+    symptom_onset = redcap_record.get('symptom_duration')
+
+    symptom_resources = []
+    symptom_references = []
+    for symptom in symptom_codes:
+        condition_resource = create_condition_resource(
+            condition_id = symptom,
+            patient_reference = patient_reference,
+            onset_datetime = symptom_onset,
+            condition_code = symptom_codes[symptom]['code'],
+            severity = symptom_codes[symptom]['severity_code']
+        )
+        condition_reference = create_reference(
+            reference_type = 'Condition',
+            reference = '#' + symptom
+        )
+        symptom_resources.append(condition_resource)
+        symptom_references.append({
+            'condition': condition_reference
+        })
+
+    return symptom_resources, symptom_references
+
+
+def determine_symptoms_codes(redcap_record: dict) -> Optional[dict]:
+    """
+    Given a *redcap_record*, determine the symptoms of the encounter
+    """
+    symptom_responses = find_selected_options('symptoms___', redcap_record)
+
+    severity_map = {
+        'Feeling feverish': 'fever_severity',
+        'Cough': 'cough_severity',
+        'Muscle or body aches': 'ache_severity',
+        'Feeling more tired than usual': 'fatigue_severity',
+        'Sore throat or itchy/scratchy throat': 'sorethroat_severity',
+        'Headaches': 'headache_severity',
+        'Chills or shivering': 'chills_severity',
+        'Sweats': 'sweats_severity',
+        'Nausea or vomiting': 'nausea_severity',
+        'Runny / stuffy nose': 'nose_severity',
+        'Increased trouble with breathing': 'breathing_severity',
+        'Diarrhea': 'diarrhea_severity',
+        'Ear pain or ear discharge': 'ear_severity',
+        'Rash': 'rash_severity'
+    }
+
+    symptom_codes = {}
+
+    for response in symptom_responses:
+        symptom = map_symptom(response)
+
+        if not symptom:
+            return None
+
+        symptom_code = create_codeable_concept(
+            system = f'{SFS}/symptom',
+            code = symptom,
+            display = symptom
+        )
+
+        symptom_codes[symptom] = {
+            'code': symptom_code,
+            'severity_code': None
+        }
+
+        if severity_map.get(response) and redcap_record.get(severity_map.get(response)):
+            severity = redcap_record[severity_map.get(response)]
+            symptom_codes[symptom]['severity_code'] = create_condition_severity_code(
+                condition_severity = severity
+            )
+
+    return symptom_codes
+
+
+def create_encounter(redcap_record: REDCapRecord,
+                     patient_reference: dict,
+                     location_references: List[dict],
+                     symptom_resources: Optional[List[Condition]],
+                     symptom_references: Optional[List[dict]]) -> tuple:
+    """
+    Create FHIR encounter resource and encounter reference from given
+    *redcap_record*.
+    """
+    encounter_id = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}"
+    enrollment_date = redcap_record.get('enrollment_date')
+
+    if not enrollment_date:
+        return None, None
+
+    # YYYY-MM-DD HH:MM in REDCap
+    encounter_date = enrollment_date.split()[0]
+
+    encounter_identifier = create_identifier(
+        system = f'{SFS}/encounter',
+        value = encounter_id
+    )
+
+    encounter_class = create_coding(
+        system = 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+        code = 'FLD'
+    )
+
+    encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(redcap_record),
+        encounter_identifier = [encounter_identifier],
+        encounter_class = encounter_class,
+        encounter_date = encounter_date,
+        patient_reference = patient_reference,
+        location_references = location_references,
+        diagnosis = symptom_references,
+        contained = symptom_resources
+    )
+
+    return create_entry_and_reference(encounter_resource, "Encounter")
+
+
+def determine_all_questionnaire_items(redcap_record: dict) -> List[dict]:
+    """
+    Given a *redcap_record*, determine answers for all core questions
+    """
+    items: Dict[str, Any] = {}
+
+    if redcap_record['age']:
+        items['age'] = [{ 'valueInteger': age_ceiling(int(redcap_record['age'])) }]
+        items['age_months'] = [{ 'valueInteger': int(age_ceiling(float(redcap_record['age_months']) / 12) * 12) }]
+
+    # Spanish language answers may exist anywhere below here.
+
+    items['travel_countries'] = [{'valueBoolean': (redcap_record['travel_countries'] == 'Yes' or redcap_record['travel_countries'] == 'Sí')}]
+    items['travel_states'] = [{'valueBoolean': (redcap_record['travel_states'] == 'Yes' or redcap_record['travel_states'] == 'Sí')}]
+
+    if redcap_record['acute_symptom_onset']:
+        items['acute_symptom_onset'] = [{ 'valueString': spanish_to_english_mapper(redcap_record['acute_symptom_onset'], 'acute_symptom_onset')}]
+
+    # Participant can select multiple insurance types, so create
+    # a separate answer for each selection
+    insurance_responses = find_selected_options('insurance___', redcap_record)
+    if insurance_responses:
+        items['insurance'] = [{'valueString': spanish_to_english_mapper(insurance, 'insurance')} for insurance in insurance_responses]
+
+    # Participant can select multiple races, so create
+    # a separate answer for each selection
+    race_responses = find_selected_options('race___', redcap_record)
+    if 'Prefer not to say' not in race_responses:
+        race_responses = [spanish_to_english_mapper(race, 'race') for race in race_responses]
+        races = race(race_responses)
+        items['race'] = [{'valueString': race} for race in races]
+
+    if redcap_record['hispanic'] != 'Prefer not to say':
+        items['ethnicity'] = [{'valueBoolean': (redcap_record['hispanic'] == 'Yes' or redcap_record['hispanic'] == "Sí")}]
+
+    if redcap_record['education']:
+        items['education'] = [{'valueString': spanish_to_english_mapper(redcap_record['education'], 'education')}]
+
+    if redcap_record['income_levels']:
+        items['income'] = [{'valueString': spanish_to_english_mapper(redcap_record['income_levels'], 'income_levels')}]
+
+    if redcap_record['housing_type']:
+        items['housing_type'] = [{'valueString': spanish_to_english_mapper(redcap_record['housing_type'], 'housing_type')}]
+
+    if redcap_record['house_members']:
+        items['house_members'] = [{'valueString': spanish_to_english_mapper(redcap_record['house_members'], 'house_members')}]
+
+    if redcap_record['antiviral_1']:
+        items['antiviral_1'] = [{'valueString': spanish_to_english_mapper(redcap_record['antiviral_1'], 'antiviral_1')}]
+
+    child_age_responses = find_selected_options("age_children___", redcap_record)
+    if child_age_responses:
+        items['age_children'] = [{'valueString': spanish_to_english_mapper(age_response, 'age_children')} for age_response in child_age_responses]
+
+    if redcap_record['regular_activities_0']:
+        items['regular_activities_0'] = [{'valueString': spanish_to_english_mapper(redcap_record['regular_activities_0'], 'regular_activities_0')}]
+
+    school_interference_responses = find_selected_options("school_interference_0___", redcap_record)
+    if school_interference_responses:
+        items['school_interference_0'] = [{'valueString': spanish_to_english_mapper(interference, 'school_interference_0')} for interference in school_interference_responses]
+
+    items['child_dayvare'] = [{'valueBoolean': (redcap_record['child_daycare'] == 'Yes' or redcap_record['child_daycare'] == 'Sí')}]
+
+    # Participant can select multiple smoking types, so create
+    # a separate answer for each selection
+    smoke_responses = find_selected_options('smoke___', redcap_record)
+    if smoke_responses:
+        items['smoke'] = [{'valueString': spanish_to_english_mapper(smoke, 'smoke')} for smoke in smoke_responses]
+
+    # Participant can select multiple chronic illnesses, so create
+    # a separate answer for each selection
+    chronic_illness = find_selected_options('chronic_illness___', redcap_record)
+    if smoke_responses:
+        items['chronic_illness'] = [{'valueString': map_chronic_illness(spanish_to_english_mapper(illness, 'illness'))} for illness in chronic_illness]
+
+    # Only include vaccine status if known
+    vaccine_status = map_vaccine(spanish_to_english_mapper(redcap_record['vaccine'], 'vaccine'))
+    # Only include vaccine status if known
+    if vaccine_status is not None:
+        items['vaccine'] = [{ 'valueBoolean': vaccine_status }]
+        immunization_date = determine_vaccine_date(
+            vaccine_year = spanish_to_english_mapper(redcap_record['vaccine_year'], 'vaccine_year'),
+            vaccine_month = spanish_to_english_mapper(redcap_record['vaccine_month'], 'vaccine_month')
+        )
+        if vaccine_status and immunization_date:
+            items['vaccine'].append({ 'valueDate': immunization_date })
+
+    response_items = []
+    for item in items:
+        response_items.append(create_questionnaire_response_item(
+            question_id = item,
+            answers = items[item]
+        ))
+
+    # fu
+    if redcap_record['doctor_1week']:
+        items['doctor_1week'] = [{'valueString': spanish_to_english_mapper(redcap_record['doctor_1week'], 'doctor_1week')}]
+
+    activity_responses = find_selected_options("activities_impacted_poc___", redcap_record)
+    if activity_responses:
+        items['activities_impacted_poc'] = [{'valueString': spanish_to_english_mapper(activity, 'activities_impacted_poc')} for activity in activity_responses]
+
+    work_impact_responses = find_selected_options('work_impact_2poc___', redcap_record)
+    if work_impact_responses:
+        items['work_impact_2poc'] = [{'valueString': spanish_to_english_mapper(impact, 'work_impact_2poc')} for impact in work_impact_responses]
+
+    return response_items
+
+
+def determine_insurance_type(insurance_reseponse: str) -> str:
+    """
+    Determine the insurance type based on a given *insurance_response*
+    """
+    insurance_map = {
+        'Private (provided by employer and/or purchased)': 'privateInsurance',
+        'Government (Medicare/Medicaid)': 'government',
+        'Other': 'other',
+        'None': 'none',
+        'Prefer not to say': 'preferNotToSay'
+    }
+
+    def standardize_insurance(insurance):
+        try:
+            return insurance_map[insurance]
+        except KeyError:
+            raise UnknownInsuranceError(f'Unknown insurance response «{insurance}»') from None
+
+    return standardize_insurance(insurance_reseponse)
+
+
+def create_questionnaire_response_entry(redcap_record: dict,
+                                        patient_reference: dict,
+                                        encounter_reference: dict) -> Optional[dict]:
+    """
+    Ceeate a questionnaire response entry based on given *redcap_record* and
+    link to *patient_refernece* and *encounter_reference*
+    """
+    questionnaire_items = determine_all_questionnaire_items(redcap_record)
+
+    if not questionnaire_items:
+        return None
+
+    questionnaire_response_resource = create_questionnaire_response_resource(
+        patient_reference = patient_reference,
+        encounter_reference = encounter_reference,
+        items = questionnaire_items
+    )
+
+    return (create_resource_entry(
+        resource = questionnaire_response_resource,
+        full_url = generate_full_url_uuid()
+    ))
+
+
+def find_selected_options(option_prefix: str, redcap_record:dict) -> list:
+    """
+    Find all choosen options within *redcap_record* where option begins with
+    provided *option_prefix*.
+
+    Note: Values of options not choosen are empty strings.
+    """
+    return [
+        value
+        for key, value
+        in redcap_record.items()
+        if key.startswith(option_prefix) and value
+    ]
+
+
+# XXX A quick and dirty mapping set to handle potentially spanish language values in variables.
+def spanish_to_english_mapper(value: str, field: str):
+
+    if field == 'acute_symptom_onset':
+        return map_spanish_symptom_onset_to_english(value)
+    elif field == 'insurance':
+        return map_spanish_insurance_to_english(value)
+    elif field == 'race':
+        return map_spanish_race_to_english(value)
+    elif field == 'education':
+        return map_spanish_education_to_english(value)
+    elif field == 'income_levels':
+        return map_spanish_income_levels_to_english(value)
+    elif field == 'housing_type':
+        return map_spanish_housing_type_to_english(value)
+    elif field == 'house_members':
+        return map_spanish_house_members_to_english(value)
+    elif field == 'antiviral_1':
+        return map_spanish_antiviral_1_to_english(value)
+    elif field == 'smoke':
+        return map_spanish_smoke_to_english(value)
+    elif field == 'illness':
+        return map_spanish_illness_to_english(value)
+    elif field == 'vaccine':
+        return map_spanish_vaccine_to_english(value)
+    elif field == 'vaccine_year':
+        return map_spanish_vaccine_year_to_english(value)
+    elif field == 'vaccine_month':
+        return map_spanish_vaccine_month_to_english(value)
+    elif field == 'age_children':
+        return map_spanish_age_children_to_english(value)
+    elif field == 'regular_activities_0':
+        return map_spanish_regular_activity_to_english(value)
+    elif field == 'school_interference_0':
+        return map_spanish_school_interference_to_english(value)
+
+    # fu
+    elif field == 'activities_impacted_poc':
+        return map_spanish_impacted_activity_to_english(value)
+    elif field == 'work_impact_2poc':
+        return map_spanish_work_impact_to_english(value)
+    elif field == 'doctor_1week':
+        return map_spanish_doctor_follow_up_to_english(value)
+    else:
+        raise UnknownMappedField(f"Unknown Spanish to English mapped field name «{field}»")
+
+
+def map_spanish_symptom_onset_to_english(to_map):
+    mapper = {
+        'Medio día': 'Half a day',
+        'Medio día a 1 día': 'Half a day - 1 day',
+        '1 a 1.5 días': '1 - 1.5 days',
+        '1.5 a 2 días': '1.5 - 2 days',
+        '3 días': '3 days',
+        '4 días': '4 days',
+        '5 o más días': '5 or more days',
+    }
+
+    def standardize_symptom_onset(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownSymptomOnsetError(f'Unknown acute symptom onset response «{to_map}»') from None
+
+    return standardize_symptom_onset(to_map)
+
+
+def map_spanish_insurance_to_english(to_map):
+    mapper = {
+        'Privado (proporcionado por el empleador y/o comprado)': 'Private (provided by employer and/or purchased)',
+        'Gubernamental (Medicare/Medicaid)': 'Government (Medicare/Medicaid)',
+        'Otra': 'Other',
+        'Ninguno': 'None',
+        'Prefiero no decir': 'Prefer not to say',
+    }
+
+    def standardize_insurance(to_map):
+        if to_map in mapper.values():
+            return determine_insurance_type(to_map)
+
+        try:
+            return determine_insurance_type(mapper[to_map])
+        except KeyError:
+            raise UnknownInsuranceValueError(f'Unknown insurance response «{to_map}»') from None
+
+    return standardize_insurance(to_map)
+
+
+def map_spanish_race_to_english(to_map):
+    mapper = {
+        'Indio americano o nativo de Alaska': 'American Indian or Alaska Native',
+        'Asiático': 'Asian',
+        'Nativo de Hawái o de otra isla del Pacífico': 'Native Hawaiian or other Pacific Islander',
+        'Negro o afroamericano': 'Black or African American',
+        'Blanco': 'White',
+        'Otra': 'Other',
+        'Prefiero no decir': 'Prefer not to say',
+    }
+
+    def standardize_race(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownRaceError(f'Unknown race response «{to_map}»') from None
+
+    return standardize_race(to_map)
+
+
+def map_spanish_education_to_english(to_map):
+    mapper = {
+        "No acabé la preparatoria (high school)": "Less than high school graduate",
+        "Terminé la preparatoria (high school) / Obtuve mi GED": "Graduated high school/obtained GED",
+        "Algunos estudios universitarios (incluida la formación vocacional, título de dos años)": "Some college (including vocational training, associate's degree)",
+        "Licenciatura": "Bachelor's degree",
+        "Título avanzado": "Advanced degree",
+        "Prefiero no decir": "Prefer not to say",
+    }
+
+    def standardize_education(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownEducationError(f'Unknown education response «{to_map}»') from None
+
+    return standardize_education(to_map)
+
+
+def map_spanish_income_levels_to_english(to_map):
+    mapper = {
+        'Menos que o igual a $25,000': 'Less than or equal to $25,000',
+        'Entre veinticinco y cincuenta mil dolares ($25,001 a $50,000)': 'Between $25 and 50 thousand ($25,001 to $50,000)',
+        'Entre cincuenta y setenta y cinco mil dolares ($50,001 a $75,000)': 'Between $50 and 75 thousand ($50,001 to $75,000)',
+        'Entre setenta y cinco y cien mil dolares ($75,001 a $100,000)': 'Between $75 and 100 thousand ($75,001 to $100,000)',
+        'Entre cien mil y cien y veinticinco mil dolares ($100,001 a $125,000)': 'Between $100 and 125 thousand ($100,001 to $125,000)',
+        'Entre cien y veinticinco mil y cien y cincuenta mil dolares ($125,001 a $150,000)': 'Between $125 and 150 thousand ($125,001 to $150,000)',
+        'Más que $150,000': 'Over $150,000',
+        'No lo sé': "Don't know",
+        'Prefiero no decir': 'Prefer not to say',
+    }
+
+    def standardize_income_level(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownIncomeError(f'Unknown income levels response «{to_map}»') from None
+
+    return standardize_income_level(to_map)
+
+
+def map_spanish_housing_type_to_english(to_map):
+    mapper = {
+        'Casa/condominio/casa adosada': 'House/condo/townhouse',
+        'Refugio': 'Shelter',
+        'Apartamento': 'Apartment',
+        'Dormitorio': 'Dormitory',
+        'Centro de vivienda asistida': 'Assisted living facility',
+        'Centro de enfermería especializada': 'Skilled nursing center',
+        'Sin residencia principal regular': 'No consistent primary residence',
+        'Otra': 'Other',
+    }
+
+    def standardize_housing_type(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownHousingTypeError(f'Unknown housing type response «{to_map}»') from None
+
+    return standardize_housing_type(to_map)
+
+
+def map_spanish_house_members_to_english(to_map):
+    mapper = {
+        'Vivo solo': 'I live by myself',
+        '2 personas': '2 people',
+        '3 personas': '3 people',
+        '4 personas': '4 people',
+        '5 personas': '5 people',
+        '6 o más personas': '6 or more people',
+    }
+
+    def standardize_house_members(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownHousingMembersError(f'Unknown house members response «{to_map}»') from None
+
+    return standardize_house_members(to_map)
+
+
+def map_spanish_antiviral_1_to_english(to_map):
+    mapper = {
+        'No': 'No',
+        'Sí; Oseltamivir (Tamiflu)': 'Yes; Oseltamivir (Tamiflu)',
+        'Sí; Zanamivir (Relenza)': 'Yes; Zanamivir (Relenza)',
+        'Sí; Peramivir (Rapivab)': 'Yes; Peramivir (Rapivab)',
+        'Sí; Baloxavir (Xofluza)': 'Yes; Baloxavir (Xofluza)',
+        'Sí, pero no sé qué medicamento': "Yes, but I don't know which medication",
+        'No lo sé': 'Do not know',
+    }
+
+    def standardize_antiviral(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownAntiviralError(f'Unknown antiviral response «{to_map}»') from None
+
+    return standardize_antiviral(to_map)
+
+
+def map_spanish_smoke_to_english(to_map):
+    mapper = {
+        'Productos de tabaco (p. ej. cigarrillos, puros, pipas)': 'Tobacco products (e.g. cigarettes, cigars, pipes)',
+        'Cigarrillos electrónicos/bolígrafos de vapor': 'Electronic cigarettes/vapor pens',
+        'Ninguna de las anteriores respuestas': 'None of the above',
+        'Prefiero no decir': 'Prefer not to say',
+    }
+
+    def standardize_smoke(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownSmokeError(f'Unknown smoke response «{to_map}»') from None
+
+    return standardize_smoke(to_map)
+
+
+def map_spanish_illness_to_english(to_map):
+    mapper = {
+        "Asma o enfermedad reactiva de las vías respiratorias": "Asthma or reactive airway disease",
+        "COPD/enfisema": "COPD/emphysema",
+        "Bronquitis crónica": "Chronic bronchitis",
+        "Cáncer": "Cancer",
+        "Diabetes": "Diabetes",
+        "Enfermedad cardíaca (insuficiencia cardíaca o ataque cardíaco)": "Heart disease (heart failure or heart attack)",
+        "Ninguna de estas afecciones": "None of these conditions",
+        "No lo sé": "Do not know",
+        "Prefiero no decir": "Prefer not to say",
+    }
+
+    def standardize_illness(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownIllnessError(f'Unknown illness response «{to_map}»') from None
+
+    return standardize_illness(to_map)
+
+
+def map_spanish_vaccine_to_english(to_map):
+    mapper = {
+        'Sí': 'Yes',
+        'No': 'No',
+        'No lo sé': 'Do not know',
+    }
+
+    def standardize_vaccine(to_map):
+        if not to_map:
+            return ''
+
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownVaccineError(f'Unknown vaccine response «{to_map}»') from None
+
+    return standardize_vaccine(to_map)
+
+
+def map_spanish_vaccine_year_to_english(to_map):
+    mapper = {
+        '2019': '2019',
+        '2020': '2020',
+        'No lo sé': 'Do not know',
+    }
+
+    def standardize_vaccine_year(to_map):
+        if not to_map:
+            return ''
+
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownVaccineYearError(f'Unknown vaccine year response «{to_map}»') from None
+
+    return standardize_vaccine_year(to_map)
+
+
+def map_spanish_vaccine_month_to_english(to_map):
+    mapper = {
+        'Enero': 'January',
+        'Febrero': 'February',
+        'Marzo': 'March',
+        'Abril': 'April',
+        'Mayo': 'May',
+        'Junio': 'June',
+        'Julio': 'July',
+        'Agosto': 'August',
+        'Septiembre': 'September',
+        'Octubre': 'October',
+        'Noviembre': 'November',
+        'Diciembre': 'December',
+        'No lo sé': 'Do not know',
+    }
+
+    def standardize_vaccine_month(to_map):
+        if not to_map:
+            return ''
+
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownVaccineMonthError(f'Unknown vaccine month response «{to_map}»') from None
+
+    return standardize_vaccine_month(to_map)
+
+
+def map_spanish_age_children_to_english(to_map):
+    mapper = {
+        'No hay niños': 'No children',
+        '0-5 años': 'Age 0-5 years',
+        '6-12 años': 'Age 6-12 years',
+        '13-18 años': 'Age 13-18 years',
+    }
+
+    def standardize_age_children(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownChildAgeError(f'Unknown child age response «{to_map}»') from None
+
+    return standardize_age_children(to_map)
+
+
+def map_spanish_doctor_follow_up_to_english(to_map):
+    mapper = {
+        "Sí - Consultorio médico o atención de urgencia": "Yes - Doctor's office or Urgent Care",
+        "Sí - Farmacia": "Yes - Pharmacy (drugstore)",
+        "Sí - Hospital o departamento de emergencias": "Yes - Hospital or Emergency Department",
+        "Si - Otro": "Yes - Other", # sic
+        "No": "No",
+    }
+
+    def standardize_doctor_follow_up(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownDoctorFollowUpError(f'Unknown doctor follow up response «{to_map}»') from None
+
+    return standardize_doctor_follow_up(to_map)
+
+
+def map_spanish_regular_activity_to_english(to_map):
+    mapper = {
+        "Nada": "Not at all",
+        "Un poco": "A little bit",
+        "Algo": "Somewhat",
+        "Bastante": "Quite a bit",
+        "Mucho": "Very much",
+    }
+
+    def standardize_regular_activity(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownRegularActivityError(f'Unknown regular activity response «{to_map}»') from None
+
+    return standardize_regular_activity(to_map)
+
+
+def map_spanish_impacted_activity_to_english(to_map):
+    mapper = {
+        "Escuela": "School",
+        "Trabajo": "Work",
+        "Hacer mandados": "Running errands",
+        "Hacer ejercicio": "Exercising",
+        "Socializar": "Socializing",
+        "Trabajar como voluntario": "Volunteering",
+        "Capacidad para cuidarme o cuidar a mi familia": "Ability to take care of myself and/or family",
+        "Ninguna de las anteriores/ mis actividades no se han visto afectadas": "None of the above / my activities have not been impacted",
+    }
+
+    def standardize_impacted_activity(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownImpactedActivityError(f'Unknown impacted activity response «{to_map}»') from None
+
+    return standardize_impacted_activity(to_map)
+
+
+def map_spanish_school_interference_to_english(to_map):
+    mapper = {
+        "Asistir a clases": "Attending class",
+        "Ir a trabajar": "Going to work",
+        "Estudiar": "Studying",
+        "Sacar buenas calificaciones en un examen o tarea de redacción": "Performing well on an exam or written assignment",
+        "Ninguna de las anteriores/ mis actividades no se han visto afectadas": "None of the above/ my activities have not been impacted",
+    }
+
+    def standardize_school_interference(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownSchoolInterferenceError(f'Unknown school interference response «{to_map}»') from None
+
+    return standardize_school_interference(to_map)
+
+
+def map_spanish_work_impact_to_english(to_map):
+    mapper = {
+        "Falté al trabajo": "I missed work",
+        "Trabajé desde casa": "I worked from home",
+        "Trabajé menos horas de lo habitual": "I worked fewer hours than usual",
+        "Ninguna de las anteriores respuestas": "None of the above",
+    }
+
+    def standardize_work_impact(to_map):
+        if to_map in mapper.values():
+            return to_map
+
+        try:
+            return mapper[to_map]
+        except KeyError:
+            raise UnknownWorkImpactError(f'Unknown work impact response «{to_map}»') from None
+
+    return standardize_work_impact(to_map)
+
+
+class UnknownMappedField(ValueError):
+    """
+    Raised by :function: `spanish_to_english_mapper` if a provided
+    *field* is not among a set of expected values
+    """
+    pass
+
+
+class UnknownSymptomOnsetError(ValueError):
+    """
+    Raised by :function: `map_spanish_symptom_onset_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownInsuranceValueError(ValueError):
+    """
+    Raised by :function: `map_spanish_insurance_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownRaceError(ValueError):
+    """
+    Raised by :function: `map_spanish_race_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownEducationError(ValueError):
+    """
+    Raised by :function: `map_spanish_education_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownIncomeError(ValueError):
+    """
+    Raised by :function: `map_spanish_income_levels_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownHousingTypeError(ValueError):
+    """
+    Raised by :function: `map_spanish_housing_type_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownHousingMembersError(ValueError):
+    """
+    Raised by :function: `map_spanish_house_members_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownAntiviralError(ValueError):
+    """
+    Raised by :function: `map_spanish_antiviral_1_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownSmokeError(ValueError):
+    """
+    Raised by :function: `map_spanish_smoke_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownIllnessError(ValueError):
+    """
+    Raised by :function: `map_spanish_illness_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownVaccineError(ValueError):
+    """
+    Raised by :function: `map_spanish_vaccine_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownVaccineYearError(ValueError):
+    """
+    Raised by :function: `map_spanish_vaccine_year_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownVaccineMonthError(ValueError):
+    """
+    Raised by :function: `map_spanish_vaccine_month_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownChildAgeError(ValueError):
+    """
+    Raised by :function: `map_spanish_age_children_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownDoctorFollowUpError(ValueError):
+    """
+    Raised by :function: `map_spanish_doctor_follow_up_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownRegularActivityError(ValueError):
+    """
+    Raised by :function: `map_spanish_regular_activity_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownImpactedActivityError(ValueError):
+    """
+    Raised by :function: `map_spanish_impacted_activity_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownSchoolInterferenceError(ValueError):
+    """
+    Raised by :function: `map_spanish_school_interference_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownWorkImpactError(ValueError):
+    """
+    Raised by :function: `map_spanish_work_impact_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownChildDaycareError(ValueError):
+    """
+    Raised by :function: `map_spanish_child_daycare_to_english` if a provided
+    *to_map* field is not among a set of expected values
+    """
+    pass
+
+
+class UnknownInsuranceError(ValueError):
+    """
+    Raised by :function: `determine_insurance_type` if a provided
+    *insurance_response* is not among a set of expected values
+    """
+    pass
+
+
+class UnknownCepheidResultError(ValueError):
+    """
+    Raised by :function: `determine_cepheid_results` if a provided
+    result response is not among a set of expected values
+    """
+    pass
+
+
+class UnknownShelterError(ValueError):
+    """
+    Raised by :function: `determine_shelter_address` if a provided shelter name
+    is not among a set of expected values
+    """
+    pass
+
+
+class UnknownDormError(ValueError):
+    """
+    Raised by :function: `determine_dorm_address` if a provided dorm name is
+    not among a set of expected values
+    """
+    pass

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -1,0 +1,602 @@
+"""
+Deprecated, data collection ended
+
+Process REDCap DETs that are specific to the
+Seattle Flu Study - Swab & Send + Home Flu Test Project.
+"""
+import re
+import click
+import json
+import logging
+from uuid import uuid4
+from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Union, Tuple
+from datetime import datetime
+from cachetools import TTLCache
+from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
+from id3c.cli.command.etl import redcap_det
+from id3c.cli.command.geocode import get_geocoded_address
+from id3c.cli.command.location import location_lookup
+from seattleflu.id3c.cli.command import age_ceiling
+from .redcap_map import *
+from .fhir import *
+from . import race, first_record_instance, required_instruments
+
+
+LOG = logging.getLogger(__name__)
+
+
+REVISION = 2
+
+REDCAP_URL = 'https://redcap.iths.org/'
+INTERNAL_SYSTEM = "https://seattleflu.org"
+UW_CENSUS_TRACT = '53033005302'
+
+PROJECT_ID = 19338
+REQUIRED_INSTRUMENTS = [
+    'screening',
+    'consent',
+    'back_end_mail_scans',
+    'illness_questionnaire',
+    'post_collection_data_entry_qc'
+]
+
+
+@redcap_det.command_for_project(
+    "swab-and-home-flu",
+    redcap_url = REDCAP_URL,
+    project_id = PROJECT_ID,
+    revision = REVISION,
+    help = __doc__)
+
+@first_record_instance
+@required_instruments(REQUIRED_INSTRUMENTS)
+def redcap_det_swab_and_home_flu(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
+    location_resource_entries = locations(db, cache, redcap_record)
+    patient_entry, patient_reference = create_patient(redcap_record)
+
+    if not patient_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct patient")
+        return None
+
+    encounter_entry, encounter_reference = create_encounter(redcap_record, patient_reference, location_resource_entries)
+
+    if not encounter_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct an encounter")
+        return None
+
+    questionnaire_entry = create_questionnaire_response(redcap_record, patient_reference, encounter_reference)
+    specimen_entry, specimen_reference = create_specimen(redcap_record, patient_reference)
+
+    if not specimen_entry:
+        LOG.warning("Skipping enrollment with insufficent information to construct a specimen")
+        return None
+
+    specimen_observation_entry = create_specimen_observation_entry(specimen_reference, patient_reference, encounter_reference)
+
+    resource_entries = [
+        patient_entry,
+        encounter_entry,
+        questionnaire_entry,
+        specimen_entry,
+        *location_resource_entries,
+        specimen_observation_entry
+    ]
+
+    return create_bundle_resource(
+        bundle_id = str(uuid4()),
+        timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}",
+        entries = list(filter(None, resource_entries))
+    )
+
+
+def locations(db: DatabaseSession, cache: TTLCache, record: dict) -> list:
+    """ Creates a list of Location resource entries from a REDCap record. """
+    def uw_affiliation(record: dict) -> List[Dict[Any, Any]]:
+        uw_affiliation = record['uw_affiliation']
+
+        student_responses = {
+            'Yes, I am an undergraduate student',
+            'Yes, I am a graduate/professional student',
+        }
+
+        employee_responses = {
+            'Yes, I am a graduate/professional student',
+            'Yes, I am a faculty member',
+            'Yes, I am a staff member/university employee',
+        }
+
+        if uw_affiliation and uw_affiliation not in {'No'}:
+            assert uw_affiliation in student_responses | employee_responses, \
+                f"Unknown UW affiliation answer: {uw_affiliation}"
+
+        uw_locations = []
+        if uw_affiliation in student_responses:
+            uw_locations.append(
+                create_location(f"{INTERNAL_SYSTEM}/location/tract", UW_CENSUS_TRACT, "school"))
+
+        if uw_affiliation in employee_responses:
+            uw_locations.append(
+                create_location(f"{INTERNAL_SYSTEM}/location/tract", UW_CENSUS_TRACT, "work"))
+
+        return uw_locations
+
+    def housing(db: DatabaseSession, cache: TTLCache, record: dict) -> tuple:
+        lodging_options = [
+            'Shelter',
+            'Assisted living facility',
+            'Skilled nursing center',
+            'No consistent primary residence'
+        ]
+
+        if record['housing_type'] in lodging_options:
+            housing_type = 'lodging'
+        else:
+            housing_type = 'residence'
+
+        address = {
+            'street': record['home_street'] or record['home_street_st'],
+            'secondary': None,
+            'city': record['homecity_other'] or record['homecity_other_st'],
+            'state': record['home_state'] or record['home_state_st'],
+            'zipcode': record['home_zipcode_2'],
+        }
+
+        lat, lng, canonicalized_address = get_geocoded_address(address, cache)
+        if not canonicalized_address:
+            return None, None  # TODO
+
+        tract_location = residence_census_tract(db, (lat, lng), housing_type)
+        # TODO what if tract_location is null?
+
+        tract_full_url = generate_full_url_uuid()
+        tract_entry = create_resource_entry(tract_location, tract_full_url)
+
+        address_hash = generate_hash(canonicalized_address)
+
+        address_location = create_location(
+            f"{INTERNAL_SYSTEM}/location/address",
+            address_hash,
+            housing_type,
+            tract_full_url
+        )
+
+        address_entry = create_resource_entry(address_location, generate_full_url_uuid())
+
+        return tract_entry, address_entry
+
+    locations = [*housing(db, cache, record)]
+
+    uw_location = uw_affiliation(record)
+    for location in uw_location:
+        if location:
+            locations.append(create_resource_entry(location, generate_full_url_uuid()))
+
+    return locations
+
+
+def create_location(system: str, value: str, location_type: str, parent: str=None) -> dict:
+    """ Returns a FHIR Location resource. """
+    location_type_system = "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+    location_type_map = {
+        "residence": "PTRES",
+        "school": "SCHOOL",
+        "work": "WORK",
+        "site": "HUSCS",
+        "lodging": "PTLDG",
+    }
+
+    location_type_cc = create_codeable_concept(location_type_system,
+                                            location_type_map[location_type])
+    location_identifier = create_identifier(system, value)
+    part_of = None
+    if parent:
+        part_of = create_reference(reference_type="Location", reference=parent)
+
+    return create_location_resource([location_type_cc], [location_identifier], part_of)
+
+
+def create_patient(record: dict) -> tuple:
+    """ Returns a FHIR Patient resource entry and reference. """
+    gender = map_sex(record["sex_new"] or record["sex"])
+
+    patient_id = generate_patient_hash(
+        names       = (record['first_name_1'], record['last_name_1']),
+        gender      = gender,
+        birth_date  = record['birthday'],
+        postal_code = record['home_zipcode_2'])
+
+    if not patient_id:
+        # Some piece of information was missing, so we couldn't generate a
+        # hash.  Fallback to treating this individual as always unique by using
+        # the REDCap record id.
+        patient_id = generate_hash(f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}")
+
+    LOG.debug(f"Generated individual identifier {patient_id}")
+
+    patient_identifier = create_identifier(f"{INTERNAL_SYSTEM}/individual", patient_id)
+    patient_resource = create_patient_resource([patient_identifier], gender)
+
+    return create_entry_and_reference(patient_resource, "Patient")
+
+
+def create_encounter(record: REDCapRecord, patient_reference: dict, locations: list) -> tuple:
+    """ Returns a FHIR Encounter resource entry and reference """
+
+    def grab_symptom_keys(key: str) -> Optional[Match[str]]:
+        if record[key] != '':
+            return re.match('symptoms___[0-9]{1,3}$', key)
+        else:
+            return None
+
+    def build_conditions_list(symptom_key: str) -> dict:
+        return create_resource_condition(record, record[symptom_key], patient_reference)
+
+    def build_diagnosis_list(symptom_key: str) -> Optional[dict]:
+        mapped_symptom = map_symptom(record[symptom_key])
+        if not mapped_symptom:
+            return None
+
+        return { "condition": { "reference": f"#{mapped_symptom}" } }
+
+    def build_locations_list(location: dict) -> dict:
+        return {
+            "location": create_reference(
+                reference_type = "Location",
+                reference = location["fullUrl"]
+            )
+        }
+
+    def non_tract_locations(resource: dict):
+        return bool(resource) \
+            and resource['resource']['identifier'][0]['system'] != f"{INTERNAL_SYSTEM}/location/tract"
+
+    symptom_keys = list(filter(grab_symptom_keys, record))
+    contained = list(filter(None, map(build_conditions_list, symptom_keys)))
+    diagnosis = list(filter(None, map(build_diagnosis_list, symptom_keys)))
+    encounter_identifier = create_identifier(
+        system = f"{INTERNAL_SYSTEM}/encounter",
+        value = f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}"
+    )
+    encounter_class_coding = create_coding(
+        system = "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        code = "HH"
+    )
+
+    encounter_date = record['enrollment_date']
+
+    if not encounter_date:
+        return None, None
+
+    non_tracts = list(filter(non_tract_locations, locations))
+    non_tract_references = list(map(build_locations_list, non_tracts))
+
+    # Site depends on study type
+    if record['study_type'] == 'Home Flu Test':
+        site = 'self-test'
+    elif record['study_type'] == 'Swab & Send':
+        site = 'swabNSend'
+    else:
+        assert False, f"Found unknown study type «{record['study_type']}»"
+
+    site_reference = {
+        "location": create_reference(
+            reference_type = "Location",
+            identifier = create_identifier(f"{INTERNAL_SYSTEM}/site", site)
+        )
+    }
+    non_tract_references.append(site_reference)
+
+    encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
+        encounter_identifier = [encounter_identifier],
+        encounter_class = encounter_class_coding,
+        encounter_date = encounter_date,
+        patient_reference = patient_reference,
+        location_references = non_tract_references,
+        diagnosis = diagnosis,
+        contained = contained
+    )
+
+    full_url = generate_full_url_uuid()
+    encounter_resource_entry = create_resource_entry(
+        resource = encounter_resource,
+        full_url = full_url
+    )
+    encounter_reference = create_reference(
+        reference_type = "Encounter",
+        reference = full_url
+    )
+
+    return encounter_resource_entry, encounter_reference
+
+
+def create_resource_condition(record: dict, symptom_name: str, patient_reference: dict) -> Optional[dict]:
+    """ Returns a FHIR Condition resource. """
+    def severity(symptom_name: Optional[str]) -> Optional[str]:
+        if symptom_name:
+            category = re.search('fever|cough|ache|fatigue|sorethroat', symptom_name.lower())
+            if category:
+                return f"{category[0]}_severity"
+
+        return None
+
+    mapped_symptom_name = map_symptom(symptom_name)
+    if not mapped_symptom_name:
+        return None
+
+    # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
+    # 3.8.  Until then, there's no reasonable way to type this data structure
+    # better than Any.
+    #   -trs, 24 Oct 2019
+    condition: Any = {
+        "resourceType": "Condition",
+        "id": mapped_symptom_name,
+        "code": {
+            "coding": [
+                {
+                    "system": f"{INTERNAL_SYSTEM}/symptom",
+                    "code": mapped_symptom_name
+                }
+            ]
+        },
+        "onsetDateTime": record["symptom_duration"], # YYYY-MM-DD in REDCap
+        "subject": patient_reference
+    }
+
+    symptom_severity = severity(mapped_symptom_name)
+    if symptom_severity and record[symptom_severity]:
+        condition['severity'] = create_condition_severity_code(record[symptom_severity]) # TODO lowercase?
+
+    return condition
+
+
+def create_specimen(record: dict, patient_reference: dict) -> tuple:
+    """ Returns a FHIR Specimen resource entry and reference """
+    def specimen_barcode(record: Any) -> str:
+        """
+        Given a REDCap *record*, returns the barcode or corrected barcode if it
+        exists.
+        """
+        barcode = record['return_utm_barcode'] or record['pre_scan_barcode']
+
+        if not barcode:
+            barcode = record['utm_tube_barcode_2'] or record['utm_tube_barcode_2_st']
+            reentered_barcode = record['reenter_barcode'] or record['reenter_barcode_st']
+
+            if record['barcode_confirm'] or record['barcode_confirm_st'] == "No":
+                #TODO: Figure out why 'corrected_barcode' doesn't always exist?
+                barcode = record['corrected_barcode'] or record['corrected_barcode_st']
+
+        return barcode
+
+    barcode = specimen_barcode(record)
+    if not barcode:
+        LOG.warning("Could not create Specimen Resource due to lack of barcode.")
+        return None, None
+
+    specimen_identifier = create_identifier(
+        system = f"{INTERNAL_SYSTEM}/sample",
+        value = barcode
+    )
+
+    # YYYY-MM-DD in REDCap
+    collected_time = record['collection_date'] or None
+
+    # YYYY-MM-DD HH:MM:SS in REDCap
+    received_time = record['samp_process_date'].split()[0] if record['samp_process_date'] else None
+
+    specimen_type = 'NSECR'  # Nasal swab.  TODO we may want shared mapping function
+    specimen_resource = create_specimen_resource(
+        [specimen_identifier], patient_reference, specimen_type, received_time, collected_time
+    )
+
+    full_url = generate_full_url_uuid()
+
+    specimen_entry = create_resource_entry(specimen_resource, full_url)
+    specimen_reference = create_reference(
+        reference = full_url,
+        reference_type = "Specimen"
+    )
+
+    return specimen_entry, specimen_reference
+
+
+def create_questionnaire_response(record: dict, patient_reference: dict,
+    encounter_reference: dict) -> Optional[dict]:
+    """ Returns a FHIR Questionnaire Response resource entry. """
+
+    def create_custom_coding_key(coded_question: str, record: dict) -> Optional[List]:
+        """
+        Handles the 'race' edge case by combining "select all that apply"-type
+        responses into one list.
+        """
+        coded_keys = list(filter(lambda r: grab_coding_keys(coded_question, r), record))
+        coded_names = list(map(lambda k: record[k], coded_keys))
+
+        if coded_question == 'race':
+            return race(coded_names)
+
+        return None
+
+    def grab_coding_keys(coded_question: str, key: str) -> Optional[Match[str]]:
+        if record[key] == '':
+            return None
+
+        return re.match(f'{coded_question}___[0-9]+$', key)
+
+
+    def build_questionnaire_items(question: str) -> Optional[dict]:
+        return questionnaire_item(record, question, category)
+
+    coding_questions = [
+        'race',
+        # 'insurance',  # TODO address these non-essential coded questions later
+        # 'how_hear_sfs',
+        # 'poc_behaviors',
+    ]
+
+    boolean_questions = [
+        'ethnicity',
+        'barcode_confirm',
+        'travel_states',
+        'travel_countries',
+    ]
+
+    integer_questions = [
+        'age',
+        'age_months',
+    ]
+
+    string_questions = [
+        'education',
+        'doctor_3e8fae',
+        'samp_process_date',
+        'house_members',
+        'shelter_members',
+        'where_sick',
+        'antiviral_0',
+        'acute_symptom_onset',
+        'doctor_1week',
+        'antiviral_1',
+    ]
+
+    question_categories = {
+        'valueCoding': coding_questions,
+        'valueBoolean': boolean_questions,
+        'valueInteger': integer_questions,
+        'valueString': string_questions,
+    }
+
+    # Do some pre-processing
+    record['race'] = create_custom_coding_key('race', record)
+    record['age'] = age_ceiling(int(record['age']))
+    record['age_months'] = age_ceiling(int(record['age_months']) / 12) * 12
+
+    items: List[dict] = []
+    for category in question_categories:
+        category_items = list(map(build_questionnaire_items, question_categories[category]))
+        for item in category_items:
+            if item:
+                items.append(item)
+
+    # Handle edge cases
+    vaccine_item = vaccine(record)
+    if vaccine_item:
+        items.append(vaccine_item)
+
+    if items:
+        questionnaire_reseponse_resource = create_questionnaire_response_resource(
+            patient_reference, encounter_reference, items
+        )
+        full_url = generate_full_url_uuid()
+        return create_resource_entry(questionnaire_reseponse_resource, full_url)
+
+    return None
+
+
+def questionnaire_item(record: dict, question_id: str, response_type: str) -> Optional[dict]:
+    """ Creates a QuestionnaireResponse internal item from a REDCap record. """
+    response = record[question_id]
+
+    def cast_to_coding(string: str):
+        """ Currently the only QuestionnaireItem we code is race. """
+        return create_coding(
+            system = f"{INTERNAL_SYSTEM}/race",
+            code = string,
+        )
+
+    def cast_to_string(string: str) -> Optional[str]:
+        if string != '':
+            return string
+        return None
+
+    def cast_to_integer(string: str) -> Optional[int]:
+        try:
+            return int(string)
+        except ValueError:
+            return None
+
+    def cast_to_boolean(string: str) -> Optional[bool]:
+        if string == 'Yes':
+            return True
+        elif re.match(r'^No($|,[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma and text
+            return False
+        return None
+
+    def build_response_answers(response: Union[str, List]) -> List:
+        answers = []
+        if not isinstance(response, list):
+            response = [response]
+
+        for item in response:
+            type_casted_item = casting_functions[response_type](item)
+
+            # cast_to_boolean can return False, so must be `is not None`
+            if type_casted_item is not None:
+                answers.append({ response_type: type_casted_item })
+
+        return answers
+
+    casting_functions: Mapping[str, Callable[[str], Any]] = {
+        'valueCoding': cast_to_coding,
+        'valueInteger': cast_to_integer,
+        'valueBoolean': cast_to_boolean,
+        'valueString': cast_to_string,
+    }
+
+    answers = build_response_answers(response)
+    if answers:
+        return create_questionnaire_response_item(question_id, answers)
+
+    return None
+
+
+def vaccine(record: Any) -> Optional[dict]:
+    """
+    For a given *record*, return a questionnaire response item with the vaccine
+    response(s) encoded.
+    """
+    vaccine_status = map_vaccine(record["vaccine"])
+    if vaccine_status is None:
+        return None
+
+    answers: List[Dict[str, Any]] = [{ 'valueBoolean': vaccine_status }]
+
+    date = vaccine_date(record)
+    if vaccine_status and date:
+        answers.append({ 'valueDate': date })
+
+    return create_questionnaire_response_item('vaccine', answers)
+
+
+def vaccine_date(record: dict) -> Optional[str]:
+    """ Converts a vaccination date to 'YYYY' or 'YYYY-MM' format. """
+    year = record['vaccine_year_fc54b4']
+    month = record['vaccine_month_dfe1c1']
+
+    if year == '' or year == 'Do not know':
+        return None
+
+    if month == 'Do not know':
+        return datetime.strptime(year, '%Y').strftime('%Y')
+
+    return datetime.strptime(f'{month} {year}', '%B %Y').strftime('%Y-%m')
+
+
+def residence_census_tract(db: DatabaseSession, lat_lng: Tuple[float, float],
+    housing_type: str) -> Optional[dict]:
+    """
+    Creates a new Location Resource for the census tract containing the given
+    *lat_lng* coordintes and associates it with the given *housing_type*.
+    """
+    location = location_lookup(db, lat_lng, 'tract')
+
+    if location and location.identifier:
+        return create_location(
+            f"{INTERNAL_SYSTEM}/location/tract", location.identifier, housing_type
+        )
+    else:
+        LOG.warning("No census tract found for given location.")
+        return None

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -230,7 +230,7 @@ def create_encounter(record: REDCapRecord, patient_reference: dict, locations: l
         else:
             return None
 
-    def build_conditions_list(symptom_key: str) -> dict:
+    def build_conditions_list(symptom_key: str) -> Optional[Condition]:
         return create_resource_condition(record, record[symptom_key], patient_reference)
 
     def build_diagnosis_list(symptom_key: str) -> Optional[dict]:
@@ -312,7 +312,7 @@ def create_encounter(record: REDCapRecord, patient_reference: dict, locations: l
     return encounter_resource_entry, encounter_reference
 
 
-def create_resource_condition(record: dict, symptom_name: str, patient_reference: dict) -> Optional[dict]:
+def create_resource_condition(record: dict, symptom_name: str, patient_reference: dict) -> Optional[Condition]:
     """ Returns a FHIR Condition resource. """
     def severity(symptom_name: Optional[str]) -> Optional[str]:
         if symptom_name:
@@ -326,11 +326,7 @@ def create_resource_condition(record: dict, symptom_name: str, patient_reference
     if not mapped_symptom_name:
         return None
 
-    # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
-    # 3.8.  Until then, there's no reasonable way to type this data structure
-    # better than Any.
-    #   -trs, 24 Oct 2019
-    condition: Any = {
+    condition: Condition = {
         "resourceType": "Condition",
         "id": mapped_symptom_name,
         "code": {
@@ -464,6 +460,7 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'insurance',
         'smoke_9a005a',
         'chronic_illness',
+        'housing_type',
     ]
 
     question_categories = {

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -21,12 +21,12 @@ from seattleflu.id3c.cli.command import age_ceiling
 from .redcap_map import *
 from .fhir import *
 from . import race, first_record_instance, required_instruments
-
+from .redcap import combine_legacy_checkbox_answers
 
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 2
+REVISION = 3
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -460,6 +460,10 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'acute_symptom_onset',
         'doctor_1week',
         'antiviral_1',
+        'income_levels',
+        'insurance',
+        'smoke_9a005a',
+        'chronic_illness',
     ]
 
     question_categories = {
@@ -469,10 +473,19 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'valueString': string_questions,
     }
 
+    checkbox_fields = [
+        'insurance',
+        'smoke_9a005a',
+        'chronic_illness',
+    ]
+
     # Do some pre-processing
     record['race'] = create_custom_coding_key('race', record)
     record['age'] = age_ceiling(int(record['age']))
     record['age_months'] = age_ceiling(int(record['age_months']) / 12) * 12
+
+    for field in checkbox_fields:
+        record[field] = combine_legacy_checkbox_answers(record, field)
 
     items: List[dict] = []
     for category in question_categories:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -438,6 +438,7 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'barcode_confirm',
         'travel_states',
         'travel_countries',
+        'child_daycare',
     ]
 
     integer_questions = [
@@ -461,6 +462,15 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'smoke_9a005a',
         'chronic_illness',
         'housing_type',
+        'agegroups',
+        'regular_activities_0',
+        'school_interference_0',
+        'activities_impacted_0v2',
+        'regular_activities_1',
+        'activities_impacted_2',
+        'school_interference_1',
+        'work_impact_0',
+        'work_impact',
     ]
 
     question_categories = {
@@ -474,6 +484,13 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'insurance',
         'smoke_9a005a',
         'chronic_illness',
+        'agegroups',
+        'school_interference_0',
+        'activities_impacted_0v2',
+        'activities_impacted_2',
+        'school_interference_1',
+        'work_impact_0',
+        'work_impact',
     ]
 
     # Do some pre-processing

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_and_home_flu.py
@@ -531,7 +531,7 @@ def questionnaire_item(record: dict, question_id: str, response_type: str) -> Op
     def cast_to_boolean(string: str) -> Optional[bool]:
         if string == 'Yes':
             return True
-        elif re.match(r'^No($|,[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma and text
+        elif re.match(r'^No($|(,|\s-)[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma or space+dash followed by text
             return False
         return None
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -415,6 +415,7 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'barcode_confirm',
         'travel_states',
         'travel_countries',
+        'child_daycare',
     ]
 
     integer_questions = [
@@ -438,6 +439,14 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'smoke_9a005a',
         'chronic_illness',
         'housing_type',
+        'agegroups',
+        'regular_activities_0',
+        'school_interference_0',
+        'activities_impacted_0',
+        'regular_activities_1',
+        'activities_impacted_2',
+        'school_interference_1',
+        'work_impact',
     ]
 
     # Do some pre-processing
@@ -446,6 +455,12 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'insurance',
         'smoke_9a005a',
         'chronic_illness',
+        'agegroups',
+        'school_interference_0',
+        'activities_impacted_0',
+        'activities_impacted_2',
+        'school_interference_1',
+        'work_impact',
     ]
 
     question_categories = {

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -232,7 +232,7 @@ def create_encounter(record: REDCapRecord, patient_reference: dict, locations: l
         else:
             return None
 
-    def build_conditions_list(symptom_key: str) -> dict:
+    def build_conditions_list(symptom_key: str) -> Optional[Condition]:
         return create_resource_condition(record, record[symptom_key], patient_reference)
 
     def build_diagnosis_list(symptom_key: str) -> Optional[dict]:
@@ -297,7 +297,7 @@ def create_encounter(record: REDCapRecord, patient_reference: dict, locations: l
     return create_entry_and_reference(encounter_resource, "Encounter")
 
 
-def create_resource_condition(record: dict, symptom_name: str, patient_reference: dict) -> Optional[dict]:
+def create_resource_condition(record: dict, symptom_name: str, patient_reference: dict) -> Optional[Condition]:
     """ Returns a FHIR Condition resource. """
     def severity(symptom_name: Optional[str]) -> Optional[str]:
         if symptom_name:
@@ -311,11 +311,7 @@ def create_resource_condition(record: dict, symptom_name: str, patient_reference
     if not mapped_symptom_name:
         return None
 
-    # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
-    # 3.8.  Until then, there's no reasonable way to type this data structure
-    # better than Any.
-    #   -trs, 24 Oct 2019
-    condition: Any = {
+    condition: Condition = {
         "resourceType": "Condition",
         "id": mapped_symptom_name,
         "code": {

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -23,12 +23,12 @@ from seattleflu.id3c.cli.command import age_ceiling
 from .redcap_map import *
 from .fhir import *
 from . import race, first_record_instance, required_instruments
-
+from .redcap import combine_legacy_checkbox_answers
 
 LOG = logging.getLogger(__name__)
 
 
-REVISION = 4
+REVISION = 5
 
 REDCAP_URL = 'https://redcap.iths.org/'
 INTERNAL_SYSTEM = "https://seattleflu.org"
@@ -437,6 +437,19 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'acute_symptom_onset',
         'doctor_1week',
         'antiviral_1',
+        'income_levels',
+        'insurance',
+        'smoke_9a005a',
+        'chronic_illness',
+        'housing_type',
+    ]
+
+    # Do some pre-processing
+    # Combine checkbox answers into one list
+    checkbox_fields = [
+        'insurance',
+        'smoke_9a005a',
+        'chronic_illness',
     ]
 
     question_categories = {
@@ -445,6 +458,9 @@ def create_questionnaire_response(record: dict, patient_reference: dict,
         'valueInteger': integer_questions,
         'valueString': string_questions,
     }
+
+    for field in checkbox_fields:
+        record[field] = combine_legacy_checkbox_answers(record, field)
 
     # Do some pre-processing
     record['race'] = create_custom_coding_key('race', record)

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -1,0 +1,579 @@
+"""
+Deprecated, data collection ended
+
+Process REDCap DET documents into the relational warehouse.
+
+Contains some hard-coded logic for which project ID correlates to which project
+(e.g. 17421 is the PID for Shelters)
+"""
+import re
+import click
+import json
+import logging
+from uuid import uuid4
+from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Union, Tuple
+from datetime import datetime
+from cachetools import TTLCache
+from id3c.db.session import DatabaseSession
+from id3c.cli.redcap import Record as REDCapRecord
+from id3c.cli.command.etl import redcap_det
+from id3c.cli.command.geocode import get_geocoded_address
+from id3c.cli.command.location import location_lookup
+from seattleflu.id3c.cli.command import age_ceiling
+from .redcap_map import *
+from .fhir import *
+from . import race, first_record_instance, required_instruments
+
+
+LOG = logging.getLogger(__name__)
+
+
+REVISION = 4
+
+REDCAP_URL = 'https://redcap.iths.org/'
+INTERNAL_SYSTEM = "https://seattleflu.org"
+UW_CENSUS_TRACT = '53033005302'
+
+PROJECT_ID = 17421
+REQUIRED_INSTRUMENTS = [
+    'consent',
+    'enrollment_questionnaire',
+    'back_end_mail_scans',
+    'illness_questionnaire_nasal_swab_collection',
+    'post_collection_data_entry_qc'
+]
+
+
+@redcap_det.command_for_project(
+    "swab-n-send",
+    redcap_url = REDCAP_URL,
+    project_id = PROJECT_ID,
+    revision = REVISION,
+    help = __doc__)
+
+@first_record_instance
+@required_instruments(REQUIRED_INSTRUMENTS)
+def redcap_det_swab_n_send(*, db: DatabaseSession, cache: TTLCache, det: dict, redcap_record: REDCapRecord) -> Optional[dict]:
+    location_resource_entries = locations(db, cache, redcap_record)
+    patient_entry, patient_reference = create_patient(redcap_record)
+
+    if not patient_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct patient")
+        return None
+
+    encounter_entry, encounter_reference = create_encounter(redcap_record, patient_reference, location_resource_entries)
+
+    if not encounter_entry:
+        LOG.warning("Skipping enrollment with insufficient information to construct an encounter")
+        return None
+
+    questionnaire_entry = create_questionnaire_response(redcap_record, patient_reference, encounter_reference)
+    specimen_entry, specimen_reference = create_specimen(redcap_record, patient_reference)
+
+    if not specimen_entry:
+        LOG.warning("Skipping enrollment with insufficent information to construct a specimen")
+        return None
+
+    specimen_observation_entry = create_specimen_observation_entry(specimen_reference, patient_reference, encounter_reference)
+
+    resource_entries = [
+        patient_entry,
+        encounter_entry,
+        questionnaire_entry,
+        specimen_entry,
+        *location_resource_entries,
+        specimen_observation_entry
+    ]
+
+    return create_bundle_resource(
+        bundle_id = str(uuid4()),
+        timestamp = datetime.now().astimezone().isoformat(),
+        source = f"{REDCAP_URL}{PROJECT_ID}/{redcap_record['record_id']}",
+        entries = list(filter(None, resource_entries))
+    )
+
+
+def locations(db: DatabaseSession, cache: TTLCache, record: dict) -> list:
+    """ Creates a list of Location resource entries from a REDCap record. """
+    def uw_affiliation(record: dict) -> List[Dict[Any, Any]]:
+        uw_affiliation = record['uw_affiliation']
+
+        student_responses = {
+            'Yes, I am an undergraduate student',
+            'Yes, I am a graduate/professional student',
+        }
+
+        employee_responses = {
+            'Yes, I am a graduate/professional student',
+            'Yes, I am a faculty member',
+            'Yes, I am a staff member/university employee',
+        }
+
+        if uw_affiliation and uw_affiliation not in {'No'}:
+            assert uw_affiliation in student_responses | employee_responses, \
+                f"Unknown UW affiliation answer: {uw_affiliation}"
+
+        uw_locations = []
+        if uw_affiliation in student_responses:
+            uw_locations.append(
+                create_location(f"{INTERNAL_SYSTEM}/location/tract", UW_CENSUS_TRACT, "school"))
+
+        if uw_affiliation in employee_responses:
+            uw_locations.append(
+                create_location(f"{INTERNAL_SYSTEM}/location/tract", UW_CENSUS_TRACT, "work"))
+
+        return uw_locations
+
+    def housing(db: DatabaseSession, cache: TTLCache, record: dict) -> tuple:
+        lodging_options = [
+            'Shelter',
+            'Assisted living facility',
+            'Skilled nursing center',
+            'No consistent primary residence'
+        ]
+
+        if record['housing_type'] in lodging_options:
+            housing_type = 'lodging'
+        else:
+            housing_type = 'residence'
+
+        address = {
+            'street': record['home_street'],
+            'secondary': None,
+            'city': record['homecity_other'],
+            'state': record['home_state'],
+            'zipcode': record['home_zipcode_2'],
+        }
+
+        lat, lng, canonicalized_address = get_geocoded_address(address, cache)
+        if not canonicalized_address:
+            return None, None  # TODO
+
+        tract_location = residence_census_tract(db, (lat, lng), housing_type)
+        # TODO what if tract_location is null?
+
+        tract_full_url = generate_full_url_uuid()
+        tract_entry = create_resource_entry(tract_location, tract_full_url)
+
+        address_hash = generate_hash(canonicalized_address)
+
+        address_location = create_location(
+            f"{INTERNAL_SYSTEM}/location/address",
+            address_hash,
+            housing_type,
+            tract_full_url
+        )
+
+        address_entry = create_resource_entry(address_location, generate_full_url_uuid())
+
+        return tract_entry, address_entry
+
+    locations = [*housing(db, cache, record)]
+
+    uw_location = uw_affiliation(record)
+    for location in uw_location:
+        if location:
+            locations.append(create_resource_entry(location, generate_full_url_uuid()))
+
+    return locations
+
+
+def create_location(system: str, value: str, location_type: str, parent: str=None) -> dict:
+    """ Returns a FHIR Location resource. """
+    location_type_system = "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+    location_type_map = {
+        "residence": "PTRES",
+        "school": "SCHOOL",
+        "work": "WORK",
+        "site": "HUSCS",
+        "lodging": "PTLDG",
+    }
+
+    location_type_cc = create_codeable_concept(location_type_system,
+                                            location_type_map[location_type])
+    location_identifier = create_identifier(system, value)
+    part_of = None
+    if parent:
+        part_of = create_reference(reference_type="Location", reference=parent)
+
+    return create_location_resource([location_type_cc], [location_identifier], part_of)
+
+
+def create_patient(record: dict) -> tuple:
+    """ Returns a FHIR Patient resource entry and reference. """
+    gender = map_sex(record["sex_new"] or record["sex"])
+
+    patient_id = generate_patient_hash(
+        names       = (record['first_name_1'], record['last_name_1']),
+        gender      = gender,
+        birth_date  = record['birthday'],
+        postal_code = record['home_zipcode_2'])
+
+    if not patient_id:
+        # Some piece of information was missing, so we couldn't generate a
+        # hash.  Fallback to treating this individual as always unique by using
+        # the REDCap record id.
+        patient_id = generate_hash(f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}")
+
+    LOG.debug(f"Generated individual identifier {patient_id}")
+
+    patient_identifier = create_identifier(f"{INTERNAL_SYSTEM}/individual", patient_id)
+    patient_resource = create_patient_resource([patient_identifier], gender)
+
+    return create_entry_and_reference(patient_resource, "Patient")
+
+
+def create_encounter(record: REDCapRecord, patient_reference: dict, locations: list) -> tuple:
+    """ Returns a FHIR Encounter resource entry and reference """
+
+    def grab_symptom_keys(key: str) -> Optional[Match[str]]:
+        if record[key] != '':
+            return re.match('symptoms(_child)?___[0-9]{1,3}$', key)
+        else:
+            return None
+
+    def build_conditions_list(symptom_key: str) -> dict:
+        return create_resource_condition(record, record[symptom_key], patient_reference)
+
+    def build_diagnosis_list(symptom_key: str) -> Optional[dict]:
+        mapped_symptom = map_symptom(record[symptom_key])
+        if not mapped_symptom:
+            return None
+
+        return { "condition": { "reference": f"#{mapped_symptom}" } }
+
+    def build_locations_list(location: dict) -> dict:
+        return {
+            "location": create_reference(
+                reference_type = "Location",
+                reference = location["fullUrl"]
+            )
+        }
+
+    def non_tract_locations(resource: dict):
+        return bool(resource) \
+            and resource['resource']['identifier'][0]['system'] != f"{INTERNAL_SYSTEM}/location/tract"
+
+    symptom_keys = list(filter(grab_symptom_keys, record))
+    contained = list(filter(None, map(build_conditions_list, symptom_keys)))
+    diagnosis = list(filter(None, map(build_diagnosis_list, symptom_keys)))
+    encounter_identifier = create_identifier(
+        system = f"{INTERNAL_SYSTEM}/encounter",
+        value = f"{REDCAP_URL}{PROJECT_ID}/{record['record_id']}"
+    )
+    encounter_class_coding = create_coding(
+        system = "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        code = "HH"
+    )
+
+    if not record.get('enrollment_date_time'):
+        return None, None
+
+    # YYYY-MM-DD HH:MM in REDCap
+    encounter_date = record['enrollment_date_time'].split()[0]
+
+    non_tracts = list(filter(non_tract_locations, locations))
+    non_tract_references = list(map(build_locations_list, non_tracts))
+    # Site for all swab 'n send Encounters is 'swabNSend'
+    site_reference = {
+        "location": create_reference(
+            reference_type = "Location",
+            identifier = create_identifier(f"{INTERNAL_SYSTEM}/site", 'swabNSend')
+        )
+    }
+    non_tract_references.append(site_reference)
+
+    encounter_resource = create_encounter_resource(
+        encounter_source = create_redcap_uri(record),
+        encounter_identifier = [encounter_identifier],
+        encounter_class = encounter_class_coding,
+        encounter_date = encounter_date,
+        patient_reference = patient_reference,
+        location_references = non_tract_references,
+        diagnosis = diagnosis,
+        contained = contained
+    )
+
+    return create_entry_and_reference(encounter_resource, "Encounter")
+
+
+def create_resource_condition(record: dict, symptom_name: str, patient_reference: dict) -> Optional[dict]:
+    """ Returns a FHIR Condition resource. """
+    def severity(symptom_name: Optional[str]) -> Optional[str]:
+        if symptom_name:
+            category = re.search('fever|cough|ache|fatigue|sorethroat', symptom_name.lower())
+            if category:
+                return f"{category[0]}_severity"
+
+        return None
+
+    mapped_symptom_name = map_symptom(symptom_name)
+    if not mapped_symptom_name:
+        return None
+
+    # XXX TODO: Define this as a TypedDict when we upgrade from Python 3.6 to
+    # 3.8.  Until then, there's no reasonable way to type this data structure
+    # better than Any.
+    #   -trs, 24 Oct 2019
+    condition: Any = {
+        "resourceType": "Condition",
+        "id": mapped_symptom_name,
+        "code": {
+            "coding": [
+                {
+                    "system": f"{INTERNAL_SYSTEM}/symptom",
+                    "code": mapped_symptom_name
+                }
+            ]
+        },
+        "onsetDateTime": record["symptom_duration"], # YYYY-MM-DD in REDCap
+        "subject": patient_reference
+    }
+
+    symptom_severity = severity(mapped_symptom_name)
+    if symptom_severity and record[symptom_severity]:
+        condition['severity'] = create_condition_severity_code(record[symptom_severity]) # TODO lowercase?
+
+    return condition
+
+
+def create_specimen(record: dict, patient_reference: dict) -> tuple:
+    """ Returns a FHIR Specimen resource entry and reference """
+    def specimen_barcode(record: Any) -> str:
+        """
+        Given a REDCap *record*, returns the barcode or corrected barcode if it
+        exists.
+        """
+        barcode = record['return_utm_barcode'] or record['pre_scan_barcode']
+
+        if not barcode:
+            barcode = record['utm_tube_barcode_2']
+            reentered_barcode = record['reenter_barcode']
+
+            if record['barcode_confirm'] == "No":
+                #TODO: Figure out why 'corrected_barcode' doesn't always exist?
+                barcode = record.get('corrected_barcode')
+
+        return barcode
+
+    barcode = specimen_barcode(record)
+    if not barcode:
+        LOG.warning("Could not create Specimen Resource due to lack of barcode.")
+        return None, None
+
+    specimen_identifier = create_identifier(
+        system = f"{INTERNAL_SYSTEM}/sample",
+        value = barcode
+    )
+
+    # YYYY-MM-DD in REDCap
+    collected_time = record['collection_date'] or None
+
+    # YYYY-MM-DD HH:MM:SS in REDCap
+    received_time = record['samp_process_date'].split()[0] if record['samp_process_date'] else None
+
+    specimen_type = 'NSECR'  # Nasal swab.  TODO we may want shared mapping function
+    specimen_resource = create_specimen_resource(
+        [specimen_identifier], patient_reference, specimen_type, received_time, collected_time
+    )
+
+    return create_entry_and_reference(specimen_resource, "Specimen")
+
+
+def create_questionnaire_response(record: dict, patient_reference: dict,
+    encounter_reference: dict) -> Optional[dict]:
+    """ Returns a FHIR Questionnaire Response resource entry. """
+
+    def create_custom_coding_key(coded_question: str, record: dict) -> Optional[List]:
+        """
+        Handles the 'race' edge case by combining "select all that apply"-type
+        responses into one list.
+        """
+        coded_keys = list(filter(lambda r: grab_coding_keys(coded_question, r), record))
+        coded_names = list(map(lambda k: record[k], coded_keys))
+
+        if coded_question == 'race':
+            return race(coded_names)
+
+        return None
+
+    def grab_coding_keys(coded_question: str, key: str) -> Optional[Match[str]]:
+        if record[key] == '':
+            return None
+
+        return re.match(f'{coded_question}___[0-9]+$', key)
+
+
+    def build_questionnaire_items(question: str) -> Optional[dict]:
+        return questionnaire_item(record, question, category)
+
+    coding_questions = [
+        'race',
+        # 'insurance',  # TODO address these non-essential coded questions later
+        # 'how_hear_sfs',
+        # 'poc_behaviors',
+    ]
+
+    boolean_questions = [
+        'ethnicity',
+        'barcode_confirm',
+        'travel_states',
+        'travel_countries',
+    ]
+
+    integer_questions = [
+        'age',
+        'age_months',
+    ]
+
+    string_questions = [
+        'education',
+        'doctor_3e8fae',
+        'samp_process_date',
+        'house_members',
+        'shelter_members',
+        'where_sick',
+        'antiviral_0',
+        'acute_symptom_onset',
+        'doctor_1week',
+        'antiviral_1',
+    ]
+
+    question_categories = {
+        'valueCoding': coding_questions,
+        'valueBoolean': boolean_questions,
+        'valueInteger': integer_questions,
+        'valueString': string_questions,
+    }
+
+    # Do some pre-processing
+    record['race'] = create_custom_coding_key('race', record)
+    record['age'] = age_ceiling(int(record['age']))
+    record['age_months'] = age_ceiling(int(record['age_months']) / 12) * 12
+
+    items: List[dict] = []
+    for category in question_categories:
+        category_items = list(map(build_questionnaire_items, question_categories[category]))
+        for item in category_items:
+            if item:
+                items.append(item)
+
+    # Handle edge cases
+    vaccine_item = vaccine(record)
+    if vaccine_item:
+        items.append(vaccine_item)
+
+    if items:
+        questionnaire_reseponse_resource = create_questionnaire_response_resource(
+            patient_reference, encounter_reference, items
+        )
+        full_url = generate_full_url_uuid()
+        return create_resource_entry(questionnaire_reseponse_resource, full_url)
+
+    return None
+
+
+def questionnaire_item(record: dict, question_id: str, response_type: str) -> Optional[dict]:
+    """ Creates a QuestionnaireResponse internal item from a REDCap record. """
+    response = record[question_id]
+
+    def cast_to_coding(string: str):
+        """ Currently the only QuestionnaireItem we code is race. """
+        return create_coding(
+            system = f"{INTERNAL_SYSTEM}/race",
+            code = string,
+        )
+
+    def cast_to_string(string: str) -> Optional[str]:
+        if string != '':
+            return string
+        return None
+
+    def cast_to_integer(string: str) -> Optional[int]:
+        try:
+            return int(string)
+        except ValueError:
+            return None
+
+    def cast_to_boolean(string: str) -> Optional[bool]:
+        if string == 'Yes':
+            return True
+        elif re.match(r'^No($|,[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma and text
+            return False
+        return None
+
+    def build_response_answers(response: Union[str, List]) -> List:
+        answers = []
+        if not isinstance(response, list):
+            response = [response]
+
+        for item in response:
+            type_casted_item = casting_functions[response_type](item)
+
+            # cast_to_boolean can return False, so must be `is not None`
+            if type_casted_item is not None:
+                answers.append({ response_type: type_casted_item })
+
+        return answers
+
+    casting_functions: Mapping[str, Callable[[str], Any]] = {
+        'valueCoding': cast_to_coding,
+        'valueInteger': cast_to_integer,
+        'valueBoolean': cast_to_boolean,
+        'valueString': cast_to_string,
+    }
+
+    answers = build_response_answers(response)
+    if answers:
+        return create_questionnaire_response_item(question_id, answers)
+
+    return None
+
+
+def vaccine(record: Any) -> Optional[dict]:
+    """
+    For a given *record*, return a questionnaire response item with the vaccine
+    response(s) encoded.
+    """
+    vaccine_status = map_vaccine(record["vaccine"])
+    if vaccine_status is None:
+        return None
+
+    answers: List[Dict[str, Any]] = [{ 'valueBoolean': vaccine_status }]
+
+    date = vaccine_date(record)
+    if vaccine_status and date:
+        answers.append({ 'valueDate': date })
+
+    return create_questionnaire_response_item('vaccine', answers)
+
+
+def vaccine_date(record: dict) -> Optional[str]:
+    """ Converts a vaccination date to 'YYYY' or 'YYYY-MM' format. """
+    year = record['vaccine_year_fc54b4']
+    month = record['vaccine_month_dfe1c1']
+
+    if year == '' or year == 'Do not know':
+        return None
+
+    if month == 'Do not know':
+        return datetime.strptime(year, '%Y').strftime('%Y')
+
+    return datetime.strptime(f'{month} {year}', '%B %Y').strftime('%Y-%m')
+
+
+def residence_census_tract(db: DatabaseSession, lat_lng: Tuple[float, float],
+    housing_type: str) -> Optional[dict]:
+    """
+    Creates a new Location Resource for the census tract containing the given
+    *lat_lng* coordintes and associates it with the given *housing_type*.
+    """
+    location = location_lookup(db, lat_lng, 'tract')
+
+    if location and location.identifier:
+        return create_location(
+            f"{INTERNAL_SYSTEM}/location/tract", location.identifier, housing_type
+        )
+    else:
+        LOG.warning("No census tract found for given location.")
+        return None

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_swab_n_send.py
@@ -510,7 +510,7 @@ def questionnaire_item(record: dict, question_id: str, response_type: str) -> Op
     def cast_to_boolean(string: str) -> Optional[bool]:
         if string == 'Yes':
             return True
-        elif re.match(r'^No($|,[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma and text
+        elif re.match(r'^No($|(,|\s-)[\w\s\'\.]*)$', string):  # Starts with "No", has optional comma or space+dash followed by text
             return False
         return None
 

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
@@ -109,7 +109,7 @@ def map_chronic_illness(illness_name: str):
         'heart disease (heart failure or heart attack)':    'cvd',
         'none of the above':                                'none',
         'do not know':                                      'dont_know',
-        'prefer not to say':                                'don_say'
+        'prefer not to say':                                'dont_say'
     }
 
     if illness_name.lower() not in illness_map:

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
@@ -96,6 +96,26 @@ def map_symptom(symptom_name: str) -> Optional[str]:
 
     return symptom_map[symptom_name.lower()]
 
+def map_chronic_illness(illness_name: str):
+    """
+    Maps a *chronic_illness* to current values in ID3C warehouse.
+    """
+    illness_map = {
+        'asthma or reactive airway disease':                'asthma',
+        'copd/emphysema':                                   'copd',
+        'chronic bronchitis':                               'bronchitis',
+        'cancer':                                           'cancer',
+        'diabetes':                                         'diabetes',
+        'heart disease (heart failure or heart attack)':    'cvd',
+        'none of the above':                                'none',
+        'do not know':                                      'dont_know',
+        'prefer not to say':                                'don_say'
+    }
+
+    if illness_name.lower() not in illness_map:
+        raise UnknownIllnessNameError(f"Unknown illness name «{illness_name}»")
+
+    return illness_map[illness_name.lower()]
 
 class UnknownSexError(ValueError):
     """
@@ -117,5 +137,12 @@ class UnknownSymptomNameError(ValueError):
     """
     Raised by :function: `map_symptom` if a provided
     *symptom_name* is not among a set of expected values
+    """
+    pass
+
+class UnknownIllnessNameError(ValueError):
+    """
+    Raised by :function: `map_chronic_illness` if a provided
+    *illness_name* is not among a set of expected values
     """
     pass

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_map.py
@@ -102,12 +102,17 @@ def map_chronic_illness(illness_name: str):
     """
     illness_map = {
         'asthma or reactive airway disease':                'asthma',
+        'blood disorders (e.g. sickle cell)':               'blood',
         'copd/emphysema':                                   'copd',
+        'copd/ emphysema':                                  'copd',
         'chronic bronchitis':                               'bronchitis',
         'cancer':                                           'cancer',
         'diabetes':                                         'diabetes',
         'heart disease (heart failure or heart attack)':    'cvd',
+        'immunosuppression (by medication or disease)':     'immunosupression',
+        'liver disease':                                    'liver',
         'none of the above':                                'none',
+        'none of these conditions':                         'none',
         'do not know':                                      'dont_know',
         'prefer not to say':                                'dont_say'
     }


### PR DESCRIPTION
Restoring 3 Swab and Send ETLs and the Kiosk ETL (which were previously dropped) to ingest addition fields requested by the Chu lab. In addition to the fields below, Spanish responses which were previously skipped in the Kiosk ETL will now be ingested.


Swab-n-send ETL
- income_levels
- insurance
- smoke_9a005a
- chronic_illness
- housing_type
- agegroups
- regular_activities_0
- school_interference_0
- activities_impacted_0
- regular_activities_1
- activities_impacted_2
- school_interference_1
- work_impact
- child_daycare

Swab-n-send + home flu ETL
- income_levels
- insurance
- smoke
- chronic_illness'
- agegroups
- regular_activities_0
- school_interference_0
- activities_impacted_0v2
- regular_activities_1
- activities_impacted_2
- school_interference_1
- work_impact_0
- work_impact
- child_daycare

Kiosks ETL
- education
- income_levels
- housing_type
- house_members
- antiviral_1
- smoke
- chronic_illness
- regular activities
- age_children
- school_interference_0
- activities_impacted_poc
- doctor_1week
- work_impact_2poc

Asymptomatic swab-n-send ETL
- hispanic (as ethnicity)
- income_levels
- insurance
- smoke
- chronic_illness
- travel_states
- travel_countries