### PR TITLE
parse-kp: read census tract as string

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -383,7 +383,7 @@ def parse_kp(kp_filename, kp_specimen_manifest_filename, manifest_format, output
     All clinical records parsed are output to stdout as newline-delimited JSON
     records.  You will likely want to redirect stdout to a file.
     """
-    clinical_records = pd.read_csv(kp_filename)
+    clinical_records = pd.read_csv(kp_filename, dtype={'CensusTract': 'string'})
     clinical_records.columns = clinical_records.columns.str.lower()
 
     clinical_records = trim_whitespace(clinical_records)


### PR DESCRIPTION
Read in census tract as string in order to preserve leading 0s.