### PR TITLE
Ingest sequencing accession IDs

### DIFF
--- a/lib/seattleflu/id3c/cli/command/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/clinical.py
@@ -59,10 +59,11 @@ def clinical():
 # Parse sequencing accessions subcommand
 @clinical.command("parse-sequencing")
 @click.argument("accession_ids_filename", metavar = "<Sequencing accession IDs filename>")
+@click.argument("record_type", metavar="<record type>", type=click.Choice(['covid', 'rsv-a', 'rsv-b']))
 @click.option("-o", "--output", metavar="<output filename>",
     help="The filename for the output of missing barcodes")
 
-def parse_sequencing_accessions(accession_ids_filename, output):
+def parse_sequencing_accessions(accession_ids_filename, record_type, output):
     """
     Process sequencing accession IDs file.
 
@@ -99,6 +100,9 @@ def parse_sequencing_accessions(accession_ids_filename, output):
         'genbank_accession': 'genbank_accession',
         '_provenance': '_provenance'
     }
+    if record_type in ['rsv-a', 'rsv-b']:
+        clinical_records = clinical_records[clinical_records['pathogen'] == record_type]
+        column_map['pathogen'] = 'pathogen'
 
     clinical_records = clinical_records[(clinical_records['sfs_sample_barcode'].notnull())&(clinical_records.status=='submitted')].rename(columns=column_map)
 

--- a/lib/seattleflu/id3c/cli/command/etl/clinical.py
+++ b/lib/seattleflu/id3c/cli/command/etl/clinical.py
@@ -213,6 +213,10 @@ def upsert_genome(db: DatabaseSession, sample: MinimalSampleRecord, organism: Or
         insert into warehouse.consensus_genome (sample_id, organism_id)
           values (%(sample_id)s, %(organism_id)s)
 
+        on conflict (sample_id, organism_id) where sequence_read_set_id is null do update
+            set sample_id = excluded.sample_id,
+                organism_id = excluded.organism_id
+
         returning consensus_genome_id as id, sample_id, organism_id
         """, data)
 


### PR DESCRIPTION
The clinical data module is being updated to parse sequencing accessioning data for uploading into receiving.clinical, and the clinical ETL is being updated for ingestion into warehouse tables. This data is being sourced from tracking sheets maintained on Github for the Seattle Flu Study.

Running this ETL on receiving.clinical records with document containing `gisaid_accession` or `genbank_accession` will result in custom processing for this particular type of data. After matching to an existing sample, a minimal `consensus_genome` and `genomic_sequence` record will be generated for each covid-19, RSV-A, RSV-B, Influenza A and Influenza B sequence record.
