### PR TITLE
Add Four new Covid-19 Vaccine Codes

### DIFF
--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -305,6 +305,8 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
 
     # COVID-19 vaccine CVX codes were sourced from here:
     # https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html
+    # this link has moved:
+    # https://www.cdc.gov/iis/code-sets/covid-19-related-codes.html
     cvx_codes = {
         88: {
             "system": "http://hl7.org/fhir/sid/cvx",
@@ -389,7 +391,7 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
         309: {
             "system": "http://hl7.org/fhir/sid/cvx",
             "code": "309",
-            "display": "COVID-19, mRNA, LNP-S, PF, tris-sucrose, 30 mcg/0.3 mL"            
+            "display": "COVID-19, mRNA, LNP-S, PF, tris-sucrose, 30 mcg/0.3 mL"
         },
         311: {
             "system": "http://hl7.org/fhir/sid/cvx",
@@ -445,8 +447,12 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
         "covid-19 pfizer mrna bivalent 5-11 yrs old":                       301,
         "covid-19 pfizer mrna bivalent 6 mos-4 yrs old":                    308,
         "covid-19 pfizer mrna 2023-24 12 yrs and older (comirnaty)":        309,
+        "covid-19 pfizer mrna 12 yrs and older (comirnaty)":                309,
         "covid-19 moderna mrna 2023-24 6 mos-11 yrs old":                   311,
+        "covid-19 moderna mrna 6 mos-11 yrs old":                           311,
         "covid-19 moderna mrna 2023-24 12 yrs and older (spikevax)":        312,
+        "covid-19 moderna mrna 12 yrs and older (spikevax)":                312,
+        "covid-19 novavax subunit adjuvanted monovalent":                   313,
         "covid-19 sinovac inactivated, non-us (coronavac)":                 511,
         "": None
     }

--- a/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
+++ b/lib/seattleflu/id3c/cli/command/etl/redcap_det_uw_retrospectives.py
@@ -403,6 +403,11 @@ def create_immunization(record: dict, patient_reference: dict) -> Optional[list]
             "code": "312",
             "display": "COVID-19, mRNA, LNP-S, PF, 50 mcg/0.5 mL"
         },
+        313: {
+            "system": "http://hl7.org/fhir/sid/cvx",
+            "code": "313",
+            "display": "COVID-19 vaccine, Subunit, rS-nanoparticle, adjuvanted, PF, 5mcg/0.5mL"
+        },
         511: {
             "system": "http://hl7.org/fhir/sid/cvx",
             "code": "511",


### PR DESCRIPTION
Vaccine source link has also moved here: https://www.cdc.gov/iis/code-sets/covid-19-related-codes.html. Seems like historical vax codes are embedded within an excel sheet now as well, although it seems reasonable we won't have any new vaccines coming in that map to retired vaccines.